### PR TITLE
removed duplicate line from read_PMT.C, unified output

### DIFF
--- a/sample-root-scripts/read_PMT.C
+++ b/sample-root-scripts/read_PMT.C
@@ -49,14 +49,13 @@ void read_PMT(char *filename=NULL) {
   // As you can see, there are lots of ways to get the number of hits.
   cout << "Number of tube hits " << wcsimrootevent->GetNumTubesHit() << endl;
   cout << "Number of Cherenkov tube hits " << wcsimrootevent->GetNcherenkovhits() << endl;
-  cout << "Number of tube hits " << wcsimrootevent->GetCherenkovHits()->GetEntries() << endl;
+  cout << "Number of Cherenkov tube hits " << wcsimrootevent->GetCherenkovHits()->GetEntries() << endl;
 
   cout << "Number of digitized tube hits " << wcsimrootevent->GetNumDigiTubesHit() << endl;
-  cout << "Number of digitized tube hits " << wcsimrootevent->GetCherenkovDigiHits()->GetEntries() << endl;
-
   cout << "Number of digitized Cherenkov tube hits " << wcsimrootevent->GetNcherenkovdigihits() << endl;
   cout << "Number of digitized Cherenkov tube hits " << wcsimrootevent->GetCherenkovDigiHits()->GetEntries() << endl;
-  cout << "Number of photoelectron hit times" << wcsimrootevent->GetCherenkovHitTimes()->GetEntries() << endl;
+
+  cout << "Number of photoelectron hit times " << wcsimrootevent->GetCherenkovHitTimes()->GetEntries() << endl;
 
   //-----------------------
 


### PR DESCRIPTION
This just makes the output of a sample script a bit nicer; it has no effect on functionality.
(as mentioned in #175 )
