### PR TITLE
Enable to modify threshold for each PD individually

### DIFF
--- a/include/WCSimPMTObject.hh
+++ b/include/WCSimPMTObject.hh
@@ -20,6 +20,7 @@ public:
   virtual G4float* GetQEWavelength()=0;
   virtual G4float  GetmaxQE()=0;
   virtual float  GettimingResolution(float)=0;
+  virtual void  Threshold(double&, int&){};
   virtual G4double GetPMTGlassThickness()=0;
 };
 
@@ -41,6 +42,7 @@ public:
   G4float* GetQEWavelength();
   G4float  GetmaxQE();
   float  GettimingResolution(float);
+  void  Threshold(double&, int&);
   G4double GetPMTGlassThickness();
 };
 
@@ -61,6 +63,7 @@ public:
   G4float* GetQEWavelength();
   G4float  GetmaxQE();
   float  GettimingResolution(float);
+  void  Threshold(double&, int&);
   G4double GetPMTGlassThickness();
 };
 
@@ -80,6 +83,7 @@ public:
   G4float* GetQEWavelength();
   G4float  GetmaxQE();
   float  GettimingResolution(float);
+  void  Threshold(double&, int&);
   G4double GetPMTGlassThickness();
  };
 
@@ -99,6 +103,7 @@ public:
   G4float* GetQEWavelength();
   G4float  GetmaxQE();
   float  GettimingResolution(float);
+  void  Threshold(double&, int&);
   G4double GetPMTGlassThickness();
  };
 
@@ -118,13 +123,8 @@ public:
   G4float* GetQEWavelength();
   G4float  GetmaxQE();
   float  GettimingResolution(float);
+  void  Threshold(double&, int&);
   G4double GetPMTGlassThickness();
  };
 
 #endif
-
-
-
-
-
-

--- a/include/WCSimWCDigitizer.hh
+++ b/include/WCSimWCDigitizer.hh
@@ -46,31 +46,7 @@ public:
   G4double GetConversion(){ return ConvRate; }
 
 private:
-  static void Threshold(double& pe,int& iflag){
-    //   CLHEP::HepRandom::setTheSeed(pe+2014);
-    double x = pe+0.1; iflag=0;
-    double thr; double RDUMMY,err;
-    if ( x<1.1) {
-      thr = std::min(1.0,
-		     -0.06374+x*(3.748+x*(-63.23+x*(452.0+x*(-1449.0+x*(2513.0
-									+x*(-2529.+x*(1472.0+x*(-452.2+x*(51.34+x*2.370))))))))));
-    } else {
-      thr = 1.0;
-    }
-    RDUMMY = G4UniformRand();
-    if (thr < RDUMMY) {
-      pe = 0.0;
-      iflag = 1;
-    }
-    else {
-      err = G4RandGauss::shoot(0.0,0.03);
-      /////      call rngaus(0.0, 0.03, err);
-      pe = pe+err;
-    }
-  }
   
-
-
   static const double offset; // hit time offset
   static const double pmtgate; // ns
   static const double eventgateup; // ns

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -35,6 +35,30 @@ float PMT20inch::GettimingResolution(float Q) {
   if (timingResolution < 0.58) timingResolution=0.58;
   return timingResolution;
 }
