### PR TITLE
Modify sample macro code to use the collection efficiency parameter.

### DIFF
--- a/novis.mac
+++ b/novis.mac
@@ -63,6 +63,9 @@
 #/WCSim/PMTQEMethod     Stacking_And_SensitiveDetector
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
+turn on or off the collection efficiency (05/27/11 XQ)
+#/WCSim/PMTCollEff on
+
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
 /WCSim/SavePi0 false
 

--- a/novis.mac
+++ b/novis.mac
@@ -63,7 +63,7 @@
 #/WCSim/PMTQEMethod     Stacking_And_SensitiveDetector
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
-turn on or off the collection efficiency (05/27/11 XQ)
+turn on or off the collection efficiency
 #/WCSim/PMTCollEff on
 
 # command to choose save or not save the pi0 info 07/03/10 (XQ)

--- a/vis.mac
+++ b/vis.mac
@@ -60,7 +60,7 @@
 #/WCSim/PMTQEMethod     Stacking_And_SensitiveDetector
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
-# turn on or off the collection efficiency (05/27/11 XQ)
+# turn on or off the collection efficiency
 #/WCSim/PMTCollEff on
 
 #/WCSim/Construct


### PR DESCRIPTION
In the current sample macro files, the collection efficiency process is disabled.
In order to enable collection efficiency process, I fixed novis.mac and vis.mac.
Because R3600 has 100% collection efficiency, the simulation result is not changed.
The figure below shows the comparison between the result of simulation with novis.mac
before and after modification. (Red: before modification, Blue: after modification)
![novis_compare](https://cloud.githubusercontent.com/assets/8589041/7316224/2524e874-eab0-11e4-90d9-59556fccca71.png)
