### PR TITLE
Feature/issue50 2

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -59,6 +59,7 @@ public:
   // Related to the WC geometry
   void SetSuperKGeometry();
   void SuperK_20inchPMT_20perCent();
+  void SuperK_20inchHPD_20perCent();
   void SuperK_12inchHPD_15perCent();
   void SuperK_20inchHPD_14perCent();
   void Cylinder_12inchHPD_15perCent();

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -59,9 +59,9 @@ public:
   // Related to the WC geometry
   void SetSuperKGeometry();
   void SuperK_20inchPMT_20perCent();
-  void SuperK_12inchHPD_14perCent();
+  void SuperK_12inchHPD_15perCent();
   void SuperK_20inchHPD_14perCent();
-  void Cylinder_12inchHPD_14perCent();
+  void Cylinder_12inchHPD_15perCent();
   void DUSEL_100kton_10inch_40perCent();
   void DUSEL_100kton_10inch_HQE_12perCent();
   void DUSEL_100kton_10inch_HQE_30perCent();

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -58,6 +58,9 @@ public:
 
   // Related to the WC geometry
   void SetSuperKGeometry();
+  void SuperK_12inchHPD_14perCent();
+  void SuperK_20inchHPD_14perCent();
+  void Cylinder_12inchHPD_14perCent();
   void DUSEL_100kton_10inch_40perCent();
   void DUSEL_100kton_10inch_HQE_12perCent();
   void DUSEL_100kton_10inch_HQE_30perCent();

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -58,6 +58,7 @@ public:
 
   // Related to the WC geometry
   void SetSuperKGeometry();
+  void SuperK_20inchPMT_20perCent();
   void SuperK_12inchHPD_14perCent();
   void SuperK_20inchHPD_14perCent();
   void Cylinder_12inchHPD_14perCent();

--- a/novis.mac
+++ b/novis.mac
@@ -12,6 +12,7 @@
 #/WCSim/WCgeom SuperK
 
 # Some other SuperK options:
+#/WCSim/WCgeom SuperK_20inchPMT_20perCent
 #/WCSim/WCgeom SuperK_12inchHPD_14perCent
 #/WCSim/WCgeom SuperK_20inchHPD_14perCent
 

--- a/novis.mac
+++ b/novis.mac
@@ -13,12 +13,12 @@
 
 # Some other SuperK options:
 #/WCSim/WCgeom SuperK_20inchPMT_20perCent
-#/WCSim/WCgeom SuperK_12inchHPD_14perCent
+#/WCSim/WCgeom SuperK_12inchHPD_15perCent
 #/WCSim/WCgeom SuperK_20inchHPD_14perCent
 
 # Generic cylindrical detector with a height of 100m and a 
 # diameter of 69m with 12" HPD and 14% photocoverage
-#/WCSim/WCgeom Cylinder_12inchHPD_14perCent
+#/WCSim/WCgeom Cylinder_12inchHPD_15perCent
 
 # Currently by defualt the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.

--- a/novis.mac
+++ b/novis.mac
@@ -10,6 +10,15 @@
 # The tube size is fixed for SK to 20"
 # These are fixed geometries for validation
 #/WCSim/WCgeom SuperK
+
+# Some other SuperK options:
+#/WCSim/WCgeom SuperK_12inchHPD_14perCent
+#/WCSim/WCgeom SuperK_20inchHPD_14perCent
+
+# Generic cylindrical detector with a height of 100m and a 
+# diameter of 69m with 12" HPD and 14% photocoverage
+#/WCSim/WCgeom Cylinder_12inchHPD_14perCent
+
 # Currently by defualt the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.
 # WCPMTsize command commented out on 10/1/09 (CWW)

--- a/novis.mac
+++ b/novis.mac
@@ -12,13 +12,13 @@
 #/WCSim/WCgeom SuperK
 
 # Some other SuperK options:
-#/WCSim/WCgeom SuperK_20inchPMT_20perCent
-#/WCSim/WCgeom SuperK_12inchHPD_15perCent
-#/WCSim/WCgeom SuperK_20inchHPD_14perCent
+#/WCSim/WCgeom SuperK_20inchPMT_20perCent # Note: the actual coverage is 20.27%
+#/WCSim/WCgeom SuperK_12inchHPD_15perCent # Note: the actual coverage is 14.59%
+#/WCSim/WCgeom SuperK_20inchHPD_14perCent # Note: the actual coverage is 13.51%
 
 # Generic cylindrical detector with a height of 100m and a 
