### PR TITLE
Fix verbose hits prints after a different geometry than the default is used.

### DIFF
--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -208,10 +208,16 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   return true;
 }
 
-void WCSimWCSD::EndOfEvent(G4HCofThisEvent*)
+void WCSimWCSD::EndOfEvent(G4HCofThisEvent* HCE)
 {
   if (verboseLevel>0) 
   { 
+
+    //Need to specify which collection in case multiple geometries are built
+    G4String WCIDCollectionName = fdet->GetIDCollectionName();
+    G4SDManager* SDman = G4SDManager::GetSDMpointer();
+    G4int collectionID = SDman->GetCollectionID(WCIDCollectionName);
+    hitsCollection = (WCSimWCHitsCollection*)HCE->GetHC(collectionID);
     G4int numHits = hitsCollection->entries();
 
     G4cout << "There are " << numHits << " hits in the WC: " << G4endl;


### PR DESCRIPTION
Fix 0 hits report when running hits/verbose 1 after Re-Constructing the geometry. This is a very useful verbose debug.
The "There are 0 hits" came from the fact that there were multiple hitCollections, one for the default Geometry, registered with SDMan (and impossible to delete), and one for the actual geometry. The collectionID of the current geometry is required to get the right hitCollection.
