### PR TITLE
Feature/issue38

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -92,25 +92,26 @@ public:
 
   WCSimPMTObject *CreatePMTObject(G4String, G4String);
 
-  WCSimPMTObject *  PMTptrID[10];
-  WCSimPMTObject * PMTptrOD[10];
-  int IDPMTCounter;
+  G4int total_array_number;
+  G4int array_index;
   int ODPMTCounter;
-  void SetPMTPointer(WCSimPMTObject* PMT, G4String PMTVolume) {
-    if(PMTVolume == "ID"){
-      PMTptrID[IDPMTCounter] = PMT;
-      IDPMTCounter++;
+  WCSimPMTObject * PMTptr[10];
+  G4String CollectionNameArray[10];
+ 
+ void SetPMTPointer(WCSimPMTObject* PMT, G4String CollectionName) {
+   CollectionNameArray[total_array_number] = CollectionName;
+   PMTptr[total_array_number] = PMT;
+   total_array_number++;
+ }
+  
+  WCSimPMTObject* GetPMTPointer(G4String CollectionName){
+    array_index = 1000; // some large number
+    for (int i=0; i<total_array_number; i++){
+      if (CollectionName == CollectionNameArray[i]){array_index = i; break;}
     }
-    else if (PMTVolume == "OD"){
-      PMTptrOD[ODPMTCounter] = PMT;
-      ODPMTCounter++;
-    }
-    else {
-       G4cout << PMTVolume << " is not a recognized PMT volume. Exiting WCSim." << G4endl; exit(1);
-    }
+    if(array_index == 1000){G4cout << CollectionName << " is not a recognized Collection Name. Exiting WCSim." << G4endl; exit(1);}
+    return PMTptr[array_index];
   }
-  WCSimPMTObject* GetPMTPointerID(int PMTTypeNumber){return PMTptrID[PMTTypeNumber];}
-  WCSimPMTObject* GetPMTPointerOD(int PMTTypeNumber){return PMTptrOD[PMTTypeNumber];}
   
   G4ThreeVector GetWCOffset(){return WCOffset;}
   

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -88,8 +88,8 @@ public:
 
   G4double GetPMTSize1() {return WCPMTSize;}
 
-  G4float GetPMTQE(G4float, G4int, G4float, G4float, G4float);
-  G4float GetPMTCollectionEfficiency(G4float theta_angle) { return GetPMTPointer()->GetCollectionEfficiency(theta_angle); };
+  G4float GetPMTQE(G4String,G4float, G4int, G4float, G4float, G4float);
+  G4float GetPMTCollectionEfficiency(G4float theta_angle, G4String CollectionName) { return GetPMTPointer(CollectionName)->GetCollectionEfficiency(theta_angle); };
 
   WCSimPMTObject *CreatePMTObject(G4String, G4String);
 
@@ -116,7 +116,7 @@ public:
   
   G4ThreeVector GetWCOffset(){return WCOffset;}
   
-  // Related to the WC tube IDs
+  // Related to the WC tube ID
   static G4int GetTubeID(std::string tubeTag){return tubeLocationMap[tubeTag];}
   static G4Transform3D GetTubeTransform(int tubeNo){return tubeIDMap[tubeNo];}
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -93,27 +93,19 @@ public:
 
   WCSimPMTObject *CreatePMTObject(G4String, G4String);
 
-  G4int total_array_number;
-  G4int array_index;
-  int ODPMTCounter;
-  WCSimPMTObject * PMTptr[10];
-  G4String CollectionNameArray[10];
+  std::map<G4String, WCSimPMTObject*>  CollectionNameMap; 
+  WCSimPMTObject * PMTptr;
  
- void SetPMTPointer(WCSimPMTObject* PMT, G4String CollectionName) {
-   CollectionNameArray[total_array_number] = CollectionName;
-   PMTptr[total_array_number] = PMT;
-   total_array_number++;
- }
-  
-  WCSimPMTObject* GetPMTPointer(G4String CollectionName){
-    array_index = 1000; // some large number
-    for (int i=0; i<total_array_number; i++){
-      if (CollectionName == CollectionNameArray[i]){array_index = i; break;}
-    }
-    if(array_index == 1000){G4cout << CollectionName << " is not a recognized Collection Name. Exiting WCSim." << G4endl; exit(1);}
-    return PMTptr[array_index];
+  void SetPMTPointer(WCSimPMTObject* PMT, G4String CollectionName){
+    CollectionNameMap[CollectionName] = PMT;
   }
-  
+
+  WCSimPMTObject* GetPMTPointer(G4String CollectionName){
+    PMTptr = CollectionNameMap[CollectionName];
+    if (PMTptr == NULL) {G4cout << CollectionName << " is not a recognized hit collection. Exiting WCSim." << G4endl; exit(1);}
+    return PMTptr;
+  }
+ 
   G4ThreeVector GetWCOffset(){return WCOffset;}
   
   // Related to the WC tube ID
@@ -250,6 +242,7 @@ private:
   G4String WCPMTName;
   typedef std::pair<G4String, G4String> PMTKey_t;
   typedef std::map<PMTKey_t, G4LogicalVolume*> PMTMap_t;
+
   static PMTMap_t PMTLogicalVolumes;
 
   // WC geometry parameters
@@ -386,7 +379,7 @@ private:
   static std::map<int, G4Transform3D> tubeIDMap;
 //  static std::map<int, cyl_location> tubeCylLocation;
   static hash_map<std::string, int, hash<std::string> >  tubeLocationMap; 
-
+ 
   // Variables related to configuration
 
   G4int myConfiguration;   // Detector Config Parameter

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -85,12 +85,28 @@ public:
 
   G4float GetPMTQE(G4float, G4int, G4float, G4float, G4float);
 
-  WCSimPMTObject *CreatePMTObject(G4String);
+  WCSimPMTObject *CreatePMTObject(G4String, G4String);
 
-  WCSimPMTObject *  PMTptr;
-  void    SetPMTPointer(WCSimPMTObject* PMT) {PMTptr = PMT;} //currently you can only save one PMT here. When we move to multiple PMTs as a future upgrade, this can be changed to an array of PMT pointers.
-  WCSimPMTObject*  GetPMTPointer(){return PMTptr;}
-
+  WCSimPMTObject *  PMTptrID[10];
+  WCSimPMTObject * PMTptrOD[10];
+  int IDPMTCounter;
+  int ODPMTCounter;
+  void SetPMTPointer(WCSimPMTObject* PMT, G4String PMTVolume) {
+    if(PMTVolume == "ID"){
+      PMTptrID[IDPMTCounter] = PMT;
+      IDPMTCounter++;
+    }
+    else if (PMTVolume == "OD"){
+      PMTptrOD[ODPMTCounter] = PMT;
+      ODPMTCounter++;
+    }
+    else {
+       G4cout << PMTVolume << " is not a recognized PMT volume. Exiting WCSim." << G4endl; exit(1);
+    }
+  }
+  WCSimPMTObject* GetPMTPointerID(int PMTTypeNumber){return PMTptrID[PMTTypeNumber];}
+  WCSimPMTObject* GetPMTPointerOD(int PMTTypeNumber){return PMTptrOD[PMTTypeNumber];}
+  
   G4ThreeVector GetWCOffset(){return WCOffset;}
   
   // Related to the WC tube IDs
@@ -150,7 +166,7 @@ private:
 
   // The Construction routines
   G4LogicalVolume*   ConstructCylinder();
-  G4LogicalVolume* ConstructPMT(G4double,G4double);
+  G4LogicalVolume* ConstructPMT(G4String,G4String);
 
   G4LogicalVolume* ConstructCaps(G4int zflip);
 
@@ -225,7 +241,7 @@ private:
 
   // WC PMT parameters
   G4String WCPMTName;
-  typedef std::pair<G4double, G4double> PMTKey_t;
+  typedef std::pair<G4String, G4String> PMTKey_t;
   typedef std::map<PMTKey_t, G4LogicalVolume*> PMTMap_t;
   static PMTMap_t PMTLogicalVolumes;
 
@@ -328,6 +344,7 @@ private:
     G4double outerPMT_Height;
     G4double outerPMT_Radius;
     G4double outerPMT_Expose;
+    G4String outerPMT_Name;
     G4double outerPMT_TopRpitch;
     G4double outerPMT_BotRpitch;
     G4double outerPMT_Apitch;

--- a/include/WCSimWCSD.hh
+++ b/include/WCSimWCSD.hh
@@ -11,7 +11,7 @@ class G4HCofThisEvent;
 class WCSimWCSD : public G4VSensitiveDetector
 {
  public:
-  WCSimWCSD(G4String,WCSimDetectorConstruction*);
+  WCSimWCSD(G4String,G4String,WCSimDetectorConstruction*);
   ~WCSimWCSD();
   
   void   Initialize(G4HCofThisEvent*);

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -565,7 +565,7 @@ else {
   // K.Zbiri: The PMT volume and the PMT glass are now put in parallel. 
   // The PMT glass is the sensitive volume in this new configuration.
 
-  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTRadius, WCPMTExposeHeight);
+  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "ID");
 
   
 
@@ -1053,8 +1053,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   // Add top and bottom PMTs
   // -----------------------------------------------------
   
-  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTRadius, WCPMTExposeHeight);
-
+	G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "ID");
+	
   G4double xoffset;
   G4double yoffset;
   G4int    icopy = 0;

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -565,7 +565,7 @@ else {
   // K.Zbiri: The PMT volume and the PMT glass are now put in parallel. 
   // The PMT glass is the sensitive volume in this new configuration.
 
-  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "ID");
+  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "glassFaceWCPMT");
 
   
 
