### PR TITLE
updated reference to documentation of root file structure

### DIFF
--- a/sample-root-scripts/pmtremove.C
+++ b/sample-root-scripts/pmtremove.C
@@ -202,7 +202,7 @@ void pmtremove(TString infile, TString outfile, double removefrac)
 	  // It is the number of tubes hit with Cherenkov photons.
 	  // The number of digitized tubes will be smaller because of the threshold.
 	  // Each hit "raw" tube has several photon hits.  The times are recorded.
-	  // See http://nwg.phy.bnl.gov/DDRD/cgi-bin/private/ShowDocument?docid=245
+	  // See chapter 5 of ../doc/DetectorDocumentation.pdf
 	  // for more information on the structure of the root file.
 	  //  
 	  // For digitized info (one time/charge tube after a trigger) use

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -158,7 +158,7 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
     // It is the number of tubes hit with Cherenkov photons.
     // The number of digitized tubes will be smaller because of the threshold.
     // Each hit "raw" tube has several photon hits.  The times are recorded.
-    // See http://nwg.phy.bnl.gov/DDRD/cgi-bin/private/ShowDocument?docid=245
+    // See chapter 5 of ../doc/DetectorDocumentation.pdf
     // for more information on the structure of the root file.
     //  
     // The following code prints out the hit times for the first 10 tubes and also


### PR DESCRIPTION
The web page appears to be down and is not available in the Internet Archive (archive.org), but the information is now available in the DetectorDocumentation.pdf.