### PR TITLE
Update README.md to update the recommended version of gcc and to put the recommended version of ROOT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ You can follow issues/requests etc by watching the GitHub respository.
 Build Instructions:
 
 You should have a recent and working version of ROOT and GEANT4.
-(Known to work with GEANT 4.9.4.p01.)  You also need all of the G4
+(Known to work with GEANT 4.9.4.p01 and ROOT v5.28.00)  You also need all of the G4
 data files including hadron xsecs etc.  Those are the only
-requirements.  The code should work with gcc 4.3.
+requirements.  The code should work with gcc 4.4.7.
 
 To compile: 
 * make clean 


### PR DESCRIPTION
We are now all working with at least gcc 4.4, so I updated the recommended compiler version to the one we are currently using at Duke (gcc4.4.7). I also put which version of ROOT should be used, since WCSim will not work with all versions of ROOT.