### PR TITLE
Restrict number of digits per PMT per trigger to <= 1

### DIFF
--- a/include/WCSimWCDAQMessenger.hh
+++ b/include/WCSimWCDAQMessenger.hh
@@ -41,6 +41,7 @@ private:
   G4String            StoreTriggerChoice;
   G4UIcmdWithABool*   MultiDigitsPerTrigger;
   G4bool              StoreMultiDigitsPerTrigger;
+  G4bool              MultiDigitsPerTriggerSet;
 
   G4UIcmdWithoutParameter* DAQConstruct; //TODO remove this
 
@@ -73,6 +74,7 @@ private:
   G4int                 StoreNDigitsPostWindow;
 
   G4String initialiseString;
+  G4bool   initialised;
 };
 
 #endif

--- a/include/WCSimWCDAQMessenger.hh
+++ b/include/WCSimWCDAQMessenger.hh
@@ -39,8 +39,8 @@ private:
   G4String            StoreDigitizerChoice;
   G4UIcmdWithAString* TriggerChoice;
   G4String            StoreTriggerChoice;
-  G4UIcmdWithABool*   RestrictDigitsPerTrigger;
-  G4bool              StoreRestrictDigitsPerTrigger;
+  G4UIcmdWithABool*   MultiDigitsPerTrigger;
+  G4bool              StoreMultiDigitsPerTrigger;
 
   G4UIcmdWithoutParameter* DAQConstruct; //TODO remove this
 

--- a/include/WCSimWCDAQMessenger.hh
+++ b/include/WCSimWCDAQMessenger.hh
@@ -39,6 +39,8 @@ private:
   G4String            StoreDigitizerChoice;
   G4UIcmdWithAString* TriggerChoice;
   G4String            StoreTriggerChoice;
+  G4UIcmdWithABool*   RestrictDigitsPerTrigger;
+  G4bool              StoreRestrictDigitsPerTrigger;
 
   G4UIcmdWithoutParameter* DAQConstruct; //TODO remove this
 

--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -60,8 +60,8 @@ public:
   // Trigger algorithm option set methods
   //
 
-  ///Set whether to restrict the number of digits per PMT per trigger to <= 1
-  void SetRestrictDigitsPerTrigger(G4bool restrict) { restrictDigitsPerTrigger = restrict; }
+  ///Set whether to allow the number of digits per PMT per trigger to go > 1
+  void SetMultiDigitsPerTrigger(G4bool allow_multi) { multiDigitsPerTrigger = allow_multi; }
 
   // NDigits options
   ///Set the threshold for the NDigits trigger
@@ -102,7 +102,7 @@ protected:
   void GetVariables();
 
   ///Set the default trigger class specific decision of whether to save multiple digits per PMT per trigger (overridden by .mac)
-  virtual bool GetDefaultRestrictDigitsPerTrigger(){ return false; }
+  virtual bool GetDefaultMultiDigitsPerTrigger()   { return true; }
   ///Set the default trigger class specific NDigits window (in ns) (overridden by .mac)
   virtual int GetDefaultNDigitsWindow()            { return 200; }
   ///Set the default trigger class specific NDigits threshold (in ns) (overridden by .mac)
@@ -157,7 +157,7 @@ protected:
   double PMTDarkRate;    ///< Dark noise rate of the PMTs
 
   // Trigger algorithm options
-  G4bool restrictDigitsPerTrigger; ///< Restrict the number of digits per PMT saved in each trigger window to be <= 1?
+  G4bool multiDigitsPerTrigger;    ///< Allow the number of digits per PMT saved in each trigger window to go > 1?
   //NDigits
   G4int  ndigitsThreshold;         ///< The threshold for the NDigits trigger
   G4int  ndigitsWindow;            ///< The time window for the NDigits trigger
@@ -302,11 +302,11 @@ private:
   ///Calls the workhorse of this class: AlgNDigits
   void DoTheWork(WCSimWCDigitsCollection* WCDCPMT);
 
