### PR TITLE
Now set the glass thickness parameter in ConstructPMT

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -249,7 +249,6 @@ private:
 
   G4double WCPMTRadius;
   G4double WCPMTExposeHeight;
-  G4double WCPMTGlassThickness;
   G4double WCBarrelPMTOffset;
 
   G4double WCIDDiameter;

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -38,12 +38,12 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   
   G4double expose;
   G4double radius;
-  G4double glassthickness;
+  G4double glassThickness;
   
   WCSimPMTObject *PMT = GetPMTPointer(CollectionName);
   expose = PMT->GetExposeHeight();
   radius = PMT->GetRadius();
-  glassthickness = PMT->GetPMTGlassThickness();
+  glassThickness = PMT->GetPMTGlassThickness();
 
   G4double sphereRadius = (expose*expose+ radius*radius)/(2*expose);
   G4double PMTOffset =  sphereRadius - expose;
@@ -86,7 +86,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   //Create PMT Interior
   G4Sphere* tmpSolidInteriorWCPMT =
       new G4Sphere(    "tmpInteriorWCPMT",
-                       0.0*m,(sphereRadius-glassthickness),
+                       0.0*m,(sphereRadius-glassThickness),
                        0.0*deg,360.0*deg,
                        0.0*deg,90.0*deg);
 
@@ -118,7 +118,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   //Create PMT Glass Face
   G4Sphere* tmpGlassFaceWCPMT =
       new G4Sphere(    "tmpGlassFaceWCPMT",
-                       (sphereRadius-glassthickness),
+                       (sphereRadius-glassThickness),
                        sphereRadius,
                        0.0*deg,360.0*deg,
                        0.0*deg,90.0*deg);

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -38,11 +38,13 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   
   G4double expose;
   G4double radius;
+  G4double glassthickness;
   
   WCSimPMTObject *PMT = GetPMTPointer(CollectionName);
   expose = PMT->GetExposeHeight();
   radius = PMT->GetRadius();
-  
+  glassthickness = PMT->GetPMTGlassThickness();
+
   G4double sphereRadius = (expose*expose+ radius*radius)/(2*expose);
   G4double PMTOffset =  sphereRadius - expose;
 
@@ -84,7 +86,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   //Create PMT Interior
   G4Sphere* tmpSolidInteriorWCPMT =
       new G4Sphere(    "tmpInteriorWCPMT",
-                       0.0*m,(sphereRadius-WCPMTGlassThickness),
+                       0.0*m,(sphereRadius-glassthickness),
                        0.0*deg,360.0*deg,
                        0.0*deg,90.0*deg);
 
@@ -116,7 +118,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   //Create PMT Glass Face
   G4Sphere* tmpGlassFaceWCPMT =
       new G4Sphere(    "tmpGlassFaceWCPMT",
-                       (sphereRadius-WCPMTGlassThickness),
+                       (sphereRadius-glassthickness),
                        sphereRadius,
                        0.0*deg,360.0*deg,
                        0.0*deg,90.0*deg);

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -24,7 +24,6 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
   WCIDHeight            = 36.200*m; //"" "" height
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
@@ -46,7 +45,6 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
   WCIDHeight            = 36.200*m; //"" "" height
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
@@ -70,7 +68,6 @@ void WCSimDetectorConstruction::SuperK_20inchBandL_20perCent()
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
   WCIDHeight            = 36.200*m; //"" "" height
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
@@ -94,7 +91,6 @@ void WCSimDetectorConstruction::SuperK_12inchBandL_15perCent()
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
   WCIDHeight            = 36.200*m; //"" "" height
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
@@ -118,7 +114,6 @@ void WCSimDetectorConstruction::SuperK_20inchBandL_14perCent()
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 33.6815*m; //16.900*2*cos(2*pi*rad/75)*m; //inner detector diameter
   WCIDHeight            = 36.200*m; //"" "" height
   WCBarrelPMTOffset     = 0.0715*m; //offset from vertical
@@ -143,7 +138,6 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 69.0*m;
   WCIDHeight            = 100.0*m;
   WCBarrelPMTOffset     = WCPMTRadius; //offset from vertical
