### PR TITLE
Fixed bug (Add dark noise before trigger)

### DIFF
--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -142,7 +142,7 @@ void WCSimWCDigitizer::AddPMTDarkRate(WCSimWCDigitsCollection* WCHCPMT)
     {
         current_time = TriggerTimes[i]+eventgatedown;
 
-	while( current_time < TriggerTimes[i] + (eventgateup - eventgatedown) )
+	while( current_time < TriggerTimes[i] + eventgateup )
         {
             // Get random time ahead for this poisson process
             current_time += -poisson_mean*log( 1-G4UniformRand() );
@@ -153,7 +153,7 @@ void WCSimWCDigitizer::AddPMTDarkRate(WCSimWCDigitsCollection* WCHCPMT)
 	    int noise_pmt = static_cast<int>( G4UniformRand() * number_pmts ); // This runs from 0 to number_pmts-1.
 	    noise_pmt = noise_pmt+1; //increment by 1 so it can be used as tubeID. Now runs from 1 to number_pmts.
 
-	    if ( current_time >= TriggerTimes[i] + (eventgateup - eventgatedown ) )
+	    if ( current_time >= TriggerTimes[i] + eventgateup )
 	      break;
 
 	    if( list[ noise_pmt ] == 0 ) // This PMT has not been hit


### PR DESCRIPTION
I found the bug that there is no dark noise before the trigger.
The figure below is comparison of hit time distribution of all photodetectors in 100 events between before and after modification.
![4khz_analyze_combine](https://cloud.githubusercontent.com/assets/8589041/5452903/e47eae9c-8563-11e4-9f0d-608221d71205.png)
Red: after modification, Blue: before modification
The gate is  (Trigger time)-400 [ns] ~ (Trigger time)+950 [ns]

And I also analyze "electrontest.mac" events in verification-test-scripts 
by using "verification_HitsChangeTime.C"
the text below is the log.

Processing verification_HitsChargeTime.C...
Stats for the first event in your version of WCSim using wcsimtest.root
Number of tube hits 2540
Number of digitized tube hits 2045
Number of photoelectron hit times 4408

---

Stats for the first event of WCSim version on GitHub using ../../WCSim_clean/verification-test-scripts/wcsimtest.root
Number of tube hits 2540
Number of digitized tube hits 2045
Number of photoelectron hit times 4408

---

FIRST EVENT TEST PASSED: Number of hit tubes matches
FIRST EVENT TEST PASSED: Number of digitized tubes matches
FIRST EVENT TEST PASSED: Number of hit times matches

---

ks test for # of digitized hits: 1
ks test for average charge: 1
ks test for average time: 1

The figure below is the output of  "verification_HitsChangeTime.C" analysis
![check](https://cloud.githubusercontent.com/assets/8589041/5453237/66ccdcb2-8568-11e4-8a0f-8e0373006d1c.png)