-  bool GetDefaultRestrictDigitsPerTrigger() { return true; } ///< SKI saves only earliest digit on a PMT in the trigger window
-  int GetDefaultNDigitsWindow()            { return 200;  } ///< SK max light travel time ~200 ns
-  int GetDefaultNDigitsThreshold()         { return 25;   } ///< SK NDigits threshold ~25
-  int GetDefaultNDigitsPreTriggerWindow()  { return -400; } ///< SK SLE trigger window ~-400
-  int GetDefaultNDigitsPostTriggerWindow() { return 950;  } ///< SK SLE trigger window ~+950
+  bool GetDefaultMultiDigitsPerTrigger()    { return false; } ///< SKI saves only earliest digit on a PMT in the trigger window
+  int  GetDefaultNDigitsWindow()            { return 200;   } ///< SK max light travel time ~200 ns
+  int  GetDefaultNDigitsThreshold()         { return 25;    } ///< SK NDigits threshold ~25
+  int  GetDefaultNDigitsPreTriggerWindow()  { return -400;  } ///< SK SLE trigger window ~-400
+  int  GetDefaultNDigitsPostTriggerWindow() { return 950;   } ///< SK SLE trigger window ~+950
 };
 
 
@@ -328,11 +328,11 @@ public:
 private:
   void DoTheWork(WCSimWCDigitsCollection* WCDCPMT);
 
-  bool GetDefaultRestrictDigitsPerTrigger() { return true; } ///< SKI saves only earliest digit on a PMT in the trigger window
-  int GetDefaultNDigitsWindow()            { return 200;  } ///< SK max light travel time ~200 ns
-  int GetDefaultNDigitsThreshold()         { return 50;   } ///< 2 * SK NDigits threshold ~25
-  int GetDefaultNDigitsPreTriggerWindow()  { return -400; } ///< SK SLE trigger window ~-400
-  int GetDefaultNDigitsPostTriggerWindow() { return 950;  } ///< SK SLE trigger window ~+950
+  bool GetDefaultMultiDigitsPerTrigger()    { return false; } ///< SKI saves only earliest digit on a PMT in the trigger window
+  int  GetDefaultNDigitsWindow()            { return 200;   } ///< SK max light travel time ~200 ns
+  int  GetDefaultNDigitsThreshold()         { return 50;    } ///< 2 * SK NDigits threshold ~25
+  int  GetDefaultNDigitsPreTriggerWindow()  { return -400;  } ///< SK SLE trigger window ~-400
+  int  GetDefaultNDigitsPostTriggerWindow() { return 950;   } ///< SK SLE trigger window ~+950
 };
 
 

--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -60,6 +60,9 @@ public:
   // Trigger algorithm option set methods
   //
 
+  ///Set whether to restrict the number of digits per PMT per trigger to <= 1
+  void SetRestrictDigitsPerTrigger(G4bool restrict) { restrictDigitsPerTrigger = restrict; }
+
   // NDigits options
   ///Set the threshold for the NDigits trigger
   void SetNDigitsThreshold(G4int threshold) { ndigitsThreshold = threshold; }
@@ -98,6 +101,8 @@ protected:
   /// Get the default threshold, etc. from the derived class, and override with read from the .mac file
   void GetVariables();
 
+  ///Set the default trigger class specific decision of whether to save multiple digits per PMT per trigger (overridden by .mac)
+  virtual bool GetDefaultRestrictDigitsPerTrigger(){ return false; }
   ///Set the default trigger class specific NDigits window (in ns) (overridden by .mac)
   virtual int GetDefaultNDigitsWindow()            { return 200; }
   ///Set the default trigger class specific NDigits threshold (in ns) (overridden by .mac)
@@ -152,6 +157,7 @@ protected:
   double PMTDarkRate;    ///< Dark noise rate of the PMTs
 
   // Trigger algorithm options
+  G4bool restrictDigitsPerTrigger; ///< Restrict the number of digits per PMT saved in each trigger window to be <= 1?
   //NDigits
   G4int  ndigitsThreshold;         ///< The threshold for the NDigits trigger
   G4int  ndigitsWindow;            ///< The time window for the NDigits trigger
@@ -296,6 +302,7 @@ private:
   ///Calls the workhorse of this class: AlgNDigits
   void DoTheWork(WCSimWCDigitsCollection* WCDCPMT);
 
+  bool GetDefaultRestrictDigitsPerTrigger() { return true; } ///< SKI saves only earliest digit on a PMT in the trigger window
   int GetDefaultNDigitsWindow()            { return 200;  } ///< SK max light travel time ~200 ns
   int GetDefaultNDigitsThreshold()         { return 25;   } ///< SK NDigits threshold ~25
   int GetDefaultNDigitsPreTriggerWindow()  { return -400; } ///< SK SLE trigger window ~-400
