### PR TITLE
Feature/macro cleanup

### DIFF
--- a/novis.mac
+++ b/novis.mac
@@ -21,16 +21,11 @@
 # diameter of 69m with 12" HPD and 14.59% photocoverage
 #/WCSim/WCgeom Cylinder_12inchHPD_15perCent # Note: the actual coverage is 14.59%
 
-# Currently by defualt the DUSEL configurations are 10 inch.
-# you can overide this with the WCPMTsize command.
-# WCPMTsize command commented out on 10/1/09 (CWW)
-#
+
+#/WCSim/WCgeom HyperK #default length is 49500 mm unless changed in /WCSim/HK/waterTankLength below.
+#/WCSim/WCgeom HyperK_withHPD #default length is 49500 mm unless changed in /WCSim/HK/waterTankLength below.
 
 #Changes the length of the simulated volume. Is currently only set up for HyperK. 
-
-#/WCSim/WCgeom HyperK #default length is 49500 mm unless changed in /WCSim/HK/PartionLength below.
-#/WCSim/WCgeom HyperK_withHPD #default length is 49500 mm unless changed in /WCSim/HK/PartionLength below.
-
 #/WCSim/HyperK/waterTank_Length 24750. mm # Equivalent length for 10 partitions
 #/WCSim/HyperK/waterTank_Length 49500. mm # Equivalent length for 5 partitions
 #/WCSim/HyperK/waterTank_Length 61875. mm # Equivalent length for 4 partitions
@@ -47,7 +42,8 @@
 #/WCSim/WCgeom DUSEL_200kton_10inch_HQE_12perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_10perCent
 #/WCSim/WCgeom DUSEL_200kton_12inch_HQE_14perCent
-#/WCSim/Construct
+
+#/WCSim/Construct # This must be uncommented in order to construct a new detector configuration. 
 
 #Added for the PMT QE option 08/17/10 (XQ)
 # 1. Stacking only mean when the photon is generated

--- a/vis.mac
+++ b/vis.mac
@@ -22,14 +22,9 @@
 # diameter of 69m with 12" HPD and 14.59% photocoverage
 #/WCSim/WCgeom Cylinder_12inchHPD_15perCent # Note: the actual coverage is 14.59%
 
-# Currently by default the DUSEL configurations are 10 inch.
-# you can overide this with the WCPMTsize command.
-# WCPMTsize command commented out on 10/1/09 (CWW)
-#
-#
-#Added for detector length option (ONLY FOR HYPER-K GEOMETRY!!) 2014/07/29. This simulates a segment of the Hyper-K detector of a given length. 
-
 #/WCSim/WCgeom HyperK #default length is 49500 mm unless changed below.
+
+#Added for detector length option (ONLY FOR HYPER-K GEOMETRY!!) 2014/07/29. This simulates a segment of the Hyper-K detector of a given length. 
 
 #/WCSim/HyperK/waterTank_Length 49500. mm # Equivalent length for 5 partitions(ie. will simulate a detector 1/10 of the HK length)
 #/WCSim/HyperK/waterTank_Length 61875. mm # Equivalent length for 4 partitions
@@ -63,7 +58,7 @@
 # turn on or off the collection efficiency
 #/WCSim/PMTCollEff on
 
-#/WCSim/Construct
+#/WCSim/Construct # This must be uncommented to construct a new detector configuration.
 
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
 #/WCSim/SavePi0 true
@@ -86,7 +81,7 @@
 /vis/scene/create
 /vis/open OGLSX
 # You can also set the size and position of the window if you like
-#/vis/open OGLSX 1000x1000-0+0
+#/vis/open OGLSX 1000x1000-0+
 /vis/ogl/set/printSize 1000 1000
 
 # Vis Settings for SK

--- a/vis.mac
+++ b/vis.mac
@@ -81,7 +81,7 @@
 /vis/scene/create
 /vis/open OGLSX
 # You can also set the size and position of the window if you like
-#/vis/open OGLSX 1000x1000-0+
+#/vis/open OGLSX 1000x1000-0+0
 /vis/ogl/set/printSize 1000 1000
 
 # Vis Settings for SK


### PR DESCRIPTION
Just a general cleanup of the vis.mac and novis.mac files. The only changes in this pull request are the addition/deletion/rearrangement of some comments which describe the functions in the macros. The main motivation for this pull request is the addition of a comment on the /WCSim/Construct line that reminds users to uncomment this out if they construct a new detector configuration, as this seems to be a common mistake. I also removed the section relating to the WCPMTsize command as this has been removed for some years now. Finally, I fixed the comments related to the /WCSim/HK/waterTankLength line and moved the comment describing the usage of this function to directly above the command lines. 