### PR TITLE
Fixed some bugs in the dark rate function, as pointed out by Trevor Stew...

### DIFF
--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -191,8 +191,9 @@ void WCSimWCDigitizer::AddPMTDarkRate(WCSimWCDigitsCollection* WCHCPMT)
 	      ahit->AddPe(current_time); // needed to increment TotalPe
 	      WCHCPMT->insert(ahit);
 	      PMTindex[noise_pmt]++; // increment number of times a PMT has been hit
-	      list[ noise_pmt ] = number_entries; // Add this PMT to the end of the list
 	      number_entries ++; //increment the number of hit PMTs
+	      list[ noise_pmt ] = number_entries; // Add this PMT to the end of the list
+
 	    }
 	    else{
 	      (*WCHCPMT)[ list[noise_pmt]-1 ]->AddPe(current_time); //The WCHCPMT list runs from 0 to (number of PMTs)-1


### PR DESCRIPTION
...art. The first bug was that the TotalPe was not being incremented if the PMT was not in the original hit array. The second bug involved an error in array index of the list array, also in the loop where the PMT had not been originally hit. I have changed the indices of the list array to now run between 1 and number of PMTs. I have also added in comments to make this function a bit easier to understand.