@@ -321,6 +328,7 @@ public:
 private:
   void DoTheWork(WCSimWCDigitsCollection* WCDCPMT);
 
+  bool GetDefaultRestrictDigitsPerTrigger() { return true; } ///< SKI saves only earliest digit on a PMT in the trigger window
   int GetDefaultNDigitsWindow()            { return 200;  } ///< SK max light travel time ~200 ns
   int GetDefaultNDigitsThreshold()         { return 50;   } ///< 2 * SK NDigits threshold ~25
   int GetDefaultNDigitsPreTriggerWindow()  { return -400; } ///< SK SLE trigger window ~-400

--- a/novis.mac
+++ b/novis.mac
@@ -78,6 +78,11 @@
 # how long does the digitizer integrate for (ns)?
 #/DAQ/DigitizerOpt/IntegrationWindow 200
 
+#generic trigger options (defaults are class-specfic. Can be overrideen here)
+# restrict the number of digits per PMT per trigger to be <= 1?
+# (note this has no effect on SKI_SKDETSIM (the restriction is always on))
+/DAQ/RestrictDigitsPerTrigger true
+
 #trigger algorithm development options (defaults are set in WCSimWCDAQMessenger. Can be overidden here)
 # do we want to save only triggered events (mode 0), both triggered events & failed events (mode 1), or only failed events (mode 2)?
 #/DAQ/TriggerSaveFailures/Mode 0

--- a/novis.mac
+++ b/novis.mac
@@ -79,9 +79,9 @@
 #/DAQ/DigitizerOpt/IntegrationWindow 200
 
 #generic trigger options (defaults are class-specfic. Can be overrideen here)
-# restrict the number of digits per PMT per trigger to be <= 1?
-# (note this has no effect on SKI_SKDETSIM (the restriction is always on))
-/DAQ/RestrictDigitsPerTrigger true
+# allow the number of digits per PMT per trigger to be > 1?
+# (note this has no effect on SKI_SKDETSIM (always has <= 1))
+#/DAQ/MultiDigitsPerTrigger false
 
 #trigger algorithm development options (defaults are set in WCSimWCDAQMessenger. Can be overidden here)
 # do we want to save only triggered events (mode 0), both triggered events & failed events (mode 1), or only failed events (mode 2)?

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -55,6 +55,14 @@ WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
   StoreTriggerChoice = defaultTrigger;
   SetNewValue(TriggerChoice, defaultTrigger);
 
+  bool defaultRestrictDigitsPerTrigger = true;
+  RestrictDigitsPerTrigger = new G4UIcmdWithABool("/DAQ/RestrictDigitsPerTrigger", this);
+  RestrictDigitsPerTrigger->SetGuidance("Restrict the number of digits per PMT per trigger to <=1?");
+  RestrictDigitsPerTrigger->SetParameterName("RestrictDigitsPerTrigger",true);
+  RestrictDigitsPerTrigger->SetDefaultValue(defaultRestrictDigitsPerTrigger);
+  StoreNDigitsAdjustForNoise = defaultRestrictDigitsPerTrigger;
+  //don't SetNewValue -> defaults class-specific and taken from GetDefault*()
+
 
   //Generic digitizer specific options
   DigitizerDir = new G4UIdirectory("/DAQ/DigitizerOpt/");
@@ -188,6 +196,7 @@ WCSimWCDAQMessenger::~WCSimWCDAQMessenger()
 
   delete DigitizerChoice;
   delete TriggerChoice;
+  delete RestrictDigitsPerTrigger;
   delete WCSimDAQDir;
 }
 
@@ -206,6 +215,11 @@ void WCSimWCDAQMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
     G4cout << "Trigger choice set to " << newValue << initialiseString.c_str() << G4endl;
     WCSimEvent->SetTriggerChoice(newValue);
     StoreTriggerChoice = newValue;
+  }
+  else if (command == RestrictDigitsPerTrigger) {
+    StoreRestrictDigitsPerTrigger = RestrictDigitsPerTrigger->GetNewBoolValue(newValue);
+    if(StoreRestrictDigitsPerTrigger)
+      G4cout << "Will restrict number of digits per PMT per trigger to <= 1" << initialiseString.c_str() << G4endl;
   }
 
   //Generic digitizer options