@@ -166,7 +160,6 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
   WCPMTName = PMT->GetPMTName();
   innerPMT_Expose = PMT->GetExposeHeight();
   innerPMT_Radius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   waterTank_TopR   = 32000.*mm;
   waterTank_BotR   = 30000.*mm;
   waterTank_Height = 48000.*mm;
@@ -211,7 +204,6 @@ void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
    WCPMTName = PMT->GetPMTName();
    innerPMT_Expose = PMT->GetExposeHeight();
    innerPMT_Radius = PMT->GetRadius();
-   WCPMTGlassThickness = PMT->GetPMTGlassThickness();
    waterTank_TopR   = 32000.*mm;
    waterTank_BotR   = 30000.*mm;
    waterTank_Height = 48000.*mm;
@@ -280,7 +272,6 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 53.0*m;
   WCIDHeight            = 60.0*m;
   WCBarrelPMTOffset	    = WCPMTRadius;
@@ -304,7 +295,6 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 53.0*m;
   WCIDHeight            = 60.0*m;
   WCBarrelPMTOffset	    = WCPMTRadius;
@@ -328,7 +318,6 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 53.0*m;
   WCIDHeight            = 60.0*m;
   WCBarrelPMTOffset	    = WCPMTRadius;
@@ -352,7 +341,6 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 53.0*m;
   WCIDHeight            = 60.0*m;
   WCBarrelPMTOffset	    = WCPMTRadius;
@@ -376,7 +364,6 @@ void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 64.0*m;
   WCIDHeight            = 60.0*m;
   WCBarrelPMTOffset	    = WCPMTRadius;
@@ -400,7 +387,6 @@ void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 62.21*m;
   WCIDHeight            = 79.96*m;
   WCBarrelPMTOffset	    = WCPMTRadius;
@@ -424,8 +410,7 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
-	WCIDDiameter          = 63.30*m;
+  	WCIDDiameter          = 63.30*m;
 	WCIDHeight            = 76.60*m;
 	WCBarrelPMTOffset	    = .1537*m;
 	WCPMTperCellHorizontal = 1.0;
@@ -444,7 +429,6 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_14perCent()
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
-  WCPMTGlassThickness = PMT->GetPMTGlassThickness();
   WCIDDiameter          = 63.30*m;
   WCIDHeight            = 76.60*m;
   WCBarrelPMTOffset	    = .1951*m;


### PR DESCRIPTION
## Summary  

The WCPMTGlassThickness parameter was being hard set in WCSimDetectorConfigs, and wasn't being called in ConstructPMT. This meant that only a single glass thickness could be specified for a given detector configuration and therefore the glass thickness used in ConstructPMT didn't necessarily correspond to the PMT being built. This pull request adds in the call for glass thickness in ConstructPMT and takes out the line which hard sets the glass thickness in DetectorConfigs. 

## Verification  

Though this change is fairly minor, a number of verification steps were done to ensure the removal of the WCPMTGlassThickness from DetectorConfigs did not affect the code output.  

The only detector configurations that build multiple PMT types are the two Hyper-K geometries (SetHyperKGeometry and SetHyperKGeometry_withHPD). In the current version of WCSim, the glass thickness for the OD tubes would have been the same as the ID tubes, whereas after the changes proposed in this pull request the glass thickness of the OD tubes will match the glass thickness specified for the given PMT type. I ran a high statistics run for both these geometries and found that the new glass thickness in the OD tubes did change the number of hits on an event-by-event basis, but that these changes are statistically consistant. 

###  SetHyperKGeometry  
![glassthickness_hkwpmt](https://cloud.githubusercontent.com/assets/1578443/7185547/6120d20a-e431-11e4-83a9-8cf3c7cfc667.png)  

###  SetHyperKGeometry_withHPD  
![glassthickness_hkwhpd](https://cloud.githubusercontent.com/assets/1578443/7185552/6bf05b1a-e431-11e4-8d80-432c3416b1b3.png)

All other detector configurations were tested by running a single event and comparing the output with the current version of WCSim. As expected, the outputs from the two versions of WCSim matched in all cases. 