-# diameter of 69m with 12" HPD and 14% photocoverage
-#/WCSim/WCgeom Cylinder_12inchHPD_15perCent
+# diameter of 69m with 12" HPD and 14.59% photocoverage
+#/WCSim/WCgeom Cylinder_12inchHPD_15perCent # Note: the actual coverage is 14.59%
 
 # Currently by defualt the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.

--- a/novis.mac
+++ b/novis.mac
@@ -13,6 +13,7 @@
 
 # Some other SuperK options:
 #/WCSim/WCgeom SuperK_20inchPMT_20perCent # Note: the actual coverage is 20.27%
+#/WCSim/WCgeom SuperK_20inchHPD_20perCent # Note: the actual coverage is 20.27%
 #/WCSim/WCgeom SuperK_12inchHPD_15perCent # Note: the actual coverage is 14.59%
 #/WCSim/WCgeom SuperK_20inchHPD_14perCent # Note: the actual coverage is 13.51%
 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -39,6 +39,82 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCAddGd               = false;
 }
 
+void WCSimDetectorConstruction::SuperK_12inchHPD_14perCent()
+{
+  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");
+  WCPMTName           = PMT->GetPMTName();
+  WCPMTExposeHeight   = PMT->GetExposeHeight();
+  WCPMTRadius         = PMT->GetRadius();
+  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
+  WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
+  WCIDHeight            = 36.200*m; //"" "" height
+  WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
+  WCPMTperCellHorizontal= 4;
+  WCPMTperCellVertical  = 3;
+  WCPMTPercentCoverage  = 14.0;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter
+								   *sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal
+									 *((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/
+									        WCPMTperCellVertical));
+  WCCapPMTSpacing       = 0.707*m; // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = 16.9*m;
+  WCBlackSheetThickness = 2.0*cm;
+  WCAddGd               = false;
+}
+
+
+void WCSimDetectorConstruction::SuperK_20inchHPD_14perCent()
+{
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE");
+  WCPMTName           = PMT->GetPMTName();
+  WCPMTExposeHeight   = PMT->GetExposeHeight();
+  WCPMTRadius         = PMT->GetRadius();
+  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
+  WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
+  WCIDHeight            = 36.200*m; //"" "" height
+  WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
+  WCPMTperCellHorizontal= 4;
+  WCPMTperCellVertical  = 3;
+  WCPMTPercentCoverage  = 14.0;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter
+								   *sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal
+									 *((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/
+									        WCPMTperCellVertical));
+  WCCapPMTSpacing       = 0.707*m; // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = 16.9*m;
+  WCBlackSheetThickness = 2.0*cm;
+  WCAddGd               = false;
+}
+
+
+void WCSimDetectorConstruction::Cylinder_12inchHPD_14perCent()
+{
+  // cylindrical detector with a height of 100m and a diameter of 69m 
+  // with 12" HPD and 14% photocoverage
+  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");
+  WCPMTName           = PMT->GetPMTName();
+  WCPMTExposeHeight   = PMT->GetExposeHeight();
+  WCPMTRadius         = PMT->GetRadius();
+  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
+  WCIDDiameter          = 69.0*m;
+  WCIDHeight            = 100.0*m;
+  WCBarrelPMTOffset     = WCPMTRadius; //offset from vertical
+  WCPMTperCellHorizontal= 4;
+  WCPMTperCellVertical  = 3;
+  WCPMTPercentCoverage  = 14.0;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter
+								   *sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal
+									 *((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/
+									        WCPMTperCellVertical));
+  WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal); // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
+  WCBlackSheetThickness = 2.0*cm;
+  WCAddGd               = false;
+}
+
 
 void WCSimDetectorConstruction::SetHyperKGeometry()
 {

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -39,6 +39,29 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCAddGd               = false;
 }
 
+void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
+{
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch");
+  WCPMTName           = PMT->GetPMTName();
+  WCPMTExposeHeight   = PMT->GetExposeHeight();
+  WCPMTRadius         = PMT->GetRadius();
+  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
+  WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
+  WCIDHeight            = 36.200*m; //"" "" height
+  WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
+  WCPMTperCellHorizontal= 4;
+  WCPMTperCellVertical  = 3; 
+  WCPMTPercentCoverage  = 20.0;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
+                                      /WCPMTperCellVertical));
+  WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal); // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
+  WCBlackSheetThickness = 2.0*cm;
+  WCAddGd               = false;
+}
+
+
 void WCSimDetectorConstruction::SuperK_12inchHPD_14perCent()
 {
   WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -64,6 +64,30 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 }
 
 
