### PR TITLE
Uncommenting out the PMTCollEff on line and making it so that collection efficiency is on by default

### DIFF
--- a/novis.mac
+++ b/novis.mac
@@ -60,7 +60,7 @@
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
 #turn on or off the collection efficiency
-#/WCSim/PMTCollEff on
+/WCSim/PMTCollEff on
 
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
 /WCSim/SavePi0 false

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -75,8 +75,8 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,WCSimTuning
   // Set the default method for implementing the PMT QE
   //-----------------------------------------------------
   SetPMT_QE_Method(1);
-   //default NOT to use collection efficiency
-  SetPMT_Coll_Eff(0);
+   //default is to use collection efficiency
+  SetPMT_Coll_Eff(1);
 
   //----------------------------------------------------- 
   // Make the detector messenger to allow changing geometry

--- a/vis.mac
+++ b/vis.mac
@@ -56,7 +56,7 @@
 #/WCSim/PMTQEMethod     SensitiveDetector_Only
 
 # turn on or off the collection efficiency
-#/WCSim/PMTCollEff on
+/WCSim/PMTCollEff on
 
 #/WCSim/Construct # This must be uncommented to construct a new detector configuration.
 


### PR DESCRIPTION
This pull request turns the PMT collection efficiency on in novis.mac and vis.mac and sets the default mode to use PMT collection efficiency in WCSimDetectorConstruction.cc.  

Currently, when you want to run the box and line (B&L) or hybrid photodector (HPD) PMTs, you have to both specify a detector configuration with B&L/HPD PMTs *and* uncomment a line in the macro which turns on collection efficiency. I think this extra step of enabling the collection efficiency in the macro is causing confusion and there is no need for it to be off by default since we are properly implementing this efficiency factor for all PMTs (100% for normal PMT, 95% for B&L, 98% for HPDs). Furthermore, since B&L PMTs are becoming the likely candidate for Hyper-K and turning on the collection efficiency is essential to having these PMTs work properly, someone should have to actively want to turn off collection efficiency for that to happen in the code. 

Using verificationhitchargetime.C, I have checked that this pull request should produce output which is identical to the code available on the current development branch for the default Super-K case. I have also run an event in the SuperK_20inchBandL_14perCent configuration and it was identical to the code available on the current development branch.