### PR TITLE
WCLength error modification

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -57,7 +57,6 @@ public:
 
   // Related to the WC geometry
   void SetSuperKGeometry();
-  void SetSuperKGeometry_withHPD();
   void DUSEL_100kton_10inch_40perCent();
   void DUSEL_100kton_10inch_HQE_12perCent();
   void DUSEL_100kton_10inch_HQE_30perCent();
@@ -113,11 +112,6 @@ public:
 
 
   // *** End HyperK Geometry ***
-
-  // HPD option
-  void   SetIsHPD(G4bool choice) {isHPD = choice;}
-  G4bool GetIsHPD() {return isHPD;}
-
 
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
@@ -301,7 +295,6 @@ private:
                                          G4double, G4double);
 
     G4bool isHyperK;
-    G4bool isHPD;
   
   G4double waterTank_TopR;
   G4double waterTank_BotR;

--- a/include/WCSimWCPMT.hh
+++ b/include/WCSimWCPMT.hh
@@ -34,7 +34,6 @@ public:
   //  static G4double GetLongTime() { return LongTime;}
   
   G4double rn1pe();
-  G4double hpd1pe_8inch();
   G4double peSmeared;
   // double PMTDarkRate; // kHz
   // double ConvRate; // kHz


### PR DESCRIPTION
Implemented HPD parameters, and fixed that WCLength was not the same value as the tube length when The HyperK detector length was changed. And implemented new geometry "SuperK_withHPD", "HyperK_withHPD"
You can make geometries with HPD by changing "WCSimDetectorConfig.cc" and "WCSimDetectorMessenger.cc", and any other factors to make geometries with normal PMT.
(Set photodetector to "20inchHPD" and implement HPD shape in WCSimDetectorConfig.cc, add SetIsHPD(true) to geometry function in WCSimDetectorMessenger.cc)
