### PR TITLE
Fix the timing resolution of Box and Line PMT

### DIFF
--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -1191,7 +1191,7 @@ G4double BoxandLine20inchHQE::GetRadius() {return .254*m;}
 G4double BoxandLine20inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
 
 float BoxandLine20inchHQE::HitTimeSmearing(float Q) {
-  G4float sig_param[4]={0.6315,0.06277,0.5728,23.9};
+  G4float sig_param[4]={0.6314,0.06260,0.5711,23.96};
   G4float lambda_param[2]={0.4094,0.06852};
   G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
 
@@ -1360,7 +1360,7 @@ G4double BoxandLine12inchHQE::GetRadius() {return 152.4*mm;}
 G4double BoxandLine12inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
 
 float BoxandLine12inchHQE::HitTimeSmearing(float Q) {
-  G4float sig_param[4]={0.6315,0.06277,0.5728,23.9};
+  G4float sig_param[4]={0.6314,0.06260,0.5711,23.96};
   G4float lambda_param[2]={0.4094,0.06852};
 
   G4float highcharge_param[2];

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -1191,10 +1191,16 @@ G4double BoxandLine20inchHQE::GetRadius() {return .254*m;}
 G4double BoxandLine20inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
 
 float BoxandLine20inchHQE::HitTimeSmearing(float Q) {
-  G4float sig_param[4]={0.8928,0.03278,0.07054,16.4};
+  G4float sig_param[4]={0.6315,0.06277,0.5728,23.9};
   G4float lambda_param[2]={0.4094,0.06852};
+  G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
 
-  G4float sigma = (sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2])*(Q<sig_param[3])+(2*sig_param[0]*sig_param[1]*sig_param[3]*sqrt(sig_param[3])*exp(-sig_param[1]*sig_param[3])/sqrt(Q)+(exp(-sig_param[1]*sig_param[3])+sig_param[2])-2*sig_param[0]*sig_param[1]*sig_param[3]*exp(-sig_param[1]*sig_param[3]))*(Q>sig_param[3]));
+  G4float highcharge_param[2];
+  highcharge_param[0]=2*sig_param[0]*sig_param[1]*sig_param[3]*sqrt(sig_param[3])*exp(-sig_param[1]*sig_param[3]);
+  highcharge_param[1]=sig_param[0]*((1-2*sig_param[1]*sig_param[3])*exp(-sig_param[1]*sig_param[3])+sig_param[2]);
+  G4float sigma_highcharge = highcharge_param[0]/sqrt(Q)+highcharge_param[1];
+
+  G4float sigma = sigma_lowcharge*(Q<sig_param[3])+sigma_highcharge*(Q>sig_param[3]);
   G4float lambda = lambda_param[0]+lambda_param[1]*Q;
   G4float Smearing_factor = G4RandGauss::shoot(-0.2,sigma)-1/lambda*log(1-G4UniformRand());
   return Smearing_factor;
@@ -1354,10 +1360,17 @@ G4double BoxandLine12inchHQE::GetRadius() {return 152.4*mm;}
 G4double BoxandLine12inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
 
 float BoxandLine12inchHQE::HitTimeSmearing(float Q) {
-  G4float sig_param[4]={0.8928,0.03278,0.07054,16.4};
+  G4float sig_param[4]={0.6315,0.06277,0.5728,23.9};
   G4float lambda_param[2]={0.4094,0.06852};
 
-  G4float sigma = (sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2])*(Q<sig_param[3])+(2*sig_param[0]*sig_param[1]*sig_param[3]*sqrt(sig_param[3])*exp(-sig_param[1]*sig_param[3])/sqrt(Q)+(exp(-sig_param[1]*sig_param[3])+sig_param[2])-2*sig_param[0]*sig_param[1]*sig_param[3]*exp(-sig_param[1]*sig_param[3]))*(Q>sig_param[3]));
+  G4float highcharge_param[2];
+  highcharge_param[0]=2*sig_param[0]*sig_param[1]*sig_param[3]*sqrt(sig_param[3])*exp(-sig_param[1]*sig_param[3]);
+  highcharge_param[1]=sig_param[0]*((1-2*sig_param[1]*sig_param[3])*exp(-sig_param[1]*sig_param[3])+sig_param[2]);
+
+  G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
+  G4float sigma_highcharge = highcharge_param[0]/sqrt(Q)+highcharge_param[1];
+
+  G4float sigma = sigma_lowcharge*(Q<sig_param[3])+sigma_highcharge*(Q>sig_param[3]);
   G4float lambda = lambda_param[0]+lambda_param[1]*Q;
   G4float Smearing_factor = G4RandGauss::shoot(-0.2,sigma)-1/lambda*log(1-G4UniformRand());
   return Smearing_factor;


### PR DESCRIPTION
This is modification for #73 issue

I analyzed the timing resolution of Box and Line PMT and fitted with correct function.
And introduced the fitted curve in WCSim.

I checked the 1 p.e. timing resolution by comparing PDs hit time and true hit time with that of nominal PD, and the MC output seems to be correspond to timing resolution calculated with input parameters.
(nominal PD is changed event by event)
(timing resolution, calculated value: 2.30 ns, MC value: 2.30 +/- 0.01 ns)
So, new code seems to work correctly.

![boxandline_checktts_modified](https://cloud.githubusercontent.com/assets/8589041/7695977/a261fdb4-fe32-11e4-9b9f-a9a57ff60845.png)
(timing resolution is sqrt(((p2)^2+2*(p3)^(-2))/2) )