@@ -280,6 +294,10 @@ void WCSimWCDAQMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 void WCSimWCDAQMessenger::SetTriggerOptions()
 {
   G4cout << "Passing Trigger options to the trigger class instance" << G4endl;
+
+  WCSimTrigger->SetRestrictDigitsPerTrigger(StoreRestrictDigitsPerTrigger);
+  if(StoreRestrictDigitsPerTrigger)
+    G4cout << "\tWill restrict number of digits per PMT per trigger to <= 1" << G4endl;
 
   WCSimTrigger->SetSaveFailuresMode(StoreSaveFailuresMode);
   std::string failuremode;

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -15,6 +15,7 @@ WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
   WCSimEvent(eventaction)
 {
   initialiseString = " (this is a default set; it may be overwritten by user commands)";
+  initialised = false;
 
   WCSimDAQDir = new G4UIdirectory("/DAQ/");
   WCSimDAQDir->SetGuidance("Commands to select DAQ options");
@@ -61,6 +62,7 @@ WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
   MultiDigitsPerTrigger->SetParameterName("MultiDigitsPerTrigger",true);
   MultiDigitsPerTrigger->SetDefaultValue(defaultMultiDigitsPerTrigger);
   StoreMultiDigitsPerTrigger = defaultMultiDigitsPerTrigger;
+  MultiDigitsPerTriggerSet = false; //this variable is bool & defaults are class specfic; use this to know if the default is overidden
   //don't SetNewValue -> defaults class-specific and taken from GetDefault*()
 
 
@@ -171,6 +173,7 @@ WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
   DAQConstruct->SetGuidance("Create the DAQ class instances");
 
   initialiseString = "";
+  initialised = true;
 }
 
 WCSimWCDAQMessenger::~WCSimWCDAQMessenger()
@@ -222,6 +225,8 @@ void WCSimWCDAQMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
       G4cout << "Will restrict number of digits per PMT per trigger to <= 1" << initialiseString.c_str() << G4endl;
     else
       G4cout << "Will allow number of digits per PMT per trigger to go > 1" << initialiseString.c_str() << G4endl;
+    if(initialised)
+      MultiDigitsPerTriggerSet = true;
   }
 
   //Generic digitizer options
@@ -297,11 +302,13 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
 {
   G4cout << "Passing Trigger options to the trigger class instance" << G4endl;
 
-  WCSimTrigger->SetMultiDigitsPerTrigger(StoreMultiDigitsPerTrigger);
-  if(!StoreMultiDigitsPerTrigger)
-    G4cout << "\tWill restrict number of digits per PMT per trigger to <= 1" << G4endl;
-  else
-    G4cout << "\tWill allow number of digits per PMT per trigger to go > 1" << initialiseString.c_str() << G4endl;
+  if(MultiDigitsPerTriggerSet) {
+    WCSimTrigger->SetMultiDigitsPerTrigger(StoreMultiDigitsPerTrigger);
+    if(!StoreMultiDigitsPerTrigger)
+      G4cout << "\tWill restrict number of digits per PMT per trigger to <= 1" << G4endl;
+    else
+      G4cout << "\tWill allow number of digits per PMT per trigger to go > 1" << initialiseString.c_str() << G4endl;
+  }
 
   WCSimTrigger->SetSaveFailuresMode(StoreSaveFailuresMode);
   std::string failuremode;

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -55,12 +55,12 @@ WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
   StoreTriggerChoice = defaultTrigger;
   SetNewValue(TriggerChoice, defaultTrigger);
 
-  bool defaultRestrictDigitsPerTrigger = true;
-  RestrictDigitsPerTrigger = new G4UIcmdWithABool("/DAQ/RestrictDigitsPerTrigger", this);
-  RestrictDigitsPerTrigger->SetGuidance("Restrict the number of digits per PMT per trigger to <=1?");
-  RestrictDigitsPerTrigger->SetParameterName("RestrictDigitsPerTrigger",true);
-  RestrictDigitsPerTrigger->SetDefaultValue(defaultRestrictDigitsPerTrigger);
-  StoreNDigitsAdjustForNoise = defaultRestrictDigitsPerTrigger;
+  bool defaultMultiDigitsPerTrigger = false;
+  MultiDigitsPerTrigger = new G4UIcmdWithABool("/DAQ/MultiDigitsPerTrigger", this);
+  MultiDigitsPerTrigger->SetGuidance("Allow the number of digits per PMT per trigger to be > 1?");
+  MultiDigitsPerTrigger->SetParameterName("MultiDigitsPerTrigger",true);
+  MultiDigitsPerTrigger->SetDefaultValue(defaultMultiDigitsPerTrigger);
+  StoreMultiDigitsPerTrigger = defaultMultiDigitsPerTrigger;
   //don't SetNewValue -> defaults class-specific and taken from GetDefault*()
 
 
@@ -196,7 +196,7 @@ WCSimWCDAQMessenger::~WCSimWCDAQMessenger()
 
   delete DigitizerChoice;
   delete TriggerChoice;
-  delete RestrictDigitsPerTrigger;
+  delete MultiDigitsPerTrigger;
   delete WCSimDAQDir;
 }
 
