### PR TITLE
Feature/issue67

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -138,6 +138,9 @@ public:
 
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
+  G4String GetIDCollectionName(){return WCIDCollectionName;}
+
+ 
 private:
 
   // Tuning parameters
@@ -237,9 +240,16 @@ private:
   G4double WCLength;
 
   G4double WCPosition;
+  
+  // Hit collection name parameters
+  G4String WCDetectorName;
+  G4String WCIDCollectionName;
+  G4String WCODCollectionName;
+
 
   // WC PMT parameters
   G4String WCPMTName;
+  G4String WCPMTName_outer;
   typedef std::pair<G4String, G4String> PMTKey_t;
   typedef std::map<PMTKey_t, G4LogicalVolume*> PMTMap_t;
 
@@ -247,7 +257,7 @@ private:
 
   // WC geometry parameters
 
-  G4double WCPMTRadius;
+   G4double WCPMTRadius;
   G4double WCPMTExposeHeight;
   G4double WCBarrelPMTOffset;
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -249,7 +249,6 @@ private:
 
   // WC PMT parameters
   G4String WCPMTName;
-  G4String WCPMTName_outer;
   typedef std::pair<G4String, G4String> PMTKey_t;
   typedef std::map<PMTKey_t, G4LogicalVolume*> PMTMap_t;
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -257,7 +257,7 @@ private:
 
   // WC geometry parameters
 
-   G4double WCPMTRadius;
+  G4double WCPMTRadius;
   G4double WCPMTExposeHeight;
   G4double WCBarrelPMTOffset;
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -147,11 +147,6 @@ private:
 
   WCSimTuningParameters* WCSimTuningParams;
 
-  // Sensitive Detectors. We declare the pointers here because we need
-  // to check their state if we change the geometry.
-
-  WCSimWCSD*  aWCPMT;
-
   //Water, Blacksheet surface
   G4OpticalSurface * OpWaterBSSurface;
 

--- a/include/WCSimWCSD.hh
+++ b/include/WCSimWCSD.hh
@@ -25,6 +25,7 @@ class WCSimWCSD : public G4VSensitiveDetector
   WCSimDetectorConstruction* fdet;
   WCSimWCHitsCollection* hitsCollection;
   std::map<int,int> PMTHitMap;   // Whether a PMT was hit already
+  int StartofFile;
 
 };
 

--- a/include/WCSimWCSD.hh
+++ b/include/WCSimWCSD.hh
@@ -25,7 +25,6 @@ class WCSimWCSD : public G4VSensitiveDetector
   WCSimDetectorConstruction* fdet;
   WCSimWCHitsCollection* hitsCollection;
   std::map<int,int> PMTHitMap;   // Whether a PMT was hit already
-  int StartofFile;
 
 };
 

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -153,13 +153,6 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   G4double mainAnnulusRmin[2] = {innerAnnulusRadius, innerAnnulusRadius};
   G4double mainAnnulusRmax[2] = {outerAnnulusRadius, outerAnnulusRadius};
 