+void PMT20inch::Threshold(double& pe,int& iflag){
+  //   CLHEP::HepRandom::setTheSeed(pe+2014);
+
+  double x = pe+0.1; iflag=0;
+  double thr; double RDUMMY,err;
+  if ( x<1.1) {
+    thr = std::min(1.0,
+		   -0.06374+x*(3.748+x*(-63.23+x*(452.0+x*(-1449.0+x*(2513.0
+								      +x*(-2529.+x*(1472.0+x*(-452.2+x*(51.34+x*2.370))))))))));
+  } else {
+    thr = 1.0;
+  }
+  RDUMMY = G4UniformRand();
+  if (thr < RDUMMY) {
+    pe = 0.0;
+    iflag = 1;
+  }
+  else {
+    err = G4RandGauss::shoot(0.0,0.03);
+    /////      call rngaus(0.0, 0.03, err);                                                                                                                                               
+    pe = pe+err;
+  }
+}
+
 
 G4float* PMT20inch::Getqpe()
    {
@@ -184,6 +208,30 @@ G4float PMT8inch::GettimingResolution(float Q) {
   // looking at SK's jitter function for 20" tubes
   if (timingResolution < 0.58) timingResolution=0.58;
   return timingResolution;}
+void PMT8inch::Threshold(double& pe,int& iflag){
+  //   CLHEP::HepRandom::setTheSeed(pe+2014); 
+
+  double x = pe+0.1; iflag=0;
+  double thr; double RDUMMY,err;
+  if ( x<1.1) {
+    thr = std::min(1.0,
+                   -0.06374+x*(3.748+x*(-63.23+x*(452.0+x*(-1449.0+x*(2513.0
+                                                                      +x*(-2529.+x*(1472.0+x*(-452.2+x*(51.34+x*2.370))))))))));
+  } else {
+    thr = 1.0;
+  }
+  RDUMMY = G4UniformRand();
+  if (thr < RDUMMY) {
+    pe = 0.0;
+    iflag = 1;
+  }
+  else {
+    err = G4RandGauss::shoot(0.0,0.03);
+    /////      call rngaus(0.0, 0.03, err); 
+
+    pe = pe+err;
+  }
+}
 
 G4float* PMT8inch::Getqpe() //currently uses the same as 20inch
    {
@@ -331,6 +379,29 @@ float PMT10inch::GettimingResolution(float Q) {
   // looking at SK's jitter function for 20" tubes
   if (timingResolution < 0.58) timingResolution=0.58;
   return timingResolution;           
+}
+void PMT10inch::Threshold(double& pe,int& iflag){
+  //   CLHEP::HepRandom::setTheSeed(pe+2014);                                                                                                        \
+                                                                                                                                                      
+  double x = pe+0.1; iflag=0;
+  double thr; double RDUMMY,err;
+  if ( x<1.1) {
+    thr = std::min(1.0,
+                   -0.06374+x*(3.748+x*(-63.23+x*(452.0+x*(-1449.0+x*(2513.0
+                                                                      +x*(-2529.+x*(1472.0+x*(-452.2+x*(51.34+x*2.370))))))))));
+  } else {
+    thr = 1.0;
+  }
+  RDUMMY = G4UniformRand();
+  if (thr < RDUMMY) {
+    pe = 0.0;
+    iflag = 1;
+  }
+  else {
+    err = G4RandGauss::shoot(0.0,0.03);
+    /////      call rngaus(0.0, 0.03, err);
+    pe = pe+err;
+  }
 }
 
 G4float* PMT10inch::Getqpe() //currently uses the same as 20inch
@@ -480,6 +551,29 @@ G4float PMT10inchHQE::GettimingResolution(float Q) {
   // looking at SK's jitter function for 20" tubes
   if (timingResolution < 0.58) timingResolution=0.58;
   return timingResolution;}
+void PMT10inchHQE::Threshold(double& pe,int& iflag){
+  //   CLHEP::HepRandom::setTheSeed(pe+2014);
+
+  double x = pe+0.1; iflag=0;
+  double thr; double RDUMMY,err;
+  if ( x<1.1) {
+    thr = std::min(1.0,
+                   -0.06374+x*(3.748+x*(-63.23+x*(452.0+x*(-1449.0+x*(2513.0
+                                                                      +x*(-2529.+x*(1472.0+x*(-452.2+x*(51.34+x*2.370))))))))));
+  } else {
+    thr = 1.0;
+  }
+  RDUMMY = G4UniformRand();
+  if (thr < RDUMMY) {
+    pe = 0.0;
+    iflag = 1;
+  }
+  else {
+    err = G4RandGauss::shoot(0.0,0.03);
+    /////      call rngaus(0.0, 0.03, err);
+    pe = pe+err;
+  }
+}
 
 G4float* PMT10inchHQE::Getqpe() //currently uses the same as 20inch
    {
@@ -628,6 +722,29 @@ G4float PMT12inchHQE::GettimingResolution(float Q) {
   // looking at SK's jitter function for 20" tubes
   if (timingResolution < 0.58) timingResolution=0.58;
   return timingResolution;}
+void PMT12inchHQE::Threshold(double& pe,int& iflag){
+  //   CLHEP::HepRandom::setTheSeed(pe+2014);
+
+  double x = pe+0.1; iflag=0;
+  double thr; double RDUMMY,err;
+  if ( x<1.1) {
+    thr = std::min(1.0,
+                   -0.06374+x*(3.748+x*(-63.23+x*(452.0+x*(-1449.0+x*(2513.0
+                                                                      +x*(-2529.+x*(1472.0+x*(-452.2+x*(51.34+x*2.370))))))))));
+  } else {
+    thr = 1.0;
+  }
+  RDUMMY = G4UniformRand();
+  if (thr < RDUMMY) {
+    pe = 0.0;
+    iflag = 1;
+  }
+  else {
+    err = G4RandGauss::shoot(0.0,0.03);
+    /////      call rngaus(0.0, 0.03, err);
+    pe = pe+err;
+  }
+}
 
 G4float* PMT12inchHQE::Getqpe() //currently uses the same as 20inch
    {

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -404,7 +404,7 @@ void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
       int iflag;
 
       //check if hits in PMT are above threshold
-      WCSimWCDigitizer::Threshold(peSmeared,iflag);
+      PMT->Threshold(peSmeared,iflag);
       peSmeared *= efficiency; // MC tuning correction
     
    


### PR DESCRIPTION
In order to introduce the threshold of new PD, I have added survival probability from threshold cut to WCSimPMTObject.cc and WCSimPMTObject.hh, and delete it from WCSimWCDigitizer.hh.
The figure and text below is the result of check with "electrontest.mac" and "verification_HitsChargeTime.C"

Processing verification_HitsChargeTime.C("../wcsimtest.root","../../WCSim_clean/verification-test-scripts/wcsimtest.root")...
Stats for the first event in your version of WCSim using ../wcsimtest.root
Number of tube hits 2540
Number of digitized tube hits 2045
Number of photoelectron hit times 4408
***********************************************************
Stats for the first event of WCSim version on GitHub using ../../WCSim_clean/verification-test-scripts/wcsimtest.root
Number of tube hits 2540
Number of digitized tube hits 2045
Number of photoelectron hit times 4408
***********************************************************
FIRST EVENT TEST PASSED: Number of hit tubes matches
FIRST EVENT TEST PASSED: Number of digitized tubes matches
FIRST EVENT TEST PASSED: Number of hit times matches
***********************************************************
ks test for # of digitized hits: 1
ks test for average charge: 1
ks test for average time: 1

![check](https://cloud.githubusercontent.com/assets/8589041/5503187/6708e56c-87b7-11e4-9987-e3c178b1585b.png)

The probability of HPD has still not been analyzed for WCSim. However the events which are cut by threshold are much less than that of PMT.
I will remove the threshold from HPD provisionally.