@@ -216,10 +216,12 @@ void WCSimWCDAQMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
     WCSimEvent->SetTriggerChoice(newValue);
     StoreTriggerChoice = newValue;
   }
-  else if (command == RestrictDigitsPerTrigger) {
-    StoreRestrictDigitsPerTrigger = RestrictDigitsPerTrigger->GetNewBoolValue(newValue);
-    if(StoreRestrictDigitsPerTrigger)
+  else if (command == MultiDigitsPerTrigger) {
+    StoreMultiDigitsPerTrigger = MultiDigitsPerTrigger->GetNewBoolValue(newValue);
+    if(!StoreMultiDigitsPerTrigger)
       G4cout << "Will restrict number of digits per PMT per trigger to <= 1" << initialiseString.c_str() << G4endl;
+    else
+      G4cout << "Will allow number of digits per PMT per trigger to go > 1" << initialiseString.c_str() << G4endl;
   }
 
   //Generic digitizer options
@@ -295,9 +297,11 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
 {
   G4cout << "Passing Trigger options to the trigger class instance" << G4endl;
 
-  WCSimTrigger->SetRestrictDigitsPerTrigger(StoreRestrictDigitsPerTrigger);
-  if(StoreRestrictDigitsPerTrigger)
+  WCSimTrigger->SetMultiDigitsPerTrigger(StoreMultiDigitsPerTrigger);
+  if(!StoreMultiDigitsPerTrigger)
     G4cout << "\tWill restrict number of digits per PMT per trigger to <= 1" << G4endl;
+  else
+    G4cout << "\tWill allow number of digits per PMT per trigger to go > 1" << initialiseString.c_str() << G4endl;
 
   WCSimTrigger->SetSaveFailuresMode(StoreSaveFailuresMode);
   std::string failuremode;

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -59,7 +59,7 @@ WCSimWCTriggerBase::~WCSimWCTriggerBase(){
 void WCSimWCTriggerBase::GetVariables()
 {
   //set the options to class-specific defaults
-  restrictDigitsPerTrigger = GetDefaultRestrictDigitsPerTrigger();
+  multiDigitsPerTrigger    = GetDefaultMultiDigitsPerTrigger();
   ndigitsThreshold         = GetDefaultNDigitsThreshold();
   ndigitsWindow            = GetDefaultNDigitsWindow();
   ndigitsPreTriggerWindow  = GetDefaultNDigitsPreTriggerWindow();
@@ -76,7 +76,7 @@ void WCSimWCTriggerBase::GetVariables()
     exit(-1);
   }
 
-  G4cout << (restrictDigitsPerTrigger ? "Using a maximum of 1 digit per PMT per trigger" : "Using mutiple digits per PMT per trigger") << G4endl
+  G4cout << (multiDigitsPerTrigger ? "Using mutiple digits per PMT per trigger" : "Using a maximum of 1 digit per PMT per trigger" ) << G4endl
 	 << "Using NDigits threshold " << ndigitsThreshold
 	 << (ndigitsAdjustForNoise ? " (will be adjusted for noise)" : "") << G4endl
 	 << "Using NDigits trigger window " << ndigitsWindow << " ns" << G4endl
@@ -397,7 +397,7 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
 
 	  //we've found a digit on this PMT. If we're restricting to just 1 digit per trigger window (e.g. SKI)
 	  // then ignore later digits and break. This takes us to the next PMT
-	  if(restrictDigitsPerTrigger)
+	  if(!multiDigitsPerTrigger)
 	    break;
 	}//digits within trigger window
       }//loop over Digits

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -59,6 +59,7 @@ WCSimWCTriggerBase::~WCSimWCTriggerBase(){
 void WCSimWCTriggerBase::GetVariables()
 {
   //set the options to class-specific defaults
+  restrictDigitsPerTrigger = GetDefaultRestrictDigitsPerTrigger();
   ndigitsThreshold         = GetDefaultNDigitsThreshold();
   ndigitsWindow            = GetDefaultNDigitsWindow();
   ndigitsPreTriggerWindow  = GetDefaultNDigitsPreTriggerWindow();
@@ -75,7 +76,8 @@ void WCSimWCTriggerBase::GetVariables()
     exit(-1);
   }
 
-  G4cout << "Using NDigits threshold " << ndigitsThreshold
+  G4cout << (restrictDigitsPerTrigger ? "Using a maximum of 1 digit per PMT per trigger" : "Using mutiple digits per PMT per trigger") << G4endl
+	 << "Using NDigits threshold " << ndigitsThreshold
 	 << (ndigitsAdjustForNoise ? " (will be adjusted for noise)" : "") << G4endl
 	 << "Using NDigits trigger window " << ndigitsWindow << " ns" << G4endl
 	 << "Using NDigits event pretrigger window " << ndigitsPreTriggerWindow << " ns" << G4endl
@@ -392,6 +394,11 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
 	  }
 	  if(remove_hits)
 	    (*WCDCPMT)[i]->RemoveDigitizedGate(ip);
+
+	  //we've found a digit on this PMT. If we're restricting to just 1 digit per trigger window (e.g. SKI)
+	  // then ignore later digits and break. This takes us to the next PMT
+	  if(restrictDigitsPerTrigger)
+	    break;
 	}//digits within trigger window
       }//loop over Digits
     }//loop over PMTs

