### PR TITLE
Fix bug in WCSimWCAddDarkNoise::FindDarkNoiseRanges to prevent seg fa…

### DIFF
--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -213,6 +213,19 @@ void WCSimWCAddDarkNoise::FindDarkNoiseRanges(WCSimWCDigitsCollection* WCHCPMT, 
   //for the algorithm below to work
   sort(ranges.begin(),ranges.end());
 
+  //check if the vector range has any entries
+  //If no entries this indicates that no digits were
+  //found in the WCSimWCDigitsCollection, which can cause 
+  //segmentation faults in the next part of the code in this method
+  //which searches for overlapping ranges.
+  //Set range vector to have one element from 0 to 0 (so no noise digits will be added)
+  if(ranges.size() == 0)
+    {
+      //push back a range of 0 and 0 and return                                                                                                                              
+      result.push_back(std::make_pair(0.,0.));
+      return;
+    }
+
   //the ranges vector contains overlapping ranges
   //this loop removes overlaps
   //output are pairs stored in the result vector


### PR DESCRIPTION
Fixes a bug in WCSimWCAddDarkNoise::FindDarkNoiseRanges (when using /DarkRate/SetDarkMode 1) which causes a segmentation fault to occur when no hits are recorded in the PMTs.  Code detects this occurrence and results in no dark noise hits being added (expected behaviour).