+// Note: the actual coverage is 20.27%
+void WCSimDetectorConstruction::SuperK_20inchHPD_20perCent()
+{
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE");
+  WCPMTName           = PMT->GetPMTName();
+  WCPMTExposeHeight   = PMT->GetExposeHeight();
+  WCPMTRadius         = PMT->GetRadius();
+  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
+  WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
+  WCIDHeight            = 36.200*m; //"" "" height
+  WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
+  WCPMTperCellHorizontal= 4;
+  WCPMTperCellVertical  = 3; 
+  WCPMTPercentCoverage  = 20.27;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
+                                      /WCPMTperCellVertical));
+  WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal); // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
+  WCBlackSheetThickness = 2.0*cm;
+  WCAddGd               = false;
+}
+
+
 // Note: the actual coverage is 14.59%
 void WCSimDetectorConstruction::SuperK_12inchHPD_15perCent()
 {

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -39,6 +39,8 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCAddGd               = false;
 }
 
+
+// Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 {
   WCSimPMTObject * PMT = CreatePMTObject("PMT20inch");
@@ -51,7 +53,7 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3; 
-  WCPMTPercentCoverage  = 20.0;
+  WCPMTPercentCoverage  = 20.27;
   WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
   WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
                                       /WCPMTperCellVertical));
@@ -62,7 +64,8 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 }
 
 
-void WCSimDetectorConstruction::SuperK_12inchHPD_14perCent()
+// Note: the actual coverage is 14.59%
+void WCSimDetectorConstruction::SuperK_12inchHPD_15perCent()
 {
   WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");
   WCPMTName           = PMT->GetPMTName();
@@ -74,7 +77,7 @@ void WCSimDetectorConstruction::SuperK_12inchHPD_14perCent()
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3;
-  WCPMTPercentCoverage  = 14.0;
+  WCPMTPercentCoverage  = 14.59;
   WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
   WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
                                       /WCPMTperCellVertical));
@@ -85,6 +88,7 @@ void WCSimDetectorConstruction::SuperK_12inchHPD_14perCent()
 }
 
 
+// Note: the actual coverage is 13.51%
 void WCSimDetectorConstruction::SuperK_20inchHPD_14perCent()
 {
   WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE");
@@ -97,7 +101,7 @@ void WCSimDetectorConstruction::SuperK_20inchHPD_14perCent()
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3;
-  WCPMTPercentCoverage  = 14.0;
+  WCPMTPercentCoverage  = 13.51;
   WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
   WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
                                       /WCPMTperCellVertical));
@@ -108,10 +112,10 @@ void WCSimDetectorConstruction::SuperK_20inchHPD_14perCent()
 }
 
 
-void WCSimDetectorConstruction::Cylinder_12inchHPD_14perCent()
+void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
 {
   // cylindrical detector with a height of 100m and a diameter of 69m 
-  // with 12" HPD and 14% photocoverage
+  // with 12" HPD and 14.59% photocoverage
   WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
@@ -122,7 +126,7 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_14perCent()
   WCBarrelPMTOffset     = WCPMTRadius; //offset from vertical
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3;
-  WCPMTPercentCoverage  = 14.0;
+  WCPMTPercentCoverage  = 14.59;
   WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
   WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
                                       /WCPMTperCellVertical));

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -52,13 +52,11 @@ void WCSimDetectorConstruction::SuperK_12inchHPD_14perCent()
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3;
   WCPMTPercentCoverage  = 14.0;
-  WCBarrelNumPMTHorizontal = round(WCIDDiameter
-								   *sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
-  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal
-									 *((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/
-									        WCPMTperCellVertical));
-  WCCapPMTSpacing       = 0.707*m; // distance between centers of top and bottom pmts
-  WCCapEdgeLimit        = 16.9*m;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
+                                      /WCPMTperCellVertical));
+  WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal); // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
   WCBlackSheetThickness = 2.0*cm;
   WCAddGd               = false;
 }
@@ -77,13 +75,11 @@ void WCSimDetectorConstruction::SuperK_20inchHPD_14perCent()
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3;
   WCPMTPercentCoverage  = 14.0;