--- a/vis.mac
+++ b/vis.mac
@@ -72,6 +72,11 @@
 # how long does the digitizer integrate for (ns)?
 #/DAQ/DigitizerOpt/IntegrationWindow 200
 
+#generic trigger options (defaults are class-specfic. Can be overrideen here)
+# restrict the number of digits per PMT per trigger to be <= 1?
+# (note this has no effect on SKI_SKDETSIM (the restriction is always on))
+/DAQ/RestrictDigitsPerTrigger true
+
 #trigger algorithm development options (defaults are set in WCSimWCDAQMessenger. Can be overidden here)
 # do we want to save only triggered events (mode 0), both triggered events & failed events (mode 1), or only failed events (mode 2)?
 #/DAQ/TriggerSaveFailures/Mode 0

--- a/vis.mac
+++ b/vis.mac
@@ -73,9 +73,9 @@
 #/DAQ/DigitizerOpt/IntegrationWindow 200
 
 #generic trigger options (defaults are class-specfic. Can be overrideen here)
-# restrict the number of digits per PMT per trigger to be <= 1?
-# (note this has no effect on SKI_SKDETSIM (the restriction is always on))
-/DAQ/RestrictDigitsPerTrigger true
+# allow the number of digits per PMT per trigger to be > 1?
+# (note this has no effect on SKI_SKDETSIM (always has <= 1))
+#/DAQ/MultiDigitsPerTrigger false
 
 #trigger algorithm development options (defaults are set in WCSimWCDAQMessenger. Can be overidden here)
 # do we want to save only triggered events (mode 0), both triggered events & failed events (mode 1), or only failed events (mode 2)?


### PR DESCRIPTION
This intends to fix #120. It adds the option to restrict the number of digits per PMT per trigger to <= 1, which is how SKI works. It is the default in both the NDigits and NDigits2 classes, and has no effect on the SKI_SKDETSIM class. I've added it as an .mac option (rather than hardcoded) so that people can study the effect of this on any trigger.

The following plots are for a 5 GeV electron particle gun, and show that turning the restriction on (red) is more consistent with the SKI_SKDETSIM option (black).

![hits5000_42-1](https://cloud.githubusercontent.com/assets/11757479/10914396/1e897192-824a-11e5-973e-d4474c29228b.png)

![time25000_42-1](https://cloud.githubusercontent.com/assets/11757479/10914395/1e89089c-824a-11e5-915b-09f8ccd6cd7f.png)
