### PR TITLE
 /mygen/vecfile not found

### DIFF
--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -101,6 +101,11 @@ public:
 
     vectorFileName = fileName;
     inputFile.open(vectorFileName, std::fstream::in);
+
+    if ( !inputFile.is_open() ) {
+      G4cout << "Vector file " << vectorFileName << " not found" << G4endl;
+      exit(-1);
+    }
   }
   inline G4bool IsGeneratingVertexInRock() { return GenerateVertexInRock; }
   inline void SetGenerateVertexInRock(G4bool choice) { GenerateVertexInRock = choice; }

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -102,7 +102,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     {
       G4cout << "Set a vector file using the command /mygen/vecfile name"
 	     << G4endl;
-      return;
+      exit(-1);
     }
 
     //


### PR DESCRIPTION
When /mygen/vecfile points to a file that doesn't exist, or isn't called when using muline mode, there should be a fatal error (rather than a warning that can get lost in the output)