-  WCBarrelNumPMTHorizontal = round(WCIDDiameter
-								   *sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
-  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal
-									 *((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/
-									        WCPMTperCellVertical));
-  WCCapPMTSpacing       = 0.707*m; // distance between centers of top and bottom pmts
-  WCCapEdgeLimit        = 16.9*m;
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
+                                      /WCPMTperCellVertical));
+  WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal); // distance between centers of top and bottom pmts
+  WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
   WCBlackSheetThickness = 2.0*cm;
   WCAddGd               = false;
 }
@@ -104,11 +100,9 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_14perCent()
   WCPMTperCellHorizontal= 4;
   WCPMTperCellVertical  = 3;
   WCPMTPercentCoverage  = 14.0;
-  WCBarrelNumPMTHorizontal = round(WCIDDiameter
-								   *sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
-  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal
-									 *((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))/
-									        WCPMTperCellVertical));
+  WCBarrelNumPMTHorizontal = round(WCIDDiameter*sqrt(pi*WCPMTPercentCoverage)/(10.0*WCPMTRadius));
+  WCBarrelNRings           = round(((WCBarrelNumPMTHorizontal*((WCIDHeight-2*WCBarrelPMTOffset)/(pi*WCIDDiameter)))
+                                      /WCPMTperCellVertical));
   WCCapPMTSpacing       = (pi*WCIDDiameter/WCBarrelNumPMTHorizontal); // distance between centers of top and bottom pmts
   WCCapEdgeLimit        = WCIDDiameter/2.0 - WCPMTRadius;
   WCBlackSheetThickness = 2.0*cm;

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -19,9 +19,9 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTConfig->SetGuidance("Available options are:\n"
                           "SuperK\n"
 			  "SuperK_20inchPMT_20perCent\n"
-			  "SuperK_12inchHPD_14perCent\n"
+			  "SuperK_12inchHPD_15perCent\n"
 			  "SuperK_20inchHPD_14perCent\n"
-			  "Cylinder_12inchHPD_14perCent\n"
+			  "Cylinder_12inchHPD_15perCent\n"
                           "HyperK\n"
                           "HyperK_withHPD\n"
                           "DUSEL_100kton_10inch_40perCent\n"
@@ -36,9 +36,9 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTConfig->SetParameterName("PMTConfig", false);
   PMTConfig->SetCandidates("SuperK "
 			   "SuperK_20inchPMT_20perCent "
-			   "SuperK_12inchHPD_14perCent "
+			   "SuperK_12inchHPD_15perCent "
 			   "SuperK_20inchHPD_14perCent "
-			   "Cylinder_12inchHPD_14perCent "
+			   "Cylinder_12inchHPD_15perCent "
 			   "HyperK "
                            "HyperK_withHPD "
                            "DUSEL_100kton_10inch_40perCent "
@@ -122,12 +122,12 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		  WCSimDetector->SetSuperKGeometry();
 		} else if (newValue == "SuperK_20inchPMT_20perCent" ){
 		  WCSimDetector->SuperK_20inchPMT_20perCent();
-		} else if ( newValue == "SuperK_12inchHPD_14perCent" ) {
-		  WCSimDetector->SuperK_12inchHPD_14perCent();
+		} else if ( newValue == "SuperK_12inchHPD_15perCent" ) {
+		  WCSimDetector->SuperK_12inchHPD_15perCent();
 		} else if ( newValue == "SuperK_20inchHPD_14perCent" ) {
 		  WCSimDetector->SuperK_20inchHPD_14perCent();
-		} else if (newValue == "Cylinder_12inchHPD_14perCent" ){
-		  WCSimDetector->Cylinder_12inchHPD_14perCent();
+		} else if (newValue == "Cylinder_12inchHPD_15perCent" ){
+		  WCSimDetector->Cylinder_12inchHPD_15perCent();
                 } else if ( newValue == "HyperK") {
                         WCSimDetector->SetIsHyperK(true);
 			WCSimDetector->SetHyperKGeometry();

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -18,6 +18,9 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTConfig->SetGuidance("Set the geometry configuration for the WC.");
   PMTConfig->SetGuidance("Available options are:\n"
                           "SuperK\n"
+			  "SuperK_12inchHPD_14perCent\n"
+			  "SuperK_20inchHPD_14perCent\n"
+			  "Cylinder_12inchHPD_14perCent\n"
                           "HyperK\n"
                           "HyperK_withHPD\n"
                           "DUSEL_100kton_10inch_40perCent\n"
@@ -31,7 +34,10 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
                          );
   PMTConfig->SetParameterName("PMTConfig", false);
   PMTConfig->SetCandidates("SuperK "
-                           "HyperK "
+			   "SuperK_12inchHPD_14perCent "
+			   "SuperK_20inchHPD_14perCent "
+			   "Cylinder_12inchHPD_14perCent "
+			   "HyperK "
                            "HyperK_withHPD "
                            "DUSEL_100kton_10inch_40perCent "
                            "DUSEL_100kton_10inch_HQE_12perCent "
@@ -111,7 +117,13 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		WCSimDetector->SetIsUpright(false);
                 WCSimDetector->SetIsHyperK(false);
                 if ( newValue == "SuperK") {
-                        WCSimDetector->SetSuperKGeometry();
+		  WCSimDetector->SetSuperKGeometry();
+		} else if ( newValue == "SuperK_12inchHPD_14perCent" ) {
+		  WCSimDetector->SuperK_12inchHPD_14perCent();
+		} else if ( newValue == "SuperK_20inchHPD_14perCent" ) {
+		  WCSimDetector->SuperK_20inchHPD_14perCent();
+		} else if (newValue == "Cylinder_12inchHPD_14perCent" ){
+		  WCSimDetector->Cylinder_12inchHPD_14perCent();
                 } else if ( newValue == "HyperK") {
                         WCSimDetector->SetIsHyperK(true);
 			WCSimDetector->SetHyperKGeometry();

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -18,6 +18,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTConfig->SetGuidance("Set the geometry configuration for the WC.");
   PMTConfig->SetGuidance("Available options are:\n"
                           "SuperK\n"
+			  "SuperK_20inchPMT_20perCent\n"
 			  "SuperK_12inchHPD_14perCent\n"
 			  "SuperK_20inchHPD_14perCent\n"
 			  "Cylinder_12inchHPD_14perCent\n"
@@ -34,6 +35,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
                          );
   PMTConfig->SetParameterName("PMTConfig", false);
   PMTConfig->SetCandidates("SuperK "
+			   "SuperK_20inchPMT_20perCent "
 			   "SuperK_12inchHPD_14perCent "
 			   "SuperK_20inchHPD_14perCent "
 			   "Cylinder_12inchHPD_14perCent "
@@ -118,6 +120,8 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
                 WCSimDetector->SetIsHyperK(false);
                 if ( newValue == "SuperK") {
 		  WCSimDetector->SetSuperKGeometry();
+		} else if (newValue == "SuperK_20inchPMT_20perCent" ){
+		  WCSimDetector->SuperK_20inchPMT_20perCent();
 		} else if ( newValue == "SuperK_12inchHPD_14perCent" ) {
 		  WCSimDetector->SuperK_12inchHPD_14perCent();
 		} else if ( newValue == "SuperK_20inchHPD_14perCent" ) {

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -19,6 +19,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTConfig->SetGuidance("Available options are:\n"
                           "SuperK\n"
 			  "SuperK_20inchPMT_20perCent\n"
+			  "SuperK_20inchHPD_20perCent\n"
 			  "SuperK_12inchHPD_15perCent\n"
 			  "SuperK_20inchHPD_14perCent\n"
 			  "Cylinder_12inchHPD_15perCent\n"
@@ -36,6 +37,7 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   PMTConfig->SetParameterName("PMTConfig", false);
   PMTConfig->SetCandidates("SuperK "
 			   "SuperK_20inchPMT_20perCent "
+			   "SuperK_20inchHPD_20perCent "
 			   "SuperK_12inchHPD_15perCent "
 			   "SuperK_20inchHPD_14perCent "
 			   "Cylinder_12inchHPD_15perCent "
@@ -122,6 +124,8 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 		  WCSimDetector->SetSuperKGeometry();
 		} else if (newValue == "SuperK_20inchPMT_20perCent" ){
 		  WCSimDetector->SuperK_20inchPMT_20perCent();
+		} else if (newValue == "SuperK_20inchHPD_20perCent" ){
+		  WCSimDetector->SuperK_20inchHPD_20perCent();
 		} else if ( newValue == "SuperK_12inchHPD_15perCent" ) {
 		  WCSimDetector->SuperK_12inchHPD_15perCent();
 		} else if ( newValue == "SuperK_20inchHPD_14perCent" ) {

--- a/vis.mac
+++ b/vis.mac
@@ -13,13 +13,13 @@
 #/WCSim/WCgeom SuperK
 
 # Some other SuperK options:
-#/WCSim/WCgeom SuperK_20inchPMT_20perCent
-#/WCSim/WCgeom SuperK_12inchHPD_15perCent
-#/WCSim/WCgeom SuperK_20inchHPD_14perCent
+#/WCSim/WCgeom SuperK_20inchPMT_20perCent # Note: the actual coverage is 20.27%
+#/WCSim/WCgeom SuperK_12inchHPD_15perCent # Note: the actual coverage is 14.59%
+#/WCSim/WCgeom SuperK_20inchHPD_14perCent # Note: the actual coverage is 13.51%
 
-# Generic cylindrical detector with a height of 100m and a 
-# diameter of 69m with 12" HPD and 14% photocoverage
-#/WCSim/WCgeom Cylinder_12inchHPD_15perCent
+# Generic cylindrical detector with a height of 100m and a
+# diameter of 69m with 12" HPD and 14.59% photocoverage
+#/WCSim/WCgeom Cylinder_12inchHPD_15perCent # Note: the actual coverage is 14.59%
 
 # Currently by default the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.

--- a/vis.mac
+++ b/vis.mac
@@ -14,12 +14,12 @@
 
 # Some other SuperK options:
 #/WCSim/WCgeom SuperK_20inchPMT_20perCent
-#/WCSim/WCgeom SuperK_12inchHPD_14perCent
+#/WCSim/WCgeom SuperK_12inchHPD_15perCent
 #/WCSim/WCgeom SuperK_20inchHPD_14perCent
 
 # Generic cylindrical detector with a height of 100m and a 
 # diameter of 69m with 12" HPD and 14% photocoverage
-#/WCSim/WCgeom Cylinder_12inchHPD_14perCent
+#/WCSim/WCgeom Cylinder_12inchHPD_15perCent
 
 # Currently by default the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.

--- a/vis.mac
+++ b/vis.mac
@@ -13,6 +13,7 @@
 #/WCSim/WCgeom SuperK
 
 # Some other SuperK options:
+#/WCSim/WCgeom SuperK_20inchPMT_20perCent
 #/WCSim/WCgeom SuperK_12inchHPD_14perCent
 #/WCSim/WCgeom SuperK_20inchHPD_14perCent
 

--- a/vis.mac
+++ b/vis.mac
@@ -11,6 +11,15 @@
 # The tube size is fixed for SK to 20"
 # These are fixed geometries for validation
 #/WCSim/WCgeom SuperK
+
+# Some other SuperK options:
+#/WCSim/WCgeom SuperK_12inchHPD_14perCent
+#/WCSim/WCgeom SuperK_20inchHPD_14perCent
+
+# Generic cylindrical detector with a height of 100m and a 
+# diameter of 69m with 12" HPD and 14% photocoverage
+#/WCSim/WCgeom Cylinder_12inchHPD_14perCent
+
 # Currently by default the DUSEL configurations are 10 inch.
 # you can overide this with the WCPMTsize command.
 # WCPMTsize command commented out on 10/1/09 (CWW)

--- a/vis.mac
+++ b/vis.mac
@@ -14,6 +14,7 @@
 
 # Some other SuperK options:
 #/WCSim/WCgeom SuperK_20inchPMT_20perCent # Note: the actual coverage is 20.27%
+#/WCSim/WCgeom SuperK_20inchHPD_20perCent # Note: the actual coverage is 20.27%
 #/WCSim/WCgeom SuperK_12inchHPD_15perCent # Note: the actual coverage is 14.59%
 #/WCSim/WCgeom SuperK_20inchHPD_14perCent # Note: the actual coverage is 13.51%
 


### PR DESCRIPTION
- Added the three new detector geometries as described in Issue 50. 
- Also implemented Erin's suggestions regarding the definitions of WCCapPMTSpacing and WCCapEdgeLimit.
- Ran WCSim with the new geometries. Occasionally get the warning "Potential overlap in geometry! *** This is just a warning message.". Ran WCSim with the (already implemented) SuperK geometry and notice a similar number of warnings. Assume this is OK?