@@ -1053,7 +1053,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   // Add top and bottom PMTs
   // -----------------------------------------------------
   
-	G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "ID");
+	G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "glassFaceWCPMT");
 	
   G4double xoffset;
   G4double yoffset;

--- a/src/WCSimConstructHyperK.cc
+++ b/src/WCSimConstructHyperK.cc
@@ -135,7 +135,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
 
   new G4PVPlacement(g4rot,
                     G4ThreeVector(r,0.,0.),
-                    ConstructPMT(innerPMT_Radius,innerPMT_Expose),
+                    ConstructPMT(WCPMTName, "ID"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -150,7 +150,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
 
   new G4PVPlacement(g4rot,
                     G4ThreeVector(r,0.,0.),
-                    ConstructPMT(innerPMT_Radius,innerPMT_Expose),
+                    ConstructPMT(WCPMTName, "ID"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -179,7 +179,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
            z = -outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Radius,outerPMT_Expose),
+                    ConstructPMT(outerPMT_Name,"OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -193,7 +193,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Radius,outerPMT_Expose),
+                    ConstructPMT(outerPMT_Name,"OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -219,7 +219,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = -outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Radius,outerPMT_Expose),
+                    ConstructPMT(outerPMT_Name,"OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -233,7 +233,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Radius,outerPMT_Expose),
+                    ConstructPMT(outerPMT_Name,"OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -246,7 +246,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateY(180.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,-innerPMT_Expose/2.),
-                    ConstructPMT(innerPMT_Radius,innerPMT_Expose),
+                    ConstructPMT(WCPMTName, "ID"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -260,7 +260,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateX(-90.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(innerPMT_Radius,innerPMT_Expose),
+                    ConstructPMT(WCPMTName, "ID"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -269,7 +269,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
                                          innerPMT_Apitch, innerPMT_Expose);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(innerPMT_Radius,innerPMT_Expose),
+                    ConstructPMT(WCPMTName, "ID"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -281,7 +281,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateX(90.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(outerPMT_Radius,outerPMT_Expose),
+                    ConstructPMT(outerPMT_Name,"OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -290,7 +290,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
                                   outerPMT_Apitch, outerPMT_Expose);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(outerPMT_Radius,outerPMT_Expose),
+                    ConstructPMT(outerPMT_Name,"OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);

--- a/src/WCSimConstructHyperK.cc
+++ b/src/WCSimConstructHyperK.cc
@@ -2,7 +2,6 @@
 #include "WCSimDetectorConstruction.hh"
 
 #include "G4SystemOfUnits.hh"
-
 #include "G4ThreeVector.hh"
 #include "G4RotationMatrix.hh"
 #include "G4Transform3D.hh"
@@ -135,7 +134,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
 
   new G4PVPlacement(g4rot,
                     G4ThreeVector(r,0.,0.),
-                    ConstructPMT(WCPMTName, "ID"),
+                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -150,7 +149,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
 
   new G4PVPlacement(g4rot,
                     G4ThreeVector(r,0.,0.),
-                    ConstructPMT(WCPMTName, "ID"),
+                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -179,7 +178,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
            z = -outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"OD"),
+                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -193,7 +192,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"OD"),
+                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -219,7 +218,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = -outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"OD"),
+                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -233,7 +232,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"OD"),
+                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -246,7 +245,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateY(180.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,-innerPMT_Expose/2.),
-                    ConstructPMT(WCPMTName, "ID"),
+                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -260,7 +259,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateX(-90.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(WCPMTName, "ID"),
+                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -269,7 +268,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
                                          innerPMT_Apitch, innerPMT_Expose);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(WCPMTName, "ID"),
+                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -281,7 +280,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateX(90.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(outerPMT_Name,"OD"),
+                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -290,7 +289,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
                                   outerPMT_Apitch, outerPMT_Expose);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(outerPMT_Name,"OD"),
+                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -20,9 +20,9 @@
 
 WCSimDetectorConstruction::PMTMap_t WCSimDetectorConstruction::PMTLogicalVolumes;
 
-G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4String PMTVolume)
+G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4String CollectionName)
 {
-  PMTKey_t key(PMTName,PMTVolume);
+  PMTKey_t key(PMTName,CollectionName);
 
   PMTMap_t::iterator it = PMTLogicalVolumes.find(key);
   if (it != PMTLogicalVolumes.end()) {
@@ -39,18 +39,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   G4double expose;
   G4double radius;
 
-  if(PMTVolume == "ID"){
-    WCSimPMTObject *PMTID = GetPMTPointerID(0);
-    expose = PMTID->GetExposeHeight();
-    radius = PMTID->GetRadius();
-  }
-  else if (PMTVolume == "OD"){
-    WCSimPMTObject *PMTOD = GetPMTPointerOD(0);
-    expose = PMTOD->GetExposeHeight();
-    radius = PMTOD->GetRadius();
-  }
-  else {
-    G4cout << PMTVolume << " is not a recognized PMT volume. Exiting WCSim." << G4endl; exit(1);}
+  WCSimPMTObject *PMT = GetPMTPointer(CollectionName);
+  expose = PMT->GetExposeHeight();
+  radius = PMT->GetRadius();
   
   G4double sphereRadius = (expose*expose+ radius*radius)/(2*expose);
   G4double PMTOffset =  sphereRadius - expose;

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -12,6 +12,7 @@
 
 #include "G4SDManager.hh"
 #include "WCSimWCSD.hh"
+#include "WCSimPMTObject.hh"
 
 #include "G4SystemOfUnits.hh"
 
@@ -19,10 +20,9 @@
 
 WCSimDetectorConstruction::PMTMap_t WCSimDetectorConstruction::PMTLogicalVolumes;
 
-G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4double radius,
-                                                         G4double expose)
+G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4String PMTVolume)
 {
-  PMTKey_t key(radius,expose);
+  PMTKey_t key(PMTName,PMTVolume);
 
   PMTMap_t::iterator it = PMTLogicalVolumes.find(key);
   if (it != PMTLogicalVolumes.end()) {
@@ -35,9 +35,23 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4double radius,
     // Gray wireframe visual style
   G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
   WCPMTVisAtt->SetForceWireframe(true);
+  
+  G4double expose;
+  G4double radius;
 
-
-
+  if(PMTVolume == "ID"){
+    WCSimPMTObject *PMTID = GetPMTPointerID(0);
+    expose = PMTID->GetExposeHeight();
+    radius = PMTID->GetRadius();
+  }
+  else if (PMTVolume == "OD"){
+    WCSimPMTObject *PMTOD = GetPMTPointerOD(0);
+    expose = PMTOD->GetExposeHeight();
+    radius = PMTOD->GetRadius();
+  }
+  else {
+    G4cout << PMTVolume << " is not a recognized PMT volume. Exiting WCSim." << G4endl; exit(1);}
+  
   G4double sphereRadius = (expose*expose+ radius*radius)/(2*expose);
   G4double PMTOffset =  sphereRadius - expose;
 

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -150,7 +150,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
     G4SDManager* SDman = G4SDManager::GetSDMpointer();
     G4String SDName = "/WCSim/";
     SDName += CollectionName;
-    aWCPMT = new WCSimWCSD(SDName,this );
+    aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
     SDman->AddNewDetector( aWCPMT );
   }
   logicGlassFaceWCPMT->SetSensitiveDetector( aWCPMT );

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -148,7 +148,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   if (!aWCPMT)
   {
     G4SDManager* SDman = G4SDManager::GetSDMpointer();
-    aWCPMT = new WCSimWCSD( "/WCSim/glassFaceWCPMT",this );
+    G4String SDName = "/WCSim/";
+    SDName += CollectionName;
+    aWCPMT = new WCSimWCSD(SDName,this );
     SDman->AddNewDetector( aWCPMT );
   }
   logicGlassFaceWCPMT->SetSensitiveDetector( aWCPMT );

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -38,7 +38,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   
   G4double expose;
   G4double radius;
-
+  
   WCSimPMTObject *PMT = GetPMTPointer(CollectionName);
   expose = PMT->GetExposeHeight();
   radius = PMT->GetRadius();

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -43,7 +43,7 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "ID");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -67,7 +67,7 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchHPD_20perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", "ID");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -91,7 +91,7 @@ void WCSimDetectorConstruction::SuperK_20inchHPD_20perCent()
 // Note: the actual coverage is 14.59%
 void WCSimDetectorConstruction::SuperK_12inchHPD_15perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE", "ID");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -115,7 +115,7 @@ void WCSimDetectorConstruction::SuperK_12inchHPD_15perCent()
 // Note: the actual coverage is 13.51%
 void WCSimDetectorConstruction::SuperK_20inchHPD_14perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", "ID");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -140,7 +140,7 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
 {
   // cylindrical detector with a height of 100m and a diameter of 69m 
   // with 12" HPD and 14.59% photocoverage
-  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE", "ID");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -182,7 +182,8 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
   innerPMT_Rpitch   =   990.*mm;
   innerPMT_Apitch   =   990.*mm;
 
-  WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
+  //WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
+  WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", "glassFaceWCPMT_OD");
   outerPMT_Name = outerPMT->GetPMTName();
   outerPMT_Expose = outerPMT->GetExposeHeight();
   outerPMT_Radius = outerPMT->GetRadius();
@@ -227,7 +228,8 @@ void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
    innerPMT_Rpitch   =   990.*mm;
    innerPMT_Apitch   =   990.*mm;
 
-   WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
+   //   WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
+   WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", "glassFaceWCPMT_OD");
    outerPMT_Expose = outerPMT->GetExposeHeight();
    outerPMT_Radius = outerPMT->GetRadius();
    outerPMT_TopR      = innerPMT_TopR + 900.*mm;

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -5,7 +5,6 @@
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 
-
 /***********************************************************
  *
  * This file contains the setup functions for various 
@@ -21,7 +20,7 @@
 
 void WCSimDetectorConstruction::SetSuperKGeometry()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -43,7 +42,7 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "glassFaceWCPMT");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -67,7 +66,7 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchBandL_20perCent()
 {
-	WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", "ID");
+	WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", "glassFaceWCPMT");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -91,7 +90,7 @@ void WCSimDetectorConstruction::SuperK_20inchBandL_20perCent()
 // Note: the actual coverage is 14.59%
 void WCSimDetectorConstruction::SuperK_12inchBandL_15perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("BoxandLine12inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("BoxandLine12inchHQE", "glassFaceWCPMT");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -115,7 +114,7 @@ void WCSimDetectorConstruction::SuperK_12inchBandL_15perCent()
 // Note: the actual coverage is 13.51%
 void WCSimDetectorConstruction::SuperK_20inchBandL_14perCent()
 {
-	WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", "ID");
+	WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", "glassFaceWCPMT");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -140,7 +139,7 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
 {
   // cylindrical detector with a height of 100m and a diameter of 69m 
   // with 12" HPD and 14.59% photocoverage
-  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE", "glassFaceWCPMT");
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -163,7 +162,7 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
 
 void WCSimDetectorConstruction::SetHyperKGeometry()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   innerPMT_Expose = PMT->GetExposeHeight();
   innerPMT_Radius = PMT->GetRadius();
@@ -208,7 +207,7 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
 
 void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", "glassFaceWCPMT");
    WCPMTName = PMT->GetPMTName();
    innerPMT_Expose = PMT->GetExposeHeight();
    innerPMT_Radius = PMT->GetRadius();
@@ -277,7 +276,7 @@ void WCSimDetectorConstruction::MatchWCSimAndHyperK()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inch", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inch", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -301,7 +300,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
 { 
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -325,7 +324,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -349,7 +348,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -373,7 +372,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
 
 void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -397,7 +396,7 @@ void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -421,7 +420,7 @@ void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -441,7 +440,7 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_14perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "ID");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "glassFaceWCPMT");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -182,7 +182,6 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
   innerPMT_Rpitch   =   990.*mm;
   innerPMT_Apitch   =   990.*mm;
 
-  //WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
   WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", "glassFaceWCPMT_OD");
   outerPMT_Name = outerPMT->GetPMTName();
   outerPMT_Expose = outerPMT->GetExposeHeight();
@@ -228,7 +227,6 @@ void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
    innerPMT_Rpitch   =   990.*mm;
    innerPMT_Apitch   =   990.*mm;
 
-   //   WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
    WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", "glassFaceWCPMT_OD");
    outerPMT_Expose = outerPMT->GetExposeHeight();
    outerPMT_Radius = outerPMT->GetRadius();

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -21,7 +21,7 @@
 
 void WCSimDetectorConstruction::SetSuperKGeometry()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -42,7 +42,7 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
 
 void WCSimDetectorConstruction::SetHyperKGeometry()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "ID");
   WCPMTName = PMT->GetPMTName();
   innerPMT_Expose = PMT->GetExposeHeight();
   innerPMT_Radius = PMT->GetRadius();
@@ -63,6 +63,7 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
   innerPMT_Apitch   =   990.*mm;
 
   WCSimPMTObject* outerPMT = new PMT8inch; //currently doesn't store the pointer to this PMT. If we want to read the qpe or QE for the OD in the future, this will need to be stored.
+  outerPMT_Name = outerPMT->GetPMTName();
   outerPMT_Expose = outerPMT->GetExposeHeight();
   outerPMT_Radius = outerPMT->GetRadius();
   outerPMT_TopR      = innerPMT_TopR + 900.*mm;
@@ -86,7 +87,7 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
 
 void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
 {
-   WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", "ID");
    WCPMTName = PMT->GetPMTName();
    innerPMT_Expose = PMT->GetExposeHeight();
    innerPMT_Radius = PMT->GetRadius();
@@ -155,7 +156,7 @@ void WCSimDetectorConstruction::MatchWCSimAndHyperK()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inch");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inch", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -179,7 +180,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
 { 
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -203,7 +204,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -227,7 +228,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -251,7 +252,7 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
 
 void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -275,7 +276,7 @@ void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -299,7 +300,7 @@ void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -319,7 +320,7 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_14perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE");
+  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "ID");
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -218,41 +218,41 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   return physiExpHall;
 }
 
-WCSimPMTObject *WCSimDetectorConstruction::CreatePMTObject(G4String PMTType)
+WCSimPMTObject *WCSimDetectorConstruction::CreatePMTObject(G4String PMTType, G4String PMTVolume)
 {
   if (PMTType == "PMT20inch"){
      WCSimPMTObject* PMT = new PMT20inch;
-      WCSimDetectorConstruction::SetPMTPointer(PMT);
+     WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
       return PMT;
   }
   else if (PMTType == "PMT8inch"){
     WCSimPMTObject* PMT = new PMT8inch;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
     return PMT;
   }
   else if (PMTType == "PMT10inch"){
     WCSimPMTObject* PMT = new PMT10inch;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
     return PMT;
   }
   else if (PMTType == "PMT10inchHQE"){
     WCSimPMTObject* PMT = new PMT10inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
     return PMT;
   }
   else if (PMTType == "PMT12inchHQE"){
     WCSimPMTObject* PMT = new PMT12inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
     return PMT;
   }
   else if (PMTType == "HPD20inchHQE"){
     WCSimPMTObject* PMT = new HPD20inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
     return PMT;
   }
   else if (PMTType == "HPD12inchHQE"){
     WCSimPMTObject* PMT = new HPD12inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
     return PMT;
   }
   else { G4cout << PMTType << " is not a recognized PMT Type. Exiting WCSim." << G4endl; exit(1);}

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -218,41 +218,41 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   return physiExpHall;
 }
 
-WCSimPMTObject *WCSimDetectorConstruction::CreatePMTObject(G4String PMTType, G4String PMTVolume)
+WCSimPMTObject *WCSimDetectorConstruction::CreatePMTObject(G4String PMTType, G4String CollectionName)
 {
   if (PMTType == "PMT20inch"){
      WCSimPMTObject* PMT = new PMT20inch;
-     WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+     WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
       return PMT;
   }
   else if (PMTType == "PMT8inch"){
     WCSimPMTObject* PMT = new PMT8inch;
-    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else if (PMTType == "PMT10inch"){
     WCSimPMTObject* PMT = new PMT10inch;
-    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else if (PMTType == "PMT10inchHQE"){
     WCSimPMTObject* PMT = new PMT10inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else if (PMTType == "PMT12inchHQE"){
     WCSimPMTObject* PMT = new PMT12inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else if (PMTType == "HPD20inchHQE"){
     WCSimPMTObject* PMT = new HPD20inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else if (PMTType == "HPD12inchHQE"){
     WCSimPMTObject* PMT = new HPD12inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT, PMTVolume);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else { G4cout << PMTType << " is not a recognized PMT Type. Exiting WCSim." << G4endl; exit(1);}

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -257,12 +257,12 @@ WCSimPMTObject *WCSimDetectorConstruction::CreatePMTObject(G4String PMTType, G4S
   }
   else if (PMTType == "BoxandLine20inchHQE"){
     WCSimPMTObject* PMT = new BoxandLine20inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
   else if (PMTType == "BoxandLine12inchHQE"){
     WCSimPMTObject* PMT = new BoxandLine12inchHQE;
-    WCSimDetectorConstruction::SetPMTPointer(PMT);
+    WCSimDetectorConstruction::SetPMTPointer(PMT, CollectionName);
     return PMT;
   }
 

--- a/src/WCSimPMTQE.cc
+++ b/src/WCSimPMTQE.cc
@@ -48,7 +48,7 @@ G4float WCSimDetectorConstruction::GetPMTQE(G4float PhotonWavelength, G4int flag
   }
   
   WCSimPMTObject *PMT;
-  PMT = GetPMTPointer();
+  PMT = GetPMTPointerID(0);
   G4float *wavelength;
   wavelength = PMT->GetQEWavelength();
   G4float *QE;

--- a/src/WCSimPMTQE.cc
+++ b/src/WCSimPMTQE.cc
@@ -18,7 +18,7 @@
  ***********************************************************/
 
 
-G4float WCSimDetectorConstruction::GetPMTQE(G4float PhotonWavelength, G4int flag, G4float low_wl, G4float high_wl, G4float ratio){
+G4float WCSimDetectorConstruction::GetPMTQE(G4String CollectionName, G4float PhotonWavelength, G4int flag, G4float low_wl, G4float high_wl, G4float ratio){
   // XQ  08/17/10
   // Decide to include the QE in the WCSim detector 
   // rathe than hard coded into the StackingAction
@@ -48,7 +48,7 @@ G4float WCSimDetectorConstruction::GetPMTQE(G4float PhotonWavelength, G4int flag
   }
   
   WCSimPMTObject *PMT;
-  PMT = GetPMTPointer("ID");
+  PMT = GetPMTPointer(CollectionName);
   G4float *wavelength;
   wavelength = PMT->GetQEWavelength();
   G4float *QE;

--- a/src/WCSimPMTQE.cc
+++ b/src/WCSimPMTQE.cc
@@ -48,7 +48,7 @@ G4float WCSimDetectorConstruction::GetPMTQE(G4float PhotonWavelength, G4int flag
   }
   
   WCSimPMTObject *PMT;
-  PMT = GetPMTPointerID(0);
+  PMT = GetPMTPointer("ID");
   G4float *wavelength;
   wavelength = PMT->GetQEWavelength();
   G4float *QE;

--- a/src/WCSimStackingAction.cc
+++ b/src/WCSimStackingAction.cc
@@ -31,7 +31,7 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
       G4float ratio = 1./(1.0-0.25);
       G4float wavelengthQE = 0;
       if(aTrack->GetCreatorProcess()==NULL) {
-	wavelengthQE  = DetConstruct->GetPMTQE(photonWavelength,1,240,660,ratio);
+	wavelengthQE  = DetConstruct->GetPMTQE("glassFaceWCPMT",photonWavelength,1,240,660,ratio);
 	if( G4UniformRand() > wavelengthQE )
 	  classification = fKill;
       }
@@ -46,9 +46,9 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
 	  // Even with WLS
 	  G4float wavelengthQE = 0;
 	  if (DetConstruct->GetPMT_QE_Method()==1){
-	    wavelengthQE  = DetConstruct->GetPMTQE(photonWavelength,1,240,660,ratio);
+	    wavelengthQE  = DetConstruct->GetPMTQE("glassFaceWCPMT",photonWavelength,1,240,660,ratio);
 	  }else if (DetConstruct->GetPMT_QE_Method()==2){
-	    wavelengthQE  = DetConstruct->GetPMTQE(photonWavelength,0,240,660,ratio);
+	    wavelengthQE  = DetConstruct->GetPMTQE("glassFaceWCPMT",photonWavelength,0,240,660,ratio);
 	  }else if (DetConstruct->GetPMT_QE_Method()==3){
 	    wavelengthQE = 1.1;
 	  }

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -344,7 +344,7 @@ void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
 
   G4float timingConstant = 0.0;
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer();
+  PMT = myDetector->GetPMTPointerID(0);
  
   G4double EvtG8Down = WCSimWCDigitizer::eventgatedown;
   G4double EvtG8Up = WCSimWCDigitizer::eventgateup;  // this is a negative number...

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -344,7 +344,7 @@ void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
 
   G4float timingConstant = 0.0;
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer("ID");
+  PMT = myDetector->GetPMTPointer("glassFaceWCPMT");
  
   G4double EvtG8Down = WCSimWCDigitizer::eventgatedown;
   G4double EvtG8Up = WCSimWCDigitizer::eventgateup;  // this is a negative number...

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -344,7 +344,7 @@ void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
 
   G4float timingConstant = 0.0;
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointerID(0);
+  PMT = myDetector->GetPMTPointer("ID");
  
   G4double EvtG8Down = WCSimWCDigitizer::eventgatedown;
   G4double EvtG8Up = WCSimWCDigitizer::eventgateup;  // this is a negative number...

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -42,7 +42,7 @@ WCSimWCPMT::~WCSimWCPMT(){
 
 G4double WCSimWCPMT::rn1pe(){
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer();
+  PMT = myDetector->GetPMTPointerID(0);
   G4int i;
   G4double random = G4UniformRand();
   G4double random2 = G4UniformRand(); 

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -42,7 +42,7 @@ WCSimWCPMT::~WCSimWCPMT(){
 
 G4double WCSimWCPMT::rn1pe(){
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer("ID");
+  PMT = myDetector->GetPMTPointer("glassFaceWCPMT");
   G4int i;
   G4double random = G4UniformRand();
   G4double random2 = G4UniformRand(); 

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -42,7 +42,7 @@ WCSimWCPMT::~WCSimWCPMT(){
 
 G4double WCSimWCPMT::rn1pe(){
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointerID(0);
+  PMT = myDetector->GetPMTPointer("ID");
   G4int i;
   G4double random = G4UniformRand();
   G4double random2 = G4UniformRand(); 

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -148,12 +148,12 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   if (fdet->GetPMT_QE_Method()==1){
     photonQE = 1.1;
   }else if (fdet->GetPMT_QE_Method()==2){
-    maxQE = fdet->GetPMTQE(wavelength,0,240,660,ratio);
-    photonQE = fdet->GetPMTQE(wavelength,1,240,660,ratio);
+    maxQE = fdet->GetPMTQE(collectionName[0],wavelength,0,240,660,ratio);
+    photonQE = fdet->GetPMTQE(collectionName[0],wavelength,1,240,660,ratio);
     photonQE = photonQE/maxQE;
   }else if (fdet->GetPMT_QE_Method()==3){
     ratio = 1./(1.-0.25);
-    photonQE = fdet->GetPMTQE(wavelength,1,240,660,ratio);
+    photonQE = fdet->GetPMTQE(collectionName[0],wavelength,1,240,660,ratio);
   }
   
   
@@ -164,7 +164,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
      G4double local_y = localPosition.y();
      G4double local_z = localPosition.z();
      theta_angle = acos(fabs(local_z)/sqrt(pow(local_x,2)+pow(local_y,2)+pow(local_z,2)))/3.1415926*180.;
-     effectiveAngularEfficiency = fdet->GetPMTCollectionEfficiency(theta_angle);
+     effectiveAngularEfficiency = fdet->GetPMTCollectionEfficiency(theta_angle, collectionName[0]);
      if (G4UniformRand() <= effectiveAngularEfficiency || fdet->UsePMT_Coll_Eff()==0){
 
       

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -13,7 +13,7 @@
 #include "WCSimDetectorConstruction.hh"
 #include "WCSimTrackInformation.hh"
 
-WCSimWCSD::WCSimWCSD(G4String name,WCSimDetectorConstruction* myDet)
+WCSimWCSD::WCSimWCSD(G4String CollectionName, G4String name,WCSimDetectorConstruction* myDet)
 :G4VSensitiveDetector(name)
 {
   // Place the name of this collection on the list.  We can have more than one
@@ -23,8 +23,7 @@ WCSimWCSD::WCSimWCSD(G4String name,WCSimDetectorConstruction* myDet)
   // Which has a "/" in it, I can find this collection later using 
   // GetCollectionID()
 
-  G4String HCname;
-  collectionName.insert(HCname="glassFaceWCPMT");
+  collectionName.insert(CollectionName);
   
   fdet = myDet;
   


### PR DESCRIPTION
## Motivation

This pull request contains code which allows for mulitple photodetectors to be built in the same detector, which is the first step in being able to implement a functional outer detector. It should be noted, however, that while you can build mutiple photodetectors in the same detector, there still exists only one electronics readout channel so only one photodetector type will be recorded and digitized. Furthermore, currently only a single sensitive detector volume can be specified. The ability to record hits from multiple photodetectors and to declare multiple sensitive detector volumes will be implemented in subsequent pull requests. This pull request is in response to issue #38.  

## Code changes in this pull request 

### Main code flow changes 

When a detector configuration is specified (in WCSimDetectorConfigs) the user instantiates a PMT using CreatePMT("PMTType", "CollectionName"). In the current version of the code the user would just specify the "PMTType", where PMTType is the type of photodetector (for example, 20inchPMT). After this pull request, the user must now also specify the "CollectionName" where CollectionName is the name of the hits collection (currently all ID tubes are set to glassFaceWCPMT). 

CreatePMT will instantiate a PMT of the specified type and will also store the PMT pointer in a map which is keyed with CollectionName. When information about the PMT is required (for example, in the digitizer when the timing resolution is needed) the PMT pointer can be retrieved using GetPMTPointer(CollectionName). Currently, all electronics are set up to find the glassFaceWCPMT CollectionName. The code will look up the CollectionName in the CollectionName array, will retrieve the index, and will call the corresponding PMTPointer from the PMTPointer array using that index. 

### Minor code changes

ConstructPMT now takes PMTName and CollectionName as inputs (before this pull request radius and expose was used). This allows the user to create an inner and outer detector with the same photodetector type, and also allows for the CollectionName to be passed in and used to create the proper hits collection name. 

Now that multiple PMT types can be properly stored in memory, the HyperK configuration in WCSimDetectorConfigs is changed to use the proper CreatePMT command for the OD tubes.

## Verification 

The verification_HitsChargeTime.C was run for both the default SK setup and for the HK setup. Both matched the clean checkout of the code. The HK detector was also run using vis.mac to ensure the new way of declaring the OD tubes looked ok by eye. 