### PR TITLE
Changing the suggested dark rate in vis.mac

### DIFF
--- a/vis.mac
+++ b/vis.mac
@@ -60,7 +60,7 @@
 
 # command to set dark noise frequency 13/06/09
 # default dark noise frequency is 0 kHz
-#/DarkRate/SetDarkRate 4 kHz
+#/DarkRate/SetDarkRate 4.2 kHz #value from SKI in SKDETSIM
 
 # command to multiply the dark rate.
 # Convert dark noise frequency before digitization to after digitization by setting suitable factor


### PR DESCRIPTION
As per Okajima's suggestion to be more in line with the SK-I default dark rate value from SKDETSIM. 