### PR TITLE
Option clarification for WCSimWCDigitizer

### DIFF
--- a/include/WCSimWCDigitizer.hh
+++ b/include/WCSimWCDigitizer.hh
@@ -89,6 +89,7 @@ private:
   G4double peSmeared;
 
   int nhitsThreshold;
+  int nhitsWindowBins;
 
   ////std::vector<G4double> TriggerTimes;
   std::map<G4int, G4int> GateMap;

--- a/novis.mac
+++ b/novis.mac
@@ -73,6 +73,7 @@
 /DAQ/Trigger NDigits
 
 #generic digitizer options (defaults are class-specific. Can be overridden here)
+#note that these options have no effect on the SKI_SKDETSIM trigger
 # how long is the digitizer dead before a new hit on the same PMT can be recorded (ns)?
 #/DAQ/DigitizerOpt/DeadTime 0
 # how long does the digitizer integrate for (ns)?

--- a/novis.mac
+++ b/novis.mac
@@ -80,6 +80,8 @@
 #/DAQ/DigitizerOpt/IntegrationWindow 200
 
 #trigger algorithm development options (defaults are set in WCSimWCDAQMessenger. Can be overidden here)
+#Note that for SKI_SKDETSIM, the events output which failed the trigger should not be used
+#(the noise is incorrect and /DAQ/TriggerSaveFailures/*TriggerWindow have no effect)
 # do we want to save only triggered events (mode 0), both triggered events & failed events (mode 1), or only failed events (mode 2)?
 #/DAQ/TriggerSaveFailures/Mode 0
 # what trigger time to use for the failed events (ns)?

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -45,8 +45,8 @@ WCSimWCDigitizer::WCSimWCDigitizer(G4String name,
   //in this class use this synonym for clarity
   nhitsThreshold  = ndigitsThreshold;
   if(nhitsWindowBins % 5) {
-    G4cerr << "Option /DAQ/TriggerNDigits/Window must be exactly divisble by 5 when running with SKI_SKDETSIM" << endl;
-      exit(-1);
+    G4cerr << "Option /DAQ/TriggerNDigits/Window must be exactly divisble by 5 when running with SKI_SKDETSIM" << G4endl;
+    exit(-1);
   }
   nhitsWindowBins = ndigitsWindow / 5;
 }

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -375,8 +375,8 @@ void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
   WCSimPMTObject * PMT;
   PMT = myDetector->GetPMTPointer(WCIDCollectionName);
  
-  G4double EvtG8Down = GetPreTriggerWindow(kTriggerNHitsSKDETSIM);  // this is a negative number...
-  G4double EvtG8Up   = GetPostTriggerWindow(kTriggerNHitsSKDETSIM);
+  G4double EvtG8Down = GetPreTriggerWindow(TriggerTypes[G]);  // this is a negative number... (usually)
+  G4double EvtG8Up   = GetPostTriggerWindow(TriggerTypes[G]);
 
   G4float tc;
   G4double lowerbound;

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -43,7 +43,12 @@ WCSimWCDigitizer::WCSimWCDigitizer(G4String name,
   //the nhits threshold value is read into the base class from /DAQ/TriggerNDigits/Threshold
   // into the variable ndigitsThreshold
   //in this class use this synonym for clarity
-  nhitsThreshold = ndigitsThreshold;
+  nhitsThreshold  = ndigitsThreshold;
+  if(nhitsWindowBins % 5) {
+    G4cerr << "Option /DAQ/TriggerNDigits/Window must be exactly divisble by 5 when running with SKI_SKDETSIM" << endl;
+      exit(-1);
+  }
+  nhitsWindowBins = ndigitsWindow / 5;
 }
 
 WCSimWCDigitizer::~WCSimWCDigitizer(){
@@ -284,8 +289,8 @@ void WCSimWCDigitizer::FindNumberOfGatesFast()
 									// so check 39 bins ahead in the histogram..
 
 	bool triggered = false;
-	while ( _mNextGate != GateMap.lower_bound( _mGateKeeper->first + 39)
-		&& _mNextGate->first <= _mGateKeeper->first + 39 		// but not more than 200ns away though!
+	while ( _mNextGate != GateMap.lower_bound( _mGateKeeper->first + nhitsWindowBins - 1)
+		&& _mNextGate->first <= _mGateKeeper->first + nhitsWindowBins - 1 		// but not more than 200ns away though!
 	      )
 	{
 
@@ -329,7 +334,7 @@ void WCSimWCDigitizer::FindNumberOfGates()
       RealOffset = 0.0; // will need to add the offset later
       for ( j = I ; j <= SearchWindow ; j++)
 	{                          // 40 corresponds to 200ns
-	  G4int beginning = ( (j+1-40>I) ? (j+1-40) : I );
+	  G4int beginning = ( (j+1-nhitsWindowBins>I) ? (j+1-nhitsWindowBins) : I );
 	  acc = 0;
 	  for ( G4int k = beginning ; k <= j; k++)
 	    {

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -44,7 +44,7 @@ WCSimWCDigitizer::WCSimWCDigitizer(G4String name,
   // into the variable ndigitsThreshold
   //in this class use this synonym for clarity
   nhitsThreshold  = ndigitsThreshold;
-  if(nhitsWindowBins % 5) {
+  if(ndigitsWindow % 5) {
     G4cerr << "Option /DAQ/TriggerNDigits/Window must be exactly divisble by 5 when running with SKI_SKDETSIM" << G4endl;
     exit(-1);
   }

--- a/vis.mac
+++ b/vis.mac
@@ -74,6 +74,8 @@
 #/DAQ/DigitizerOpt/IntegrationWindow 200
 
 #trigger algorithm development options (defaults are set in WCSimWCDAQMessenger. Can be overidden here)
+#Note that for SKI_SKDETSIM, the events output which failed the trigger should not be used
+#(the noise is incorrect and /DAQ/TriggerSaveFailures/*TriggerWindow have no effect)
 # do we want to save only triggered events (mode 0), both triggered events & failed events (mode 1), or only failed events (mode 2)?
 #/DAQ/TriggerSaveFailures/Mode 0
 # what trigger time to use for the failed events (ns)?

--- a/vis.mac
+++ b/vis.mac
@@ -67,6 +67,7 @@
 /DAQ/Trigger NDigits
 
 #generic digitizer options (defaults are class-specific. Can be overridden here)
+#note that these options have no effect on the SKI_SKDETSIM trigger
 # how long is the digitizer dead before a new hit on the same PMT can be recorded (ns)?
 #/DAQ/DigitizerOpt/DeadTime 0
 # how long does the digitizer integrate for (ns)?


### PR DESCRIPTION
Some new DAQ options have no effect on the old digitizer WCSimWCDigitizer, and this wasn't documented. This commit does two things:
* Makes the trigger decision window option have an effect on WCSimWCDigitizer
* Makes it clear in the .mac files that the generic digitizer options (deadtime & integration window) have no effect on WCSimWCDigitizer