### PR TITLE
Modify comment about CE modification

### DIFF
--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -1343,7 +1343,7 @@ G4float* BoxandLine20inchHQE::GetQEWavelength(){
 }
 
 G4float* BoxandLine20inchHQE::GetQE(){
-  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.32 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
+  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.27 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
   static G4float QE[20] =
     { 0.00*correctionFactor, .0008*correctionFactor, .1255*correctionFactor, .254962*correctionFactor, .2930*correctionFactor, .3127*correctionFactor, .3130*correctionFactor, .2994*correctionFactor, .2791*correctionFactor, .2491*correctionFactor,
       .2070*correctionFactor,  .1758*correctionFactor, .1384*correctionFactor, .0779*correctionFactor, .0473*correctionFactor, .0288*correctionFactor, .0149*correctionFactor, .0062*correctionFactor, .0002*correctionFactor, .0001*correctionFactor};  
@@ -1351,7 +1351,7 @@ G4float* BoxandLine20inchHQE::GetQE(){
   return QE;
 }
 G4float BoxandLine20inchHQE::GetmaxQE(){
-  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.32 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
+  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.27 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
   const G4float maxQE = 0.315*correctionFactor;
   return maxQE;
 }
@@ -1516,7 +1516,7 @@ G4float* BoxandLine12inchHQE::GetQEWavelength(){
 }
 
 G4float* BoxandLine12inchHQE::GetQE(){
-  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.32 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
+  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.27 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
   static G4float QE[20] =
     { 0.00*correctionFactor, .0008*correctionFactor, .1255*correctionFactor, .254962*correctionFactor, .2930*correctionFactor, .3127*correctionFactor, .3130*correctionFactor, .2994*correctionFactor, .2791*correctionFactor, .2491*correctionFactor,
       .2070*correctionFactor,  .1758*correctionFactor, .1384*correctionFactor, .0779*correctionFactor, .0473*correctionFactor, .0288*correctionFactor, .0149*correctionFactor, .0062*correctionFactor, .0002*correctionFactor, .0001*correctionFactor};  
@@ -1524,7 +1524,7 @@ G4float* BoxandLine12inchHQE::GetQE(){
   return QE;
 }
 G4float BoxandLine12inchHQE::GetmaxQE(){
-  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.32 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
+  G4float correctionFactor = 1./0.73;//Correction factor added in July 2015 to scale the output of B&L PDs to 2.27 times the 20" PMTS based on Hamamatsu simulation. This was done in Pull Request #98 and will be removed once a more permanent solution is found.
   const G4float maxQE = 0.315*correctionFactor;
   return maxQE;
 }


### PR DESCRIPTION
Because the hit efficiency evaluation of R3600 was wrong and evaluate again.
(R3600 hit efficiency was changed from 71.7% to 73.2%)
As a result, the expected output ratio of Box & Line PMT/R3600 (comparison of QE x CE x (hit efficiency) value) was fixed from 2.32 to 2.27.
This factor was mentioned in WCSimPMTObject.cc, and it was fixed on this pull request.