### PR TITLE
Feature/geant4.9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ doc/DetectorDocumentation.pdf.
 ```
 WCSim development is supported by the United States National Science Foundation.
 ```
+
+Test

--- a/README.md
+++ b/README.md
@@ -56,5 +56,3 @@ doc/DetectorDocumentation.pdf.
 ```
 WCSim development is supported by the United States National Science Foundation.
 ```
-
-Test

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -736,7 +736,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
      new G4OpticalSurface("WaterBSCellSurface");
 
    OpWaterBSSurface->SetType(dielectric_dielectric);
-   OpWaterBSSurface->SetModel(unified); // deprecated in 4.9.6
+   OpWaterBSSurface->SetModel(unified); 
    OpWaterBSSurface->SetFinish(groundfrontpainted);
    OpWaterBSSurface->SetSigmaAlpha(0.1);
 
@@ -758,7 +758,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
    OpGlassCathodeSurface =
      new G4OpticalSurface("GlassCathodeSurface");
    OpGlassCathodeSurface->SetType(dielectric_dielectric);
-   OpGlassCathodeSurface->SetModel(unified);  // deprecated in 4.9.6
+   OpGlassCathodeSurface->SetModel(unified);  
    //   OpGlassCathodeSurface->SetFinish(groundbackpainted);
    OpGlassCathodeSurface->SetFinish(polished);
    //OpGlassCathodeSurface->SetSigmaAlpha(0.002);
@@ -799,7 +799,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
      new G4OpticalSurface("WaterTyCellSurface");
 
    OpWaterTySurface->SetType(dielectric_dielectric);
-   OpWaterTySurface->SetModel(unified);  // deprecated in 4.9.6
+   OpWaterTySurface->SetModel(unified); 
    OpWaterTySurface->SetFinish(groundbackpainted); //a guess, but seems to work
    OpWaterTySurface->SetSigmaAlpha(0.5); //cf. A. Chavarria's ~30deg
 

--- a/src/WCSimPhysicsList.cc
+++ b/src/WCSimPhysicsList.cc
@@ -280,9 +280,6 @@ void WCSimPhysicsList::ConstructOp(){
   // theCherenkovProcess->SetMaxBetaChangePerStep(10.0);
   // theCherenkovProcess->SetTrackSecondariesFirst(true);
 
-  G4OpticalSurfaceModel themodel = unified;
-  theBoundaryProcess->SetModel(themodel);   // deprecated in 4.9.6
-
   theParticleIterator->reset();
   while( (*theParticleIterator)() )
   {


### PR DESCRIPTION
This feature branch also compiles with geant4.9.6. The function call SetModel of G4OpticalBoundaryProcess that was already not used in Geant4.9.4 is removed in the newer version. Instead Geant4 uses the function call from the G4OpticalSurface to determine which model (glisur, unified or Look-up tables) to use. These calls are NOT deprecated as mentioned incorrectly in WCSimConstructMaterials.cc. If these are not set, Geant4 will use the defaults of G4OpticalSurface (see G4OpticalSurface.hh), which is "glisur" and not "unified" which we are currently using.
Expected physics (model or data) differences between geant4.9.6 and geant4.9.4 will be discussed in the Physics Lists issue.