-  mainAnnulusRmax[0]+=4000;
-  mainAnnulusRmax[1]+=4000;
-  printf("fundamental parameters: %lf %lf %lf %lf %lf %lf\n",
-		 mainAnnulusRmin[0],mainAnnulusRmin[1],
-		 mainAnnulusRmax[0],mainAnnulusRmax[1],
-		 mainAnnulusZ[0],mainAnnulusZ[1]);
-
   G4Polyhedra* solidWCBarrelAnnulus = new G4Polyhedra("WCBarrelAnnulus",
                                                    0.*deg, // phi start
                                                    totalAngle, 
@@ -226,8 +219,8 @@ else {
   // Subdivisions of the BarrelRings are cells
   //------------------------------------------------------
 
- printf("***make barrel cells: from %lf to %lf\n",mainAnnulusRmin,mainAnnulusRmax);
- G4Polyhedra* solidWCBarrelCell = new G4Polyhedra("WCBarrelCell",
+
+  G4Polyhedra* solidWCBarrelCell = new G4Polyhedra("WCBarrelCell",
                                                    -dPhi/2.+0.*deg, // phi start
                                                    dPhi, //total Phi
                                                    1, //NPhi-gon
@@ -573,7 +566,7 @@ else {
   // The PMT glass is the sensitive volume in this new configuration.
 
   G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, WCIDCollectionName);
-  // G4LogicalVolume* logicWCPMT_OD = ConstructPMT(WCPMTName_outer, "glassFaceWCPMT_OD");
+
   
 
   //jl145------------------------------------------------
@@ -626,9 +619,8 @@ else {
 
     ///////////////   Barrel PMT placement
   G4RotationMatrix* WCPMTRotation = new G4RotationMatrix;
-  G4RotationMatrix* WCPMTARotation = new G4RotationMatrix;
   WCPMTRotation->rotateY(90.*deg);
-  WCPMTARotation->rotateY(-90.*deg);
+
   G4double barrelCellWidth = 2.*WCIDRadius*tan(dPhi/2.);
   G4double horizontalSpacing   = barrelCellWidth/WCPMTperCellHorizontal;
   G4double verticalSpacing     = barrelCellHeight/WCPMTperCellVertical;
@@ -639,7 +631,7 @@ else {
 						 -barrelCellWidth/2.+(i+0.5)*horizontalSpacing,
 						 -barrelCellHeight/2.+(j+0.5)*verticalSpacing);
 
-	  G4ThreeVector PMTAPosition =  G4ThreeVector(WCIDRadius+2000, -barrelCellWidth/2.+(i+0.5)*horizontalSpacing,-barrelCellHeight/2.+(j+0.5)*verticalSpacing);
+
       G4VPhysicalVolume* physiWCBarrelPMT =
 	new G4PVPlacement(WCPMTRotation,              // its rotation
 			  PMTPosition, 
@@ -649,14 +641,10 @@ else {
 			  false,                     // no boolean operations
 			  (int)(i*WCPMTperCellVertical+j),
 			  true);                       
-	  double x=PMTAPosition.getX();
-	  double y=PMTAPosition.getY();
-	  double z=PMTAPosition.getZ();
-	  double phi=WCPMTARotation->getPhi();
-	  double theta=WCPMTARotation->getTheta();
-	  double psi=WCPMTARotation->getPsi();
-	  printf("***************\n************\n************\nhere I am: make WCPMT with at position %lf %lf %lf and rotation %lf %lf %lf\n",phi,theta,psi,x,y,z);
-   
+      
+   // logicWCPMT->GetDaughter(0),physiCapPMT is the glass face. If you add more 
+     // daugter volumes to the PMTs (e.g. a acryl cover) you have to check, if
+		// this is still the case.
     }
   }
   //-------------------------------------------------------------
@@ -1066,8 +1054,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   // -----------------------------------------------------
   
 	G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, WCIDCollectionName);
-
-
+	
   G4double xoffset;
   G4double yoffset;
   G4int    icopy = 0;

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -153,6 +153,13 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   G4double mainAnnulusRmin[2] = {innerAnnulusRadius, innerAnnulusRadius};
   G4double mainAnnulusRmax[2] = {outerAnnulusRadius, outerAnnulusRadius};
 
+  mainAnnulusRmax[0]+=4000;
+  mainAnnulusRmax[1]+=4000;
+  printf("fundamental parameters: %lf %lf %lf %lf %lf %lf\n",
+		 mainAnnulusRmin[0],mainAnnulusRmin[1],
+		 mainAnnulusRmax[0],mainAnnulusRmax[1],
+		 mainAnnulusZ[0],mainAnnulusZ[1]);
+
   G4Polyhedra* solidWCBarrelAnnulus = new G4Polyhedra("WCBarrelAnnulus",
                                                    0.*deg, // phi start
                                                    totalAngle, 
@@ -219,8 +226,8 @@ else {
   // Subdivisions of the BarrelRings are cells
   //------------------------------------------------------
 
-
-  G4Polyhedra* solidWCBarrelCell = new G4Polyhedra("WCBarrelCell",
+ printf("***make barrel cells: from %lf to %lf\n",mainAnnulusRmin,mainAnnulusRmax);
+ G4Polyhedra* solidWCBarrelCell = new G4Polyhedra("WCBarrelCell",
                                                    -dPhi/2.+0.*deg, // phi start
                                                    dPhi, //total Phi
                                                    1, //NPhi-gon
@@ -565,8 +572,8 @@ else {
   // K.Zbiri: The PMT volume and the PMT glass are now put in parallel. 
   // The PMT glass is the sensitive volume in this new configuration.
 
-  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "glassFaceWCPMT");
-
+  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, WCIDCollectionName);
+  // G4LogicalVolume* logicWCPMT_OD = ConstructPMT(WCPMTName_outer, "glassFaceWCPMT_OD");
   
 
   //jl145------------------------------------------------
@@ -619,8 +626,9 @@ else {
 
     ///////////////   Barrel PMT placement
   G4RotationMatrix* WCPMTRotation = new G4RotationMatrix;
+  G4RotationMatrix* WCPMTARotation = new G4RotationMatrix;
   WCPMTRotation->rotateY(90.*deg);
-
+  WCPMTARotation->rotateY(-90.*deg);
   G4double barrelCellWidth = 2.*WCIDRadius*tan(dPhi/2.);
   G4double horizontalSpacing   = barrelCellWidth/WCPMTperCellHorizontal;
   G4double verticalSpacing     = barrelCellHeight/WCPMTperCellVertical;
@@ -631,7 +639,7 @@ else {
 						 -barrelCellWidth/2.+(i+0.5)*horizontalSpacing,
 						 -barrelCellHeight/2.+(j+0.5)*verticalSpacing);
 
-
+	  G4ThreeVector PMTAPosition =  G4ThreeVector(WCIDRadius+2000, -barrelCellWidth/2.+(i+0.5)*horizontalSpacing,-barrelCellHeight/2.+(j+0.5)*verticalSpacing);
       G4VPhysicalVolume* physiWCBarrelPMT =
 	new G4PVPlacement(WCPMTRotation,              // its rotation
 			  PMTPosition, 
@@ -641,10 +649,14 @@ else {
 			  false,                     // no boolean operations
 			  (int)(i*WCPMTperCellVertical+j),
 			  true);                       
-      
-   // logicWCPMT->GetDaughter(0),physiCapPMT is the glass face. If you add more 
-     // daugter volumes to the PMTs (e.g. a acryl cover) you have to check, if
-		// this is still the case.
+	  double x=PMTAPosition.getX();
+	  double y=PMTAPosition.getY();
+	  double z=PMTAPosition.getZ();
+	  double phi=WCPMTARotation->getPhi();
+	  double theta=WCPMTARotation->getTheta();
+	  double psi=WCPMTARotation->getPsi();
+	  printf("***************\n************\n************\nhere I am: make WCPMT with at position %lf %lf %lf and rotation %lf %lf %lf\n",phi,theta,psi,x,y,z);
+   
     }
   }
   //-------------------------------------------------------------
@@ -1053,8 +1065,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   // Add top and bottom PMTs
   // -----------------------------------------------------
   
-	G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, "glassFaceWCPMT");
-	
+	G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, WCIDCollectionName);
+
+
   G4double xoffset;
   G4double yoffset;
   G4int    icopy = 0;

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -125,7 +125,7 @@ void WCSimDetectorConstruction::DescribeAndRegisterPMT(G4VPhysicalVolume* aPV ,i
         G4cerr << "Cannot continue -- hits will not be recorded correctly."  << G4endl;
         G4cerr << "Please make sure that logical volumes with multiple placements are each given a unique copy number" << G4endl;
         assert(false);
-	 }
+    }
     tubeLocationMap[tubeTag] = totalNumPMTs;
     
     // Put the transform for this tube into the map keyed by its ID

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -104,7 +104,8 @@ void WCSimDetectorConstruction::DescribeAndRegisterPMT(G4VPhysicalVolume* aPV ,i
 
   replicaNoString[aDepth] = pvname.str() + "-" + depth.str();
 
-  if ((aPV->GetName() == "glassFaceWCPMT")) {
+  if (aPV->GetName()== WCIDCollectionName ||aPV->GetName()== WCODCollectionName ) 
+    {
 
     // First increment the number of PMTs in the tank.
     totalNumPMTs++;  
@@ -124,7 +125,7 @@ void WCSimDetectorConstruction::DescribeAndRegisterPMT(G4VPhysicalVolume* aPV ,i
         G4cerr << "Cannot continue -- hits will not be recorded correctly."  << G4endl;
         G4cerr << "Please make sure that logical volumes with multiple placements are each given a unique copy number" << G4endl;
         assert(false);
-    }
+	 }
     tubeLocationMap[tubeTag] = totalNumPMTs;
     
     // Put the transform for this tube into the map keyed by its ID

--- a/src/WCSimConstructHyperK.cc
+++ b/src/WCSimConstructHyperK.cc
@@ -119,6 +119,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   G4RotationMatrix* g4rot;
   G4LogicalVolume* pmtCellLV;
 
+  //Construct the PMTs
+
+  G4LogicalVolume* logicWCPMT = ConstructPMT(WCPMTName, WCIDCollectionName);
+  G4LogicalVolume* logicWCPMT_OD = ConstructPMT(outerPMT_Name, WCODCollectionName);
+
   // Radial PMTs
 
   pmtCellLV = ConstructRadialPMT(true,  innerPMT_TopR, innerPMT_Height,
@@ -134,7 +139,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
 
   new G4PVPlacement(g4rot,
                     G4ThreeVector(r,0.,0.),
-                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
+                    logicWCPMT,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -149,7 +154,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
 
   new G4PVPlacement(g4rot,
                     G4ThreeVector(r,0.,0.),
-                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
+                    logicWCPMT,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -178,7 +183,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
            z = -outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
+                     logicWCPMT_OD,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -192,7 +197,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
+                     logicWCPMT_OD,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -218,7 +223,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = -outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
+                     logicWCPMT_OD,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -232,7 +237,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   z = outerPMT_Apitch/4.;
 
   new G4PVPlacement(g4rot, G4ThreeVector(x,y,z),
-                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
+                     logicWCPMT_OD,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -245,7 +250,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateY(180.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,-innerPMT_Expose/2.),
-                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
+                    logicWCPMT,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -259,7 +264,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateX(-90.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
+                    logicWCPMT,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -268,7 +273,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
                                          innerPMT_Apitch, innerPMT_Expose);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(WCPMTName, "glassFaceWCPMT"),
+                    logicWCPMT,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -280,7 +285,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
   g4rot->rotateX(90.*deg);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
+                     logicWCPMT_OD,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);
@@ -289,7 +294,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructHyperK()
                                   outerPMT_Apitch, outerPMT_Expose);
 
   new G4PVPlacement(g4rot, G4ThreeVector(0.,0.,0.),
-                    ConstructPMT(outerPMT_Name,"glassFaceWCPMT_OD"),
+                     logicWCPMT_OD,
                     "PMT",
                     pmtCellLV,
                     false,PMTCopyNo++,checkOverlaps);

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -124,21 +124,21 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
                        0.0*deg,90.0*deg);
   
   G4SubtractionSolid* solidGlassFaceWCPMT =
-      new G4SubtractionSolid(    "glassFaceWCPMT",
+      new G4SubtractionSolid(    CollectionName,
                                  tmpGlassFaceWCPMT,
                                  solidCutOffTubs); 
 
   G4LogicalVolume *logicGlassFaceWCPMT =
     new G4LogicalVolume(    solidGlassFaceWCPMT,
                             G4Material::GetMaterial("Glass"),
-                            "glassFaceWCPMT",
+                            CollectionName,
                             0,0,0);
 
   G4VPhysicalVolume* physiGlassFaceWCPMT =
       new G4PVPlacement(0,
                         G4ThreeVector(0, 0, -1.0*PMTOffset),
                         logicGlassFaceWCPMT,
-                        "glassFaceWCPMT",
+                        CollectionName,
                         logicWCPMT,
                         false,
                         0,
@@ -146,15 +146,15 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
 
   //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
   logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
-
-  if (!aWCPMT)
-  {
+  
+  //  if (!aWCPMT)
+  //  {
     G4SDManager* SDman = G4SDManager::GetSDMpointer();
     G4String SDName = "/WCSim/";
     SDName += CollectionName;
     aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
     SDman->AddNewDetector( aWCPMT );
-  }
+    // }
   logicGlassFaceWCPMT->SetSensitiveDetector( aWCPMT );
 
   PMTLogicalVolumes[key] = logicWCPMT;

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -147,6 +147,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
   logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
   
+  // Instantiate a new sensitive detector and register this sensitive detector volume with the SD Manager. 
     G4SDManager* SDman = G4SDManager::GetSDMpointer();
     G4String SDName = "/WCSim/";
     SDName += CollectionName;

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -147,14 +147,12 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
   logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
   
-  //  if (!aWCPMT)
-  //  {
     G4SDManager* SDman = G4SDManager::GetSDMpointer();
     G4String SDName = "/WCSim/";
     SDName += CollectionName;
     aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
     SDman->AddNewDetector( aWCPMT );
-    // }
+
   logicGlassFaceWCPMT->SetSensitiveDetector( aWCPMT );
 
   PMTLogicalVolumes[key] = logicWCPMT;

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -146,14 +146,14 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
 
   //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
   logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
-  
+ 
   // Instantiate a new sensitive detector and register this sensitive detector volume with the SD Manager. 
-    G4SDManager* SDman = G4SDManager::GetSDMpointer();
-    G4String SDName = "/WCSim/";
-    SDName += CollectionName;
-    aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
-    SDman->AddNewDetector( aWCPMT );
-
+  G4SDManager* SDman = G4SDManager::GetSDMpointer();
+  G4String SDName = "/WCSim/";
+  SDName += CollectionName;
+  aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
+  SDman->AddNewDetector( aWCPMT );
+  
   logicGlassFaceWCPMT->SetSensitiveDetector( aWCPMT );
 
   PMTLogicalVolumes[key] = logicWCPMT;

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -151,7 +151,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
   G4SDManager* SDman = G4SDManager::GetSDMpointer();
   G4String SDName = "/WCSim/";
   SDName += CollectionName;
-  aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
+  WCSimWCSD* aWCPMT = new WCSimWCSD(CollectionName,SDName,this );
   SDman->AddNewDetector( aWCPMT );
   
   logicGlassFaceWCPMT->SetSensitiveDetector( aWCPMT );

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -20,7 +20,10 @@
 
 void WCSimDetectorConstruction::SetSuperKGeometry()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "glassFaceWCPMT");
+  WCDetectorName = "SuperK";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", WCIDCollectionName);
+ 
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -41,7 +44,9 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "glassFaceWCPMT");
+  WCDetectorName = "SuperK_20inchPMT_20perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", WCIDCollectionName);
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -64,7 +69,9 @@ void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchBandL_20perCent()
 {
-	WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "SuperK_20inchBandL_20perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", WCIDCollectionName);
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -87,7 +94,9 @@ void WCSimDetectorConstruction::SuperK_20inchBandL_20perCent()
 // Note: the actual coverage is 14.59%
 void WCSimDetectorConstruction::SuperK_12inchBandL_15perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("BoxandLine12inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "SuperK_12inchBandL_15perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("BoxandLine12inchHQE", WCIDCollectionName);
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -110,7 +119,9 @@ void WCSimDetectorConstruction::SuperK_12inchBandL_15perCent()
 // Note: the actual coverage is 13.51%
 void WCSimDetectorConstruction::SuperK_20inchBandL_14perCent()
 {
-	WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "SuperK_20inchBandL_14perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("BoxandLine20inchHQE", WCIDCollectionName);
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -131,10 +142,12 @@ void WCSimDetectorConstruction::SuperK_20inchBandL_14perCent()
 
 
 void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
-{
+{ 
+  WCDetectorName = "Cylinder_12inchHPD_15perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
   // cylindrical detector with a height of 100m and a diameter of 69m 
   // with 12" HPD and 14.59% photocoverage
-  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE", "glassFaceWCPMT");
+  WCSimPMTObject * PMT = CreatePMTObject("HPD12inchHQE", WCIDCollectionName);
   WCPMTName           = PMT->GetPMTName();
   WCPMTExposeHeight   = PMT->GetExposeHeight();
   WCPMTRadius         = PMT->GetRadius();
@@ -156,7 +169,11 @@ void WCSimDetectorConstruction::Cylinder_12inchHPD_15perCent()
 
 void WCSimDetectorConstruction::SetHyperKGeometry()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", "glassFaceWCPMT");
+  WCDetectorName = "HyperK";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCODCollectionName = WCDetectorName + "-glassFaceWCPMT_OD"; 
+  WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", WCIDCollectionName);
+  WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", WCODCollectionName);
   WCPMTName = PMT->GetPMTName();
   innerPMT_Expose = PMT->GetExposeHeight();
   innerPMT_Radius = PMT->GetRadius();
@@ -175,7 +192,6 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
   innerPMT_Rpitch   =   990.*mm;
   innerPMT_Apitch   =   990.*mm;
 
-  WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", "glassFaceWCPMT_OD");
   outerPMT_Name = outerPMT->GetPMTName();
   outerPMT_Expose = outerPMT->GetExposeHeight();
   outerPMT_Radius = outerPMT->GetRadius();
@@ -200,7 +216,11 @@ void WCSimDetectorConstruction::SetHyperKGeometry()
 
 void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "HyperK_withHPD";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCODCollectionName = WCDetectorName + "-glassFaceWCPMT_OD"; 
+  WCSimPMTObject * PMT = CreatePMTObject("HPD20inchHQE", WCIDCollectionName);
+  WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", WCODCollectionName);
    WCPMTName = PMT->GetPMTName();
    innerPMT_Expose = PMT->GetExposeHeight();
    innerPMT_Radius = PMT->GetRadius();
@@ -219,7 +239,7 @@ void WCSimDetectorConstruction::SetHyperKGeometry_withHPD()
    innerPMT_Rpitch   =   990.*mm;
    innerPMT_Apitch   =   990.*mm;
 
-   WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", "glassFaceWCPMT_OD");
+ 
    outerPMT_Expose = outerPMT->GetExposeHeight();
    outerPMT_Radius = outerPMT->GetRadius();
    outerPMT_TopR      = innerPMT_TopR + 900.*mm;
@@ -267,8 +287,10 @@ void WCSimDetectorConstruction::MatchWCSimAndHyperK()
 
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
-{
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inch", "glassFaceWCPMT");
+{ 
+  WCDetectorName = "DUSEL_100kton_10inch_40perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inch", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -291,7 +313,9 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_40perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
 { 
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_100kton_10inch_HQE_12perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -314,7 +338,9 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_12perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_100kton_10inch_HQE_30perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -337,7 +363,9 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent()
 
 void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_100kton_10inch_HQE_30perCent_Gd";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -360,7 +388,9 @@ void WCSimDetectorConstruction::DUSEL_100kton_10inch_HQE_30perCent_Gd()
 
 void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_150kton_10inch_HQE_30perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -383,7 +413,9 @@ void WCSimDetectorConstruction::DUSEL_150kton_10inch_HQE_30perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_200kton_10inch_HQE_12perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT10inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -406,7 +438,9 @@ void WCSimDetectorConstruction::DUSEL_200kton_10inch_HQE_12perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_200kton_12inch_HQE_10perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -425,7 +459,9 @@ void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_10perCent()
 
 void WCSimDetectorConstruction::DUSEL_200kton_12inch_HQE_14perCent()
 {
-  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", "glassFaceWCPMT");
+  WCDetectorName = "DUSEL_200kton_12inch_HQE_14perCent";
+  WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
+  WCSimPMTObject * PMT = CreatePMTObject("PMT12inchHQE", WCIDCollectionName);
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -30,11 +30,6 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,WCSimTuning
   isHyperK  = false;
 
   debugMode = false;
-//-----------------------------------------------------
-// Initilize SD pointers
-//-----------------------------------------------------
-
-      aWCPMT     = NULL;
 
   myConfiguration = DetConfig;
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -91,10 +91,10 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
   // Get Hit collection of this event
   G4HCofThisEvent* HCE         = evt->GetHCofThisEvent();
   WCSimWCHitsCollection* WCHC = 0;
-
+  G4String WCIDCollectionName = detectorConstructor->GetIDCollectionName();
   if (HCE)
   { 
-    G4String name =   "glassFaceWCPMT";
+    G4String name =   WCIDCollectionName;
     G4int collectionID = SDman->GetCollectionID(name);
     WCHC = (WCSimWCHitsCollection*)HCE->GetHC(collectionID);
   }

--- a/src/WCSimStackingAction.cc
+++ b/src/WCSimStackingAction.cc
@@ -20,6 +20,7 @@ WCSimStackingAction::~WCSimStackingAction(){;}
 G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
 (const G4Track* aTrack) 
 {
+  G4String WCIDCollectionName = DetConstruct->GetIDCollectionName();
   G4ClassificationOfNewTrack classification    = fWaiting;
   G4ParticleDefinition*      particleType      = aTrack->GetDefinition();
   
@@ -31,7 +32,7 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
       G4float ratio = 1./(1.0-0.25);
       G4float wavelengthQE = 0;
       if(aTrack->GetCreatorProcess()==NULL) {
-	wavelengthQE  = DetConstruct->GetPMTQE("glassFaceWCPMT",photonWavelength,1,240,660,ratio);
+	wavelengthQE  = DetConstruct->GetPMTQE(WCIDCollectionName,photonWavelength,1,240,660,ratio);
 	if( G4UniformRand() > wavelengthQE )
 	  classification = fKill;
       }
@@ -46,9 +47,9 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
 	  // Even with WLS
 	  G4float wavelengthQE = 0;
 	  if (DetConstruct->GetPMT_QE_Method()==1){
-	    wavelengthQE  = DetConstruct->GetPMTQE("glassFaceWCPMT",photonWavelength,1,240,660,ratio);
+	    wavelengthQE  = DetConstruct->GetPMTQE(WCIDCollectionName,photonWavelength,1,240,660,ratio);
 	  }else if (DetConstruct->GetPMT_QE_Method()==2){
-	    wavelengthQE  = DetConstruct->GetPMTQE("glassFaceWCPMT",photonWavelength,0,240,660,ratio);
+	    wavelengthQE  = DetConstruct->GetPMTQE(WCIDCollectionName,photonWavelength,0,240,660,ratio);
 	  }else if (DetConstruct->GetPMT_QE_Method()==3){
 	    wavelengthQE = 1.1;
 	  }

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -341,10 +341,10 @@ void WCSimWCDigitizer::FindNumberOfGates()
 
 void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
 {
-
+  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
   G4float timingConstant = 0.0;
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer("glassFaceWCPMT");
+  PMT = myDetector->GetPMTPointer(WCIDCollectionName);
  
   G4double EvtG8Down = WCSimWCDigitizer::eventgatedown;
   G4double EvtG8Up = WCSimWCDigitizer::eventgateup;  // this is a negative number...

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -41,8 +41,9 @@ WCSimWCPMT::~WCSimWCPMT(){
 }
 
 G4double WCSimWCPMT::rn1pe(){
+  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer("glassFaceWCPMT");
+  PMT = myDetector->GetPMTPointer(WCIDCollectionName);
   G4int i;
   G4double random = G4UniformRand();
   G4double random2 = G4UniformRand(); 
@@ -63,11 +64,11 @@ G4double WCSimWCPMT::rn1pe(){
 void WCSimWCPMT::Digitize()
 {
   DigitsCollection = new WCSimWCDigitsCollection ("WCDigitizedCollectionPMT",collectionName[0]);
-
+  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
   G4DigiManager* DigiMan = G4DigiManager::GetDMpointer();
  
   // Get the Associated Hit collection IDs
-  G4int WCHCID = DigiMan->GetHitsCollectionID("glassFaceWCPMT");
+  G4int WCHCID = DigiMan->GetHitsCollectionID(WCIDCollectionName);
 
   // The Hits collection
   WCSimWCHitsCollection* WCHC =

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -103,7 +103,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   // they don't in skdetsim. 
   if ( particleDefinition != G4OpticalPhoton::OpticalPhotonDefinition())
     return false;
-
+  G4String WCIDCollectionName = fdet->GetIDCollectionName();
   // M Fechner : too verbose
   //  if (aStep->GetTrack()->GetTrackStatus() == fAlive) cout << "status is fAlive\n";
   if ((aStep->GetTrack()->GetTrackStatus() == fAlive )
@@ -148,7 +148,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   if (fdet->GetPMT_QE_Method()==1){
     photonQE = 1.1;
   }else if (fdet->GetPMT_QE_Method()==2){
-    maxQE = fdet->GetPMTQE(volumeName,wavelength,0,240,660,ratio);
+    maxQE = fdet->GetPMTQE(WCIDCollectionName,wavelength,0,240,660,ratio);
     photonQE = fdet->GetPMTQE(volumeName, wavelength,1,240,660,ratio);
     photonQE = photonQE/maxQE;
   }else if (fdet->GetPMT_QE_Method()==3){

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -148,12 +148,12 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   if (fdet->GetPMT_QE_Method()==1){
     photonQE = 1.1;
   }else if (fdet->GetPMT_QE_Method()==2){
-    maxQE = fdet->GetPMTQE(collectionName[0],wavelength,0,240,660,ratio);
-    photonQE = fdet->GetPMTQE(collectionName[0],wavelength,1,240,660,ratio);
+    maxQE = fdet->GetPMTQE(volumeName,wavelength,0,240,660,ratio);
+    photonQE = fdet->GetPMTQE(volumeName, wavelength,1,240,660,ratio);
     photonQE = photonQE/maxQE;
   }else if (fdet->GetPMT_QE_Method()==3){
     ratio = 1./(1.-0.25);
-    photonQE = fdet->GetPMTQE(collectionName[0],wavelength,1,240,660,ratio);
+    photonQE = fdet->GetPMTQE(volumeName, wavelength,1,240,660,ratio);
   }
   
   
@@ -164,7 +164,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
      G4double local_y = localPosition.y();
      G4double local_z = localPosition.z();
      theta_angle = acos(fabs(local_z)/sqrt(pow(local_x,2)+pow(local_y,2)+pow(local_z,2)))/3.1415926*180.;
-     effectiveAngularEfficiency = fdet->GetPMTCollectionEfficiency(theta_angle, collectionName[0]);
+     effectiveAngularEfficiency = fdet->GetPMTCollectionEfficiency(theta_angle, volumeName);
      if (G4UniformRand() <= effectiveAngularEfficiency || fdet->UsePMT_Coll_Eff()==0){
        //Retrieve the pointer to the appropriate hit collection. Since volumeName is the same as the SD name, this works. 
        G4SDManager* SDman = G4SDManager::GetSDMpointer();

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -35,8 +35,7 @@ WCSimWCSD::~WCSimWCSD() {}
 
 void WCSimWCSD::Initialize(G4HCofThisEvent* HCE)
 {
-  PMTHitMap.clear();
-
+ 
   // This is a trick.  We only want to do this once.  When the program
   // starts HCID will equal -1.  Then it will be set to the pointer to
   // this collection.
@@ -60,7 +59,6 @@ void WCSimWCSD::Initialize(G4HCofThisEvent* HCE)
   newHit->SetMaxPe(0);
   delete newHit;
 
-  StartofFile = 0;
 }
 
 G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
@@ -211,8 +209,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 }
 
 void WCSimWCSD::EndOfEvent(G4HCofThisEvent*)
-{ PMTHitMap.clear();  
-  StartofFile = 0;
+{ 
   if (verboseLevel>0) 
   { 
     G4int numHits = hitsCollection->entries();


### PR DESCRIPTION
This commit allows for multiple sensitive detectors to be instantiated and to have unique hit collections. This is a necessary step towards our goal of having a working outer detector volume. 

## Modified file descriptions

WCSimDetectorConstruction.hh: Now contains a method to recall a hit collection name. Currently this is just whatever the user has specified as the ID collection.  

WCSimConstructCylinder.cc: Now calls ConstructPMT with the ID collection name rather than a hard coded "glassFaceWCPMT" collection name.  

WCSimConstructGeometryTables.cc: Will now assign a PMTID to tubes which belong to the ID or the OD hit collections.  

WCSimConstructHyperK.cc: Now calls ConstructPMT once to build an ID tube and once to build an OD tube. Tubes are built with the corresponding hit collections which have been specified in WCSimDetectorConfigs.cc.

WCSimConstructPMT.cc: The logical volume for the sensitive detector now matches the hit collection name rather than being the hard coded "glassFaceWCPMT". Multiple sensitve detectors can now be instatiated. 

WCSimDetectorConfigs.cc: Each configuration now has a detector name associated with it. This is to make the hit collection names distinct for the given configuration and to avoid the situation where we repeat a hit collection name when we rebuild (for example, if we build a glassFaceWCPMT in the default SK configuration, and then build glassFaceWCPMT in HK using the macro). 

WCSimEventAction.cc: Gets the hit collection associated with the ID for use by the digitizer electronics. This can be extended to be used with the OD (or with multiple hit collections) in the future. 

WCSimStackingAction.cc: Does the pruning for the quatum efficiency using the tube associated with the ID. For the OD to be properly implemented, we will need to think of a clever way to account for the different tubes in the configuration and choose an appropriate way to prune for the QE. For now, the only configuration this will affect is Hyper-K (since it is the only one with an OD) and there will be no change in performance since the QE correction was done for the ID collection previous to this pull request. 

WCSimWCDigitizer.cc and WCSimWCPMT.cc: Still gets the pointer for the ID tubes, but now finds the appropriate hit collection name for those tubes, rather than hard coding it in. 

WCSimWCSD.cc: Now applies the appropriate QE if method 3 (sensitive detector only) is applied. For method 2 (stacking action and sensitive detector) is applied, then the maxPe of the ID tube (which was used in stacking action) is used in the QE scaling. When filling the hit collection, the routine now must find which volume was hit and find the appropriate hit collection pointer.