### PR TITLE
Feature/issue9: Changes to update GEANT version to 4.10.x

### DIFF
--- a/include/WCSimPhysicsList.hh
+++ b/include/WCSimPhysicsList.hh
@@ -25,7 +25,6 @@ class WCSimPhysicsList: public G4VPhysicsConstructor
 
     G4String SecondaryHadModel;
 
-    G4bool gheishahad;
     G4bool bertinihad;
     G4bool binaryhad;
 

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -28,9 +28,9 @@ void WCSimDetectorConstruction::PrintGeometryTree
   for (int levels = 0; levels < aDepth; levels++) G4cout << " ";
   G4cout << aPV->GetName() << " Level:" << aDepth 
 	 << " Pos:" << aTransform.getTranslation() 
-	 << " Rot:" << aTransform.getRotation().getTheta()/deg 
-	 << "," << aTransform.getRotation().getPhi()/deg 
-	 << "," << aTransform.getRotation().getPsi()/deg
+	 << " Rot:" << aTransform.getRotation().getTheta()/CLHEP::deg 
+	 << "," << aTransform.getRotation().getPhi()/CLHEP::deg 
+	 << "," << aTransform.getRotation().getPsi()/CLHEP::deg
 	 << G4endl;
 }
 
@@ -46,16 +46,16 @@ void WCSimDetectorConstruction::GetWCGeom
     if ((aPV->GetName() == "WCBarrel") ||
         (aPV->GetName() == "WorldBox")) {    // last condition is the HyperK Envelope name.
     // Stash info in data member
-    WCOffset = G4ThreeVector(aTransform.getTranslation().getX()/cm,
-			     aTransform.getTranslation().getY()/cm,
-			     aTransform.getTranslation().getZ()/cm);
+    WCOffset = G4ThreeVector(aTransform.getTranslation().getX()/CLHEP::cm,
+			     aTransform.getTranslation().getY()/CLHEP::cm,
+			     aTransform.getTranslation().getZ()/CLHEP::cm);
     }
 
 	
 
     // Stash info in data member
     // AH Need to store this in CM for it to be understood by SK code
-    WCPMTSize = WCPMTRadius/cm;// I think this is just a variable no if needed
+    WCPMTSize = WCPMTRadius/CLHEP::cm;// I think this is just a variable no if needed
 
 
     // Note WC can be off-center... get both extremities
@@ -69,9 +69,9 @@ void WCSimDetectorConstruction::GetWCGeom
     }
 
     if ((aPV->GetName() == "WCCapBlackSheet") || (aPV->GetName().find("glassFaceWCPMT") != std::string::npos)){ 
-      G4float x =  aTransform.getTranslation().getX()/cm;
-      G4float y =  aTransform.getTranslation().getY()/cm;
-      G4float z =  aTransform.getTranslation().getZ()/cm;
+      G4float x =  aTransform.getTranslation().getX()/CLHEP::cm;
+      G4float y =  aTransform.getTranslation().getY()/CLHEP::cm;
+      G4float z =  aTransform.getTranslation().getZ()/CLHEP::cm;
       
       if (x<xmin){xmin=x;}
       if (x>xmax){xmax=x;}
@@ -137,10 +137,10 @@ void WCSimDetectorConstruction::DescribeAndRegisterPMT(G4VPhysicalVolume* aPV ,i
       
     // Print
     //     G4cout << "Tube: "<<std::setw(4) << totalNumPMTs << " " << tubeTag
-    //     	   << " Pos:" << aTransform.getTranslation()/cm 
-    //     	   << " Rot:" << aTransform.getRotation().getTheta()/deg 
-    //     	   << "," << aTransform.getRotation().getPhi()/deg 
-    //     	   << "," << aTransform.getRotation().getPsi()/deg
+    //     	   << " Pos:" << aTransform.getTranslation()/CLHEP::cm 
+    //     	   << " Rot:" << aTransform.getRotation().getTheta()/CLHEP::deg 
+    //     	   << "," << aTransform.getRotation().getPhi()/CLHEP::deg 
+    //     	   << "," << aTransform.getRotation().getPsi()/CLHEP::deg
     //     	   << G4endl; 
   }
 }
@@ -159,8 +159,8 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
   // (JF) Get first tube transform for filling in detector radius
   // the height is still done with WCCylInfo above
   G4Transform3D firstTransform = tubeIDMap[2];
-  innerradius = sqrt(pow(firstTransform.getTranslation().getX()/cm,2)
-                            + pow(firstTransform.getTranslation().getY()/cm,2));
+  innerradius = sqrt(pow(firstTransform.getTranslation().getX()/CLHEP::cm,2)
+                            + pow(firstTransform.getTranslation().getY()/CLHEP::cm,2));
 
   if (isEggShapedHyperK){
     geoFile << setw(8)<< 0;
@@ -208,9 +208,9 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
     
     geoFile.precision(9);
      geoFile << setw(4) << tubeID 
- 	    << " " << setw(8) << newTransform.getTranslation().getX()/cm
- 	    << " " << setw(8) << newTransform.getTranslation().getY()/cm
- 	    << " " << setw(8) << newTransform.getTranslation().getZ()/cm
+ 	    << " " << setw(8) << newTransform.getTranslation().getX()/CLHEP::cm
+ 	    << " " << setw(8) << newTransform.getTranslation().getY()/CLHEP::cm
+ 	    << " " << setw(8) << newTransform.getTranslation().getZ()/CLHEP::cm
 	    << " " << setw(7) << pmtOrientation.x()
 	    << " " << setw(7) << pmtOrientation.y()
 	    << " " << setw(7) << pmtOrientation.z()
@@ -218,9 +218,9 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
  	    << G4endl;
      
      WCSimPmtInfo *new_pmt = new WCSimPmtInfo(cylLocation,
-					      newTransform.getTranslation().getX()/cm,
-					      newTransform.getTranslation().getY()/cm,
-					      newTransform.getTranslation().getZ()/cm,
+					      newTransform.getTranslation().getX()/CLHEP::cm,
+					      newTransform.getTranslation().getY()/CLHEP::cm,
+					      newTransform.getTranslation().getZ()/CLHEP::cm,
 					      pmtOrientation.x(),
 					      pmtOrientation.y(),
 					      pmtOrientation.z(),

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -19,25 +19,25 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   //---Vacuum
 
-  density     = universe_mean_density;              //from PhysicalConstants.h
-  G4double pressure    = 1.e-19*pascal;
-  G4double temperature = 0.1*kelvin;
-  a = 1.01*g/mole;
+  density     = CLHEP::universe_mean_density;              //from PhysicalConstants.h
+  G4double pressure    = 1.e-19*CLHEP::pascal;
+  G4double temperature = 0.1*CLHEP::kelvin;
+  a = 1.01*CLHEP::g/CLHEP::mole;
   G4Material* Vacuum = 
     new G4Material("Vacuum", 1., a, density,
                    kStateGas,temperature,pressure);
 
   //---Water
   
-  a = 1.01*g/mole;
+  a = 1.01*CLHEP::g/CLHEP::mole;
   G4Element* elH 
     = new G4Element("Hydrogen","H", 1,a);
   
-  a = 16.00*g/mole;
+  a = 16.00*CLHEP::g/CLHEP::mole;
   G4Element* elO 
     = new G4Element("Oxygen","O", 8,a);
   
-  density = 1.00*g/cm3;
+  density = 1.00*CLHEP::g/CLHEP::cm3;
   G4Material* Water 
     = new G4Material("Water",density,2);
   Water->AddElement(elH, 2);
@@ -45,78 +45,78 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
  //---Gd doped Water
 
- a = 157.25*g/mole;
+ a = 157.25*CLHEP::g/CLHEP::mole;
  G4Element* Gd
     = new G4Element("Gadolinium","Gd", 64,a);
 
- density = 1.00*g/cm3;
+ density = 1.00*CLHEP::g/CLHEP::cm3;
  G4Material* DopedWater
     = new G4Material("Doped Water",density,2);
- DopedWater->AddMaterial(Water,99.9*perCent);
- DopedWater->AddElement(Gd,0.1*perCent);
+ DopedWater->AddMaterial(Water,99.9*CLHEP::perCent);
+ DopedWater->AddElement(Gd,0.1*CLHEP::perCent);
 
  //---Ice 
  
- density = 0.92*g/cm3;//Ice
+ density = 0.92*CLHEP::g/CLHEP::cm3;//Ice
  G4Material* Ice = new G4Material("Ice",density,2);
  Ice->AddElement(elH, 2);
  Ice->AddElement(elO, 1);
 
  //---Steel
   
-  a= 12.01*g/mole;
+  a= 12.01*CLHEP::g/CLHEP::mole;
   G4Element* elC 
     = new G4Element("Carbon","C", 6,a);
   
-  a = 55.85*g/mole;
+  a = 55.85*CLHEP::g/CLHEP::mole;
   G4Element* elFe
     = new G4Element("Iron","Fe", 26,a);
   
-  density = 7.8*g/cm3;
+  density = 7.8*CLHEP::g/CLHEP::cm3;
   G4Material* Steel
     = new G4Material("Steel",density,2);
-  Steel->AddElement(elC, 1.*perCent);
-  Steel->AddElement(elFe, 99.*perCent);
+  Steel->AddElement(elC, 1.*CLHEP::perCent);
+  Steel->AddElement(elFe, 99.*CLHEP::perCent);
   
   //---Stainless steel 304L (simple example, particular alloy can be different)
   
-  a = 51.9961*g/mole;
+  a = 51.9961*CLHEP::g/CLHEP::mole;
   G4Element* elCr = new G4Element("Chromium", "Cr", 24., a);
   
-  a = 58.6934*g/mole;
+  a = 58.6934*CLHEP::g/CLHEP::mole;
   G4Element* elNi = new G4Element("Nickel", "Ni", 28., a);
 
-  a = 54.938*g/mole;
+  a = 54.938*CLHEP::g/CLHEP::mole;
   G4Element* elMn = new G4Element("Manganese", "Mn", 25., a); 
 
-  a = 30.974*g/mole;
+  a = 30.974*CLHEP::g/CLHEP::mole;
   G4Element* elP = new G4Element("Phosphore", "P", 15., a);
 
-  a = 28.09*g/mole;
+  a = 28.09*CLHEP::g/CLHEP::mole;
   G4Element* elSi = new G4Element("Silicon", "Si", 14., a); 
 
-  a = 32.065*g/mole;
+  a = 32.065*CLHEP::g/CLHEP::mole;
   G4Element* elS = new G4Element("Sulphur", "S", 16., a);
 
-  density = 7.81*g/cm3;
+  density = 7.81*CLHEP::g/CLHEP::cm3;
   G4Material* StainlessSteel = new G4Material("StainlessSteel", density, 8);
  
-  StainlessSteel->AddElement(elFe, 70.44*perCent);
-  StainlessSteel->AddElement(elCr, 18*perCent);
-  StainlessSteel->AddElement(elC,  0.08*perCent);
-  StainlessSteel->AddElement(elNi, 8*perCent); 
-  StainlessSteel->AddElement(elP, 0.45*perCent);
-  StainlessSteel->AddElement(elSi,  1*perCent);
-  StainlessSteel->AddElement(elMn, 2*perCent);
-  StainlessSteel->AddElement(elS, 0.03*perCent);
+  StainlessSteel->AddElement(elFe, 70.44*CLHEP::perCent);
+  StainlessSteel->AddElement(elCr, 18*CLHEP::perCent);
+  StainlessSteel->AddElement(elC,  0.08*CLHEP::perCent);
+  StainlessSteel->AddElement(elNi, 8*CLHEP::perCent); 
+  StainlessSteel->AddElement(elP, 0.45*CLHEP::perCent);
+  StainlessSteel->AddElement(elSi,  1*CLHEP::perCent);
+  StainlessSteel->AddElement(elMn, 2*CLHEP::perCent);
+  StainlessSteel->AddElement(elS, 0.03*CLHEP::perCent);
   
   G4MaterialPropertiesTable *mpt = new G4MaterialPropertiesTable();
    
   const G4int nEntries = 2;
-  G4double photonEnergy[nEntries] = {1.*eV , 7.*eV};
+  G4double photonEnergy[nEntries] = {1.*CLHEP::eV , 7.*CLHEP::eV};
   
   //G4double rindex_Steel[nEntries] = {1.462 , 1.462}; // No I haven't gone mad
-  G4double abslength_Steel[nEntries] = {.001*mm , .001*mm};
+  G4double abslength_Steel[nEntries] = {.001*CLHEP::mm , .001*CLHEP::mm};
   //mpt->AddProperty("RINDEX", photonEnergy, rindex_Steel, nEntries);
   mpt->AddProperty("ABSLENGTH", photonEnergy, abslength_Steel, nEntries);
   
@@ -124,7 +124,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   //---Solid Dry Ice
 
-  density = 1.563*g/cm3;
+  density = 1.563*CLHEP::g/CLHEP::cm3;
   G4Material* DryIce = new G4Material("SolidDryIce", density, 2);
   DryIce->AddElement(elC, 1);
   DryIce->AddElement(elO, 2);
@@ -133,19 +133,19 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   //---Air
   
-  a = 14.01*g/mole;
+  a = 14.01*CLHEP::g/CLHEP::mole;
   G4Element* elN 
     = new G4Element("Nitrogen","N", 7,a);
   
-  density = 1.290*mg/cm3;
+  density = 1.290*CLHEP::mg/CLHEP::cm3;
   G4Material* Air 
     = new G4Material("Air",density,2);
-  Air->AddElement(elN, 70.*perCent);
-  Air->AddElement(elO, 30.*perCent);
+  Air->AddElement(elN, 70.*CLHEP::perCent);
+  Air->AddElement(elO, 30.*CLHEP::perCent);
   
   //---Plastic
   
-  density = 0.95*g/cm3;
+  density = 0.95*CLHEP::g/CLHEP::cm3;
   G4Material* Plastic
     = new G4Material("Plastic",density,2);
   Plastic->AddElement(elC, 1);
@@ -153,17 +153,17 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   //---Aluminum (element and material)
 
-  a = 26.98*g/mole;
+  a = 26.98*CLHEP::g/CLHEP::mole;
   G4Element* elAl = new G4Element("Aluminum", "Al", 13, a);  
 
-  density = 2.7*g/cm3;
+  density = 2.7*CLHEP::g/CLHEP::cm3;
   G4Material* Aluminum
     = new G4Material("Aluminum",density,1);
   Aluminum->AddElement(elAl, 1);
 
   //---Black sheet
 
-  density = 0.95*g/cm3;
+  density = 0.95*CLHEP::g/CLHEP::cm3;
   G4Material* Blacksheet
     = new G4Material("Blacksheet",density,2);
   Blacksheet->AddElement(elC, 1);
@@ -171,7 +171,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   //---Tyvek - jl145
 
-  density = 0.38*g/cm3;  //cf. DuPont product handbook
+  density = 0.38*CLHEP::g/CLHEP::cm3;  //cf. DuPont product handbook
   G4Material* Tyvek
     = new G4Material("Tyvek",density,2);
   Tyvek->AddElement(elC, 1);  //polyethylene
@@ -179,28 +179,28 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   //---Glass
  
-  density = 2.20*g/cm3;
+  density = 2.20*CLHEP::g/CLHEP::cm3;
   G4Material* SiO2 = new G4Material("SiO2",density,2);
   SiO2->AddElement(elSi, 1);
   SiO2->AddElement(elO , 2);
 
-  a = 10.81*g/mole;
+  a = 10.81*CLHEP::g/CLHEP::mole;
   G4Element* elB = new G4Element("Boron", "B", 5, a);  
 
-  density = 2.46*g/cm3;
+  density = 2.46*CLHEP::g/CLHEP::cm3;
   G4Material* B2O3 = new G4Material("B2O3",density,2);
   B2O3->AddElement(elB, 2);
   B2O3->AddElement(elO, 3);
 
-  a = 22.99*g/mole;
+  a = 22.99*CLHEP::g/CLHEP::mole;
   G4Element* elNa = new G4Element("Sodium", "Na", 11, a);  
 
-  density = 2.27*g/cm3;
+  density = 2.27*CLHEP::g/CLHEP::cm3;
   G4Material* Na2O = new G4Material("Na2O",density,2);
   Na2O->AddElement(elNa, 2);
   Na2O->AddElement(elO, 1);
 
-  density = 4.00*g/cm3;
+  density = 4.00*CLHEP::g/CLHEP::cm3;
   G4Material* Al2O3 = new G4Material("Al2O3",density,2);
   Al2O3->AddElement(elAl, 2);
   Al2O3->AddElement(elO, 3);
@@ -211,42 +211,42 @@ void WCSimDetectorConstruction::ConstructMaterials()
 //   blackAcryl -> AddElement(elC, 4);
 //   blackAcryl -> AddElement(elO, 2);
 
-  density = 2.23*g/cm3;
+  density = 2.23*CLHEP::g/CLHEP::cm3;
   G4Material* Glass
     = new G4Material("Glass",density,4);
   //G4Material* Glass
   //= new G4Material("Glass",density,8);  //Put in 8 materials later
   
-  Glass->AddMaterial(SiO2, 80.6*perCent);
-  Glass->AddMaterial(B2O3, 13.0*perCent);
-  Glass->AddMaterial(Na2O, 4.0*perCent);
-  Glass->AddMaterial(Al2O3, 2.4*perCent);
-  //Glass->AddMaterial(Al2O3, 2.3*perCent);  
+  Glass->AddMaterial(SiO2, 80.6*CLHEP::perCent);
+  Glass->AddMaterial(B2O3, 13.0*CLHEP::perCent);
+  Glass->AddMaterial(Na2O, 4.0*CLHEP::perCent);
+  Glass->AddMaterial(Al2O3, 2.4*CLHEP::perCent);
+  //Glass->AddMaterial(Al2O3, 2.3*CLHEP::perCent);  
   //Put in 2.3 percent if the other 4 materials = 0.1 percent
 
   //---Rock
  
-  //  a = 16.00*g/mole;  G4Element* elO  = new G4Element("Oxygen","O", 8,a);
-  //  a = 28.09*g/mole;  G4Element* elSi = new G4Element("Silicon", "Si", 14., a); 
-  //  a = 26.98*g/mole;  G4Element* elAl = new G4Element("Aluminum", "Al", 13, a);  
-  //  a = 55.85*g/mole;  G4Element* elFe = new G4Element("Iron","Fe", 26,a);
-  a = 40.08*g/mole;  G4Element* elCa = new G4Element("Calcium","Ca", 20,a);
-  //  a = 22.99*g/mole;  G4Element* elNa = new G4Element("Sodium", "Na", 11, a);  
-  a = 39.10*g/mole;  G4Element* elK = new G4Element("Potassium","K", 19,a);
-  a = 24.30*g/mole;  G4Element* elMg = new G4Element("Magnesium","Mg",12,a);
+  //  a = 16.00*CLHEP::g/CLHEP::mole;  G4Element* elO  = new G4Element("Oxygen","O", 8,a);
+  //  a = 28.09*CLHEP::g/CLHEP::mole;  G4Element* elSi = new G4Element("Silicon", "Si", 14., a); 
+  //  a = 26.98*CLHEP::g/CLHEP::mole;  G4Element* elAl = new G4Element("Aluminum", "Al", 13, a);  
+  //  a = 55.85*CLHEP::g/CLHEP::mole;  G4Element* elFe = new G4Element("Iron","Fe", 26,a);
+  a = 40.08*CLHEP::g/CLHEP::mole;  G4Element* elCa = new G4Element("Calcium","Ca", 20,a);
+  //  a = 22.99*CLHEP::g/CLHEP::mole;  G4Element* elNa = new G4Element("Sodium", "Na", 11, a);  
+  a = 39.10*CLHEP::g/CLHEP::mole;  G4Element* elK = new G4Element("Potassium","K", 19,a);
+  a = 24.30*CLHEP::g/CLHEP::mole;  G4Element* elMg = new G4Element("Magnesium","Mg",12,a);
  
-  density = 2.7*g/cm3; 
+  density = 2.7*CLHEP::g/CLHEP::cm3; 
   G4Material* Rock = new G4Material("Rock", density, 8);
   
   //From Daya-Bay 
-  Rock->AddElement(elO,  48.50*perCent);
-  Rock->AddElement(elSi, 34.30*perCent);
-  Rock->AddElement(elAl,  8.00*perCent);
-  Rock->AddElement(elFe,  2.00*perCent);
-  Rock->AddElement(elCa,  0.20*perCent);
-  Rock->AddElement(elNa,  2.40*perCent);
-  Rock->AddElement(elK,   4.50*perCent);
-  Rock->AddElement(elMg,  0.10*perCent);
+  Rock->AddElement(elO,  48.50*CLHEP::perCent);
+  Rock->AddElement(elSi, 34.30*CLHEP::perCent);
+  Rock->AddElement(elAl,  8.00*CLHEP::perCent);
+  Rock->AddElement(elFe,  2.00*CLHEP::perCent);
+  Rock->AddElement(elCa,  0.20*CLHEP::perCent);
+  Rock->AddElement(elNa,  2.40*CLHEP::perCent);
+  Rock->AddElement(elK,   4.50*CLHEP::perCent);
+  Rock->AddElement(elMg,  0.10*CLHEP::perCent);
 
 
 
@@ -273,14 +273,14 @@ void WCSimDetectorConstruction::ConstructMaterials()
   const G4int NUMENTRIES = 32;
  
   G4double PPCKOV[NUMENTRIES] =
-    { 2.034E-9*GeV, 2.068E-9*GeV, 2.103E-9*GeV, 2.139E-9*GeV,
-      2.177E-9*GeV, 2.216E-9*GeV, 2.256E-9*GeV, 2.298E-9*GeV,
-      2.341E-9*GeV, 2.386E-9*GeV, 2.433E-9*GeV, 2.481E-9*GeV,
-      2.532E-9*GeV, 2.585E-9*GeV, 2.640E-9*GeV, 2.697E-9*GeV,
-      2.757E-9*GeV, 2.820E-9*GeV, 2.885E-9*GeV, 2.954E-9*GeV,
-      3.026E-9*GeV, 3.102E-9*GeV, 3.181E-9*GeV, 3.265E-9*GeV,
-      3.353E-9*GeV, 3.446E-9*GeV, 3.545E-9*GeV, 3.649E-9*GeV,
-      3.760E-9*GeV, 3.877E-9*GeV, 4.002E-9*GeV, 4.136E-9*GeV };
+    { 2.034E-9*CLHEP::GeV, 2.068E-9*CLHEP::GeV, 2.103E-9*CLHEP::GeV, 2.139E-9*CLHEP::GeV,
+      2.177E-9*CLHEP::GeV, 2.216E-9*CLHEP::GeV, 2.256E-9*CLHEP::GeV, 2.298E-9*CLHEP::GeV,
+      2.341E-9*CLHEP::GeV, 2.386E-9*CLHEP::GeV, 2.433E-9*CLHEP::GeV, 2.481E-9*CLHEP::GeV,
+      2.532E-9*CLHEP::GeV, 2.585E-9*CLHEP::GeV, 2.640E-9*CLHEP::GeV, 2.697E-9*CLHEP::GeV,
+      2.757E-9*CLHEP::GeV, 2.820E-9*CLHEP::GeV, 2.885E-9*CLHEP::GeV, 2.954E-9*CLHEP::GeV,
+      3.026E-9*CLHEP::GeV, 3.102E-9*CLHEP::GeV, 3.181E-9*CLHEP::GeV, 3.265E-9*CLHEP::GeV,
+      3.353E-9*CLHEP::GeV, 3.446E-9*CLHEP::GeV, 3.545E-9*CLHEP::GeV, 3.649E-9*CLHEP::GeV,
+      3.760E-9*CLHEP::GeV, 3.877E-9*CLHEP::GeV, 4.002E-9*CLHEP::GeV, 4.136E-9*CLHEP::GeV };
 
 
   // default values
@@ -309,21 +309,21 @@ void WCSimDetectorConstruction::ConstructMaterials()
    const G4int NUMENTRIES_water=60;
 
    G4double ENERGY_water[NUMENTRIES_water] =
-     { 1.56962e-09*GeV, 1.58974e-09*GeV, 1.61039e-09*GeV, 1.63157e-09*GeV, 
-       1.65333e-09*GeV, 1.67567e-09*GeV, 1.69863e-09*GeV, 1.72222e-09*GeV, 
-       1.74647e-09*GeV, 1.77142e-09*GeV,1.7971e-09*GeV, 1.82352e-09*GeV, 
-       1.85074e-09*GeV, 1.87878e-09*GeV, 1.90769e-09*GeV, 1.93749e-09*GeV, 
-       1.96825e-09*GeV, 1.99999e-09*GeV, 2.03278e-09*GeV, 2.06666e-09*GeV,
-       2.10169e-09*GeV, 2.13793e-09*GeV, 2.17543e-09*GeV, 2.21428e-09*GeV, 
-       2.25454e-09*GeV, 2.29629e-09*GeV, 2.33962e-09*GeV, 2.38461e-09*GeV, 
-       2.43137e-09*GeV, 2.47999e-09*GeV, 2.53061e-09*GeV, 2.58333e-09*GeV, 
-       2.63829e-09*GeV, 2.69565e-09*GeV, 2.75555e-09*GeV, 2.81817e-09*GeV, 
-       2.88371e-09*GeV, 2.95237e-09*GeV, 3.02438e-09*GeV, 3.09999e-09*GeV,
-       3.17948e-09*GeV, 3.26315e-09*GeV, 3.35134e-09*GeV, 3.44444e-09*GeV, 
-       3.54285e-09*GeV, 3.64705e-09*GeV, 3.75757e-09*GeV, 3.87499e-09*GeV, 
-       3.99999e-09*GeV, 4.13332e-09*GeV, 4.27585e-09*GeV, 4.42856e-09*GeV, 
-       4.59258e-09*GeV, 4.76922e-09*GeV, 4.95999e-09*GeV, 5.16665e-09*GeV, 
-       5.39129e-09*GeV, 5.63635e-09*GeV, 5.90475e-09*GeV, 6.19998e-09*GeV };
+     { 1.56962e-09*CLHEP::GeV, 1.58974e-09*CLHEP::GeV, 1.61039e-09*CLHEP::GeV, 1.63157e-09*CLHEP::GeV, 
+       1.65333e-09*CLHEP::GeV, 1.67567e-09*CLHEP::GeV, 1.69863e-09*CLHEP::GeV, 1.72222e-09*CLHEP::GeV, 
+       1.74647e-09*CLHEP::GeV, 1.77142e-09*CLHEP::GeV,1.7971e-09*CLHEP::GeV, 1.82352e-09*CLHEP::GeV, 
+       1.85074e-09*CLHEP::GeV, 1.87878e-09*CLHEP::GeV, 1.90769e-09*CLHEP::GeV, 1.93749e-09*CLHEP::GeV, 
+       1.96825e-09*CLHEP::GeV, 1.99999e-09*CLHEP::GeV, 2.03278e-09*CLHEP::GeV, 2.06666e-09*CLHEP::GeV,
+       2.10169e-09*CLHEP::GeV, 2.13793e-09*CLHEP::GeV, 2.17543e-09*CLHEP::GeV, 2.21428e-09*CLHEP::GeV, 
+       2.25454e-09*CLHEP::GeV, 2.29629e-09*CLHEP::GeV, 2.33962e-09*CLHEP::GeV, 2.38461e-09*CLHEP::GeV, 
+       2.43137e-09*CLHEP::GeV, 2.47999e-09*CLHEP::GeV, 2.53061e-09*CLHEP::GeV, 2.58333e-09*CLHEP::GeV, 
+       2.63829e-09*CLHEP::GeV, 2.69565e-09*CLHEP::GeV, 2.75555e-09*CLHEP::GeV, 2.81817e-09*CLHEP::GeV, 
+       2.88371e-09*CLHEP::GeV, 2.95237e-09*CLHEP::GeV, 3.02438e-09*CLHEP::GeV, 3.09999e-09*CLHEP::GeV,
+       3.17948e-09*CLHEP::GeV, 3.26315e-09*CLHEP::GeV, 3.35134e-09*CLHEP::GeV, 3.44444e-09*CLHEP::GeV, 
+       3.54285e-09*CLHEP::GeV, 3.64705e-09*CLHEP::GeV, 3.75757e-09*CLHEP::GeV, 3.87499e-09*CLHEP::GeV, 
+       3.99999e-09*CLHEP::GeV, 4.13332e-09*CLHEP::GeV, 4.27585e-09*CLHEP::GeV, 4.42856e-09*CLHEP::GeV, 
+       4.59258e-09*CLHEP::GeV, 4.76922e-09*CLHEP::GeV, 4.95999e-09*CLHEP::GeV, 5.16665e-09*CLHEP::GeV, 
+       5.39129e-09*CLHEP::GeV, 5.63635e-09*CLHEP::GeV, 5.90475e-09*CLHEP::GeV, 6.19998e-09*CLHEP::GeV };
 
 
 
@@ -362,65 +362,65 @@ void WCSimDetectorConstruction::ConstructMaterials()
     //T. Akiri: Values from Skdetsim 
     G4double ABSORPTION_water[NUMENTRIES_water] =
       {
-        16.1419*cm*ABWFF,  18.278*cm*ABWFF, 21.0657*cm*ABWFF, 24.8568*cm*ABWFF, 30.3117*cm*ABWFF, 
-	38.8341*cm*ABWFF, 54.0231*cm*ABWFF, 81.2306*cm*ABWFF, 120.909*cm*ABWFF, 160.238*cm*ABWFF, 
-	193.771*cm*ABWFF, 215.017*cm*ABWFF, 227.747*cm*ABWFF,  243.85*cm*ABWFF, 294.036*cm*ABWFF, 
-	321.647*cm*ABWFF,  342.81*cm*ABWFF, 362.827*cm*ABWFF, 378.041*cm*ABWFF, 449.378*cm*ABWFF,
-        739.434*cm*ABWFF, 1114.23*cm*ABWFF, 1435.56*cm*ABWFF, 1611.06*cm*ABWFF, 1764.18*cm*ABWFF, 
-	2100.95*cm*ABWFF,  2292.9*cm*ABWFF, 2431.33*cm*ABWFF,  3053.6*cm*ABWFF, 4838.23*cm*ABWFF, 
-	6539.65*cm*ABWFF, 7682.63*cm*ABWFF, 9137.28*cm*ABWFF, 12220.9*cm*ABWFF, 15270.7*cm*ABWFF, 
-	19051.5*cm*ABWFF, 23671.3*cm*ABWFF, 29191.1*cm*ABWFF, 35567.9*cm*ABWFF,   42583*cm*ABWFF,
-        49779.6*cm*ABWFF, 56465.3*cm*ABWFF,   61830*cm*ABWFF, 65174.6*cm*ABWFF, 66143.7*cm*ABWFF,   
-	  64820*cm*ABWFF,   61635*cm*ABWFF, 57176.2*cm*ABWFF, 52012.1*cm*ABWFF, 46595.7*cm*ABWFF, 
-	41242.1*cm*ABWFF, 36146.3*cm*ABWFF, 31415.4*cm*ABWFF, 27097.8*cm*ABWFF, 23205.7*cm*ABWFF, 
-	19730.3*cm*ABWFF, 16651.6*cm*ABWFF, 13943.6*cm*ABWFF, 11578.1*cm*ABWFF, 9526.13*cm*ABWFF
+        16.1419*CLHEP::cm*ABWFF,  18.278*CLHEP::cm*ABWFF, 21.0657*CLHEP::cm*ABWFF, 24.8568*CLHEP::cm*ABWFF, 30.3117*CLHEP::cm*ABWFF, 
+	38.8341*CLHEP::cm*ABWFF, 54.0231*CLHEP::cm*ABWFF, 81.2306*CLHEP::cm*ABWFF, 120.909*CLHEP::cm*ABWFF, 160.238*CLHEP::cm*ABWFF, 
+	193.771*CLHEP::cm*ABWFF, 215.017*CLHEP::cm*ABWFF, 227.747*CLHEP::cm*ABWFF,  243.85*CLHEP::cm*ABWFF, 294.036*CLHEP::cm*ABWFF, 
+	321.647*CLHEP::cm*ABWFF,  342.81*CLHEP::cm*ABWFF, 362.827*CLHEP::cm*ABWFF, 378.041*CLHEP::cm*ABWFF, 449.378*CLHEP::cm*ABWFF,
+        739.434*CLHEP::cm*ABWFF, 1114.23*CLHEP::cm*ABWFF, 1435.56*CLHEP::cm*ABWFF, 1611.06*CLHEP::cm*ABWFF, 1764.18*CLHEP::cm*ABWFF, 
+	2100.95*CLHEP::cm*ABWFF,  2292.9*CLHEP::cm*ABWFF, 2431.33*CLHEP::cm*ABWFF,  3053.6*CLHEP::cm*ABWFF, 4838.23*CLHEP::cm*ABWFF, 
+	6539.65*CLHEP::cm*ABWFF, 7682.63*CLHEP::cm*ABWFF, 9137.28*CLHEP::cm*ABWFF, 12220.9*CLHEP::cm*ABWFF, 15270.7*CLHEP::cm*ABWFF, 
+	19051.5*CLHEP::cm*ABWFF, 23671.3*CLHEP::cm*ABWFF, 29191.1*CLHEP::cm*ABWFF, 35567.9*CLHEP::cm*ABWFF,   42583*CLHEP::cm*ABWFF,
+        49779.6*CLHEP::cm*ABWFF, 56465.3*CLHEP::cm*ABWFF,   61830*CLHEP::cm*ABWFF, 65174.6*CLHEP::cm*ABWFF, 66143.7*CLHEP::cm*ABWFF,   
+	  64820*CLHEP::cm*ABWFF,   61635*CLHEP::cm*ABWFF, 57176.2*CLHEP::cm*ABWFF, 52012.1*CLHEP::cm*ABWFF, 46595.7*CLHEP::cm*ABWFF, 
+	41242.1*CLHEP::cm*ABWFF, 36146.3*CLHEP::cm*ABWFF, 31415.4*CLHEP::cm*ABWFF, 27097.8*CLHEP::cm*ABWFF, 23205.7*CLHEP::cm*ABWFF, 
+	19730.3*CLHEP::cm*ABWFF, 16651.6*CLHEP::cm*ABWFF, 13943.6*CLHEP::cm*ABWFF, 11578.1*CLHEP::cm*ABWFF, 9526.13*CLHEP::cm*ABWFF
       };
 
     //Xin Qian: proposed value for absorption length
     // G4double ABSORPTION_water[NUMENTRIES_water] =
-//       {22.8154*cm*ABWFF, 28.6144*cm*ABWFF, 35.9923*cm*ABWFF, 45.4086*cm*ABWFF, 57.4650*cm*ABWFF,
-//        72.9526*cm*ABWFF, 75*cm*ABWFF,      81.2317*cm*ABWFF, 120.901*cm*ABWFF, 160.243*cm*ABWFF,
-//        193.797*cm*ABWFF, 215.045*cm*ABWFF, 227.786*cm*ABWFF, 243.893*cm*ABWFF, 294.113*cm*ABWFF,
-//        321.735*cm*ABWFF, 342.931*cm*ABWFF, 362.967*cm*ABWFF, 378.212*cm*ABWFF, 449.602*cm*ABWFF,
-//        740.143*cm*ABWFF, 1116.06*cm*ABWFF, 1438.78*cm*ABWFF, 1615.48*cm*ABWFF, 1769.86*cm*ABWFF,
-//        2109.67*cm*ABWFF, 2304.13*cm*ABWFF, 2444.97*cm*ABWFF, 3076.83*cm*ABWFF, 4901.5*cm*ABWFF,
-//        6666.57*cm*ABWFF, 7873.95*cm*ABWFF, 9433.81*cm*ABWFF, 10214.5*cm*ABWFF, 10845.8*cm*ABWFF,
-//        15746.9*cm*ABWFF, 20201.8*cm*ABWFF, 22025.8*cm*ABWFF, 21142.2*cm*ABWFF, 15083.9*cm*ABWFF,
-//        11751*cm*ABWFF,   8795.34*cm*ABWFF, 8741.23*cm*ABWFF, 7102.37*cm*ABWFF, 6060.68*cm*ABWFF,
-//        4498.56*cm*ABWFF, 3039.56*cm*ABWFF, 2232.2*cm*ABWFF,  1938*cm*ABWFF,    1811.58*cm*ABWFF,
-//        1610.32*cm*ABWFF, 1338.7*cm*ABWFF,  1095.3*cm*ABWFF,  977.525*cm*ABWFF, 965.258*cm*ABWFF,
-//        1082.86*cm*ABWFF, 876.434*cm*ABWFF, 633.723*cm*ABWFF, 389.87*cm*ABWFF,  142.011*cm*ABWFF
+//       {22.8154*CLHEP::cm*ABWFF, 28.6144*CLHEP::cm*ABWFF, 35.9923*CLHEP::cm*ABWFF, 45.4086*CLHEP::cm*ABWFF, 57.4650*CLHEP::cm*ABWFF,
+//        72.9526*CLHEP::cm*ABWFF, 75*CLHEP::cm*ABWFF,      81.2317*CLHEP::cm*ABWFF, 120.901*CLHEP::cm*ABWFF, 160.243*CLHEP::cm*ABWFF,
+//        193.797*CLHEP::cm*ABWFF, 215.045*CLHEP::cm*ABWFF, 227.786*CLHEP::cm*ABWFF, 243.893*CLHEP::cm*ABWFF, 294.113*CLHEP::cm*ABWFF,
+//        321.735*CLHEP::cm*ABWFF, 342.931*CLHEP::cm*ABWFF, 362.967*CLHEP::cm*ABWFF, 378.212*CLHEP::cm*ABWFF, 449.602*CLHEP::cm*ABWFF,
+//        740.143*CLHEP::cm*ABWFF, 1116.06*CLHEP::cm*ABWFF, 1438.78*CLHEP::cm*ABWFF, 1615.48*CLHEP::cm*ABWFF, 1769.86*CLHEP::cm*ABWFF,
+//        2109.67*CLHEP::cm*ABWFF, 2304.13*CLHEP::cm*ABWFF, 2444.97*CLHEP::cm*ABWFF, 3076.83*CLHEP::cm*ABWFF, 4901.5*CLHEP::cm*ABWFF,
+//        6666.57*CLHEP::cm*ABWFF, 7873.95*CLHEP::cm*ABWFF, 9433.81*CLHEP::cm*ABWFF, 10214.5*CLHEP::cm*ABWFF, 10845.8*CLHEP::cm*ABWFF,
+//        15746.9*CLHEP::cm*ABWFF, 20201.8*CLHEP::cm*ABWFF, 22025.8*CLHEP::cm*ABWFF, 21142.2*CLHEP::cm*ABWFF, 15083.9*CLHEP::cm*ABWFF,
+//        11751*CLHEP::cm*ABWFF,   8795.34*CLHEP::cm*ABWFF, 8741.23*CLHEP::cm*ABWFF, 7102.37*CLHEP::cm*ABWFF, 6060.68*CLHEP::cm*ABWFF,
+//        4498.56*CLHEP::cm*ABWFF, 3039.56*CLHEP::cm*ABWFF, 2232.2*CLHEP::cm*ABWFF,  1938*CLHEP::cm*ABWFF,    1811.58*CLHEP::cm*ABWFF,
+//        1610.32*CLHEP::cm*ABWFF, 1338.7*CLHEP::cm*ABWFF,  1095.3*CLHEP::cm*ABWFF,  977.525*CLHEP::cm*ABWFF, 965.258*CLHEP::cm*ABWFF,
+//        1082.86*CLHEP::cm*ABWFF, 876.434*CLHEP::cm*ABWFF, 633.723*CLHEP::cm*ABWFF, 389.87*CLHEP::cm*ABWFF,  142.011*CLHEP::cm*ABWFF
 //       };
 
     /*G4double ABSORPTION_water[NUMENTRIES_water] = //old
-     { 22.8154*cm*ABWFF, 28.6144*cm*ABWFF, 35.9923*cm*ABWFF, 45.4086*cm*ABWFF, 57.4650*cm*ABWFF,
-       72.9526*cm*ABWFF, 92.9156*cm*ABWFF, 118.737*cm*ABWFF, 152.255*cm*ABWFF, 195.925*cm*ABWFF,
-       202.429*cm*ABWFF, 224.719*cm*ABWFF, 236.407*cm*ABWFF, 245.700*cm*ABWFF, 289.017*cm*ABWFF,
-       305.810*cm*ABWFF, 316.456*cm*ABWFF, 326.797*cm*ABWFF, 347.222*cm*ABWFF, 414.938*cm*ABWFF,
-       636.943*cm*ABWFF, 934.579*cm*ABWFF, 1245.33*cm*ABWFF, 1402.52*cm*ABWFF, 1550.39*cm*ABWFF,
-       1745.20*cm*ABWFF, 1883.24*cm*ABWFF, 2016.13*cm*ABWFF, 2442.18*cm*ABWFF, 3831.28*cm*ABWFF,
-       4652.89*cm*ABWFF, 5577.04*cm*ABWFF, 6567.08*cm*ABWFF, 7559.88*cm*ABWFF, 8470.06*cm*ABWFF,
-       9205.54*cm*ABWFF, 9690.95*cm*ABWFF, 9888.36*cm*ABWFF, 9804.50*cm*ABWFF, 9482.17*cm*ABWFF,
-       8982.77*cm*ABWFF, 8369.39*cm*ABWFF, 7680.31*cm*ABWFF, 6902.11*cm*ABWFF, 6183.84*cm*ABWFF,
-       5522.27*cm*ABWFF, 4914.33*cm*ABWFF, 4357.09*cm*ABWFF, 3847.72*cm*ABWFF, 3383.51*cm*ABWFF,
-       2961.81*cm*ABWFF, 2580.08*cm*ABWFF, 2235.83*cm*ABWFF, 1926.66*cm*ABWFF, 1650.21*cm*ABWFF,
-       1404.21*cm*ABWFF, 1186.44*cm*ABWFF, 994.742*cm*ABWFF, 827.027*cm*ABWFF, 681.278*cm*ABWFF};
+     { 22.8154*CLHEP::cm*ABWFF, 28.6144*CLHEP::cm*ABWFF, 35.9923*CLHEP::cm*ABWFF, 45.4086*CLHEP::cm*ABWFF, 57.4650*CLHEP::cm*ABWFF,
+       72.9526*CLHEP::cm*ABWFF, 92.9156*CLHEP::cm*ABWFF, 118.737*CLHEP::cm*ABWFF, 152.255*CLHEP::cm*ABWFF, 195.925*CLHEP::cm*ABWFF,
+       202.429*CLHEP::cm*ABWFF, 224.719*CLHEP::cm*ABWFF, 236.407*CLHEP::cm*ABWFF, 245.700*CLHEP::cm*ABWFF, 289.017*CLHEP::cm*ABWFF,
+       305.810*CLHEP::cm*ABWFF, 316.456*CLHEP::cm*ABWFF, 326.797*CLHEP::cm*ABWFF, 347.222*CLHEP::cm*ABWFF, 414.938*CLHEP::cm*ABWFF,
+       636.943*CLHEP::cm*ABWFF, 934.579*CLHEP::cm*ABWFF, 1245.33*CLHEP::cm*ABWFF, 1402.52*CLHEP::cm*ABWFF, 1550.39*CLHEP::cm*ABWFF,
+       1745.20*CLHEP::cm*ABWFF, 1883.24*CLHEP::cm*ABWFF, 2016.13*CLHEP::cm*ABWFF, 2442.18*CLHEP::cm*ABWFF, 3831.28*CLHEP::cm*ABWFF,
+       4652.89*CLHEP::cm*ABWFF, 5577.04*CLHEP::cm*ABWFF, 6567.08*CLHEP::cm*ABWFF, 7559.88*CLHEP::cm*ABWFF, 8470.06*CLHEP::cm*ABWFF,
+       9205.54*CLHEP::cm*ABWFF, 9690.95*CLHEP::cm*ABWFF, 9888.36*CLHEP::cm*ABWFF, 9804.50*CLHEP::cm*ABWFF, 9482.17*CLHEP::cm*ABWFF,
+       8982.77*CLHEP::cm*ABWFF, 8369.39*CLHEP::cm*ABWFF, 7680.31*CLHEP::cm*ABWFF, 6902.11*CLHEP::cm*ABWFF, 6183.84*CLHEP::cm*ABWFF,
+       5522.27*CLHEP::cm*ABWFF, 4914.33*CLHEP::cm*ABWFF, 4357.09*CLHEP::cm*ABWFF, 3847.72*CLHEP::cm*ABWFF, 3383.51*CLHEP::cm*ABWFF,
+       2961.81*CLHEP::cm*ABWFF, 2580.08*CLHEP::cm*ABWFF, 2235.83*CLHEP::cm*ABWFF, 1926.66*CLHEP::cm*ABWFF, 1650.21*CLHEP::cm*ABWFF,
+       1404.21*CLHEP::cm*ABWFF, 1186.44*CLHEP::cm*ABWFF, 994.742*CLHEP::cm*ABWFF, 827.027*CLHEP::cm*ABWFF, 681.278*CLHEP::cm*ABWFF};
     */
     
     /*
    G4double ABSORPTION_water[NUMENTRIES_water] = //new
-     {25.3504*cm, 31.7938*cm, 39.9915*cm, 50.454*cm, 63.85*cm, 
-      81.0584*cm, 103.24*cm, 131.93*cm, 169.172*cm, 217.694*cm, 
-      224.921*cm, 249.688*cm, 262.674*cm, 273*cm, 321.13*cm, 339.789*cm,
-      351.617*cm, 363.108*cm, 385.802*cm, 461.042*cm, 707.714*cm, 
-      1038.42*cm, 1383.7*cm, 1558.36*cm, 1722.65*cm, 1939.11*cm, 
-      2092.49*cm, 2240.14*cm, 2962.96*cm, 4967.03*cm, 6368.58*cm, 
-      8207.56*cm, 10634.2*cm, 13855.3*cm, 18157.3*cm, 23940.2*cm, 
-      31766*cm, 42431.6*cm, 57074.9*cm, 77335.9*cm, 105598*cm, 
-      145361*cm, 192434*cm, 183898*cm, 176087*cm, 168913*cm, 162301*cm, 
-      156187*cm, 150516*cm, 145243*cm, 140327*cm, 135733*cm, 131430*cm, 
-      127392*cm, 123594*cm, 120016*cm, 116640*cm, 113448*cm, 110426*cm, 
-      107562*cm};
+     {25.3504*CLHEP::cm, 31.7938*CLHEP::cm, 39.9915*CLHEP::cm, 50.454*CLHEP::cm, 63.85*CLHEP::cm, 
+      81.0584*CLHEP::cm, 103.24*CLHEP::cm, 131.93*CLHEP::cm, 169.172*CLHEP::cm, 217.694*CLHEP::cm, 
+      224.921*CLHEP::cm, 249.688*CLHEP::cm, 262.674*CLHEP::cm, 273*CLHEP::cm, 321.13*CLHEP::cm, 339.789*CLHEP::cm,
+      351.617*CLHEP::cm, 363.108*CLHEP::cm, 385.802*CLHEP::cm, 461.042*CLHEP::cm, 707.714*CLHEP::cm, 
+      1038.42*CLHEP::cm, 1383.7*CLHEP::cm, 1558.36*CLHEP::cm, 1722.65*CLHEP::cm, 1939.11*CLHEP::cm, 
+      2092.49*CLHEP::cm, 2240.14*CLHEP::cm, 2962.96*CLHEP::cm, 4967.03*CLHEP::cm, 6368.58*CLHEP::cm, 
+      8207.56*CLHEP::cm, 10634.2*CLHEP::cm, 13855.3*CLHEP::cm, 18157.3*CLHEP::cm, 23940.2*CLHEP::cm, 
+      31766*CLHEP::cm, 42431.6*CLHEP::cm, 57074.9*CLHEP::cm, 77335.9*CLHEP::cm, 105598*CLHEP::cm, 
+      145361*CLHEP::cm, 192434*CLHEP::cm, 183898*CLHEP::cm, 176087*CLHEP::cm, 168913*CLHEP::cm, 162301*CLHEP::cm, 
+      156187*CLHEP::cm, 150516*CLHEP::cm, 145243*CLHEP::cm, 140327*CLHEP::cm, 135733*CLHEP::cm, 131430*CLHEP::cm, 
+      127392*CLHEP::cm, 123594*CLHEP::cm, 120016*CLHEP::cm, 116640*CLHEP::cm, 113448*CLHEP::cm, 110426*CLHEP::cm, 
+      107562*CLHEP::cm};
   */
    // M Fechner: Rayleigh scattering -- as of version 4.6.2 of GEANT,
    // one may use one's own Rayleigh scattering lengths (the buffer is no
@@ -446,41 +446,41 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
    //T. Akiri: Values from Skdetsim 
    G4double RAYLEIGH_water[NUMENTRIES_water] = {
-      386929*cm*RAYFF,  366249*cm*RAYFF,  346398*cm*RAYFF,  327355*cm*RAYFF,  309097*cm*RAYFF,  
-      291603*cm*RAYFF,  274853*cm*RAYFF,  258825*cm*RAYFF,  243500*cm*RAYFF,  228856*cm*RAYFF,  
-      214873*cm*RAYFF,  201533*cm*RAYFF,  188816*cm*RAYFF,  176702*cm*RAYFF,  165173*cm*RAYFF,
-      154210*cm*RAYFF,  143795*cm*RAYFF,  133910*cm*RAYFF,  124537*cm*RAYFF,  115659*cm*RAYFF,  
-      107258*cm*RAYFF, 99318.2*cm*RAYFF, 91822.2*cm*RAYFF,   84754*cm*RAYFF, 78097.3*cm*RAYFF, 
-     71836.5*cm*RAYFF,   65956*cm*RAYFF, 60440.6*cm*RAYFF, 55275.4*cm*RAYFF, 50445.6*cm*RAYFF,
-       45937*cm*RAYFF, 41735.2*cm*RAYFF, 37826.6*cm*RAYFF, 34197.6*cm*RAYFF, 30834.9*cm*RAYFF, 
-     27725.4*cm*RAYFF, 24856.6*cm*RAYFF, 22215.9*cm*RAYFF, 19791.3*cm*RAYFF, 17570.9*cm*RAYFF,   
-       15543*cm*RAYFF, 13696.6*cm*RAYFF, 12020.5*cm*RAYFF, 10504.1*cm*RAYFF, 9137.15*cm*RAYFF,
-     7909.45*cm*RAYFF,  6811.3*cm*RAYFF, 5833.25*cm*RAYFF,  4966.2*cm*RAYFF, 4201.36*cm*RAYFF, 
-     3530.28*cm*RAYFF, 2944.84*cm*RAYFF, 2437.28*cm*RAYFF, 2000.18*cm*RAYFF,  1626.5*cm*RAYFF, 
-     1309.55*cm*RAYFF, 1043.03*cm*RAYFF, 821.016*cm*RAYFF,  637.97*cm*RAYFF, 488.754*cm*RAYFF
+      386929*CLHEP::cm*RAYFF,  366249*CLHEP::cm*RAYFF,  346398*CLHEP::cm*RAYFF,  327355*CLHEP::cm*RAYFF,  309097*CLHEP::cm*RAYFF,  
+      291603*CLHEP::cm*RAYFF,  274853*CLHEP::cm*RAYFF,  258825*CLHEP::cm*RAYFF,  243500*CLHEP::cm*RAYFF,  228856*CLHEP::cm*RAYFF,  
+      214873*CLHEP::cm*RAYFF,  201533*CLHEP::cm*RAYFF,  188816*CLHEP::cm*RAYFF,  176702*CLHEP::cm*RAYFF,  165173*CLHEP::cm*RAYFF,
+      154210*CLHEP::cm*RAYFF,  143795*CLHEP::cm*RAYFF,  133910*CLHEP::cm*RAYFF,  124537*CLHEP::cm*RAYFF,  115659*CLHEP::cm*RAYFF,  
+      107258*CLHEP::cm*RAYFF, 99318.2*CLHEP::cm*RAYFF, 91822.2*CLHEP::cm*RAYFF,   84754*CLHEP::cm*RAYFF, 78097.3*CLHEP::cm*RAYFF, 
+     71836.5*CLHEP::cm*RAYFF,   65956*CLHEP::cm*RAYFF, 60440.6*CLHEP::cm*RAYFF, 55275.4*CLHEP::cm*RAYFF, 50445.6*CLHEP::cm*RAYFF,
+       45937*CLHEP::cm*RAYFF, 41735.2*CLHEP::cm*RAYFF, 37826.6*CLHEP::cm*RAYFF, 34197.6*CLHEP::cm*RAYFF, 30834.9*CLHEP::cm*RAYFF, 
+     27725.4*CLHEP::cm*RAYFF, 24856.6*CLHEP::cm*RAYFF, 22215.9*CLHEP::cm*RAYFF, 19791.3*CLHEP::cm*RAYFF, 17570.9*CLHEP::cm*RAYFF,   
+       15543*CLHEP::cm*RAYFF, 13696.6*CLHEP::cm*RAYFF, 12020.5*CLHEP::cm*RAYFF, 10504.1*CLHEP::cm*RAYFF, 9137.15*CLHEP::cm*RAYFF,
+     7909.45*CLHEP::cm*RAYFF,  6811.3*CLHEP::cm*RAYFF, 5833.25*CLHEP::cm*RAYFF,  4966.2*CLHEP::cm*RAYFF, 4201.36*CLHEP::cm*RAYFF, 
+     3530.28*CLHEP::cm*RAYFF, 2944.84*CLHEP::cm*RAYFF, 2437.28*CLHEP::cm*RAYFF, 2000.18*CLHEP::cm*RAYFF,  1626.5*CLHEP::cm*RAYFF, 
+     1309.55*CLHEP::cm*RAYFF, 1043.03*CLHEP::cm*RAYFF, 821.016*CLHEP::cm*RAYFF,  637.97*CLHEP::cm*RAYFF, 488.754*CLHEP::cm*RAYFF
    };
 
    /*G4double RAYLEIGH_water[NUMENTRIES_water] = {
-     167024.4*cm*RAYFF, 158726.7*cm*RAYFF, 150742*cm*RAYFF,
-     143062.5*cm*RAYFF, 135680.2*cm*RAYFF, 128587.4*cm*RAYFF,
-     121776.3*cm*RAYFF, 115239.5*cm*RAYFF, 108969.5*cm*RAYFF,
-     102958.8*cm*RAYFF, 97200.35*cm*RAYFF, 91686.86*cm*RAYFF,
-     86411.33*cm*RAYFF, 81366.79*cm*RAYFF, 76546.42*cm*RAYFF,
-     71943.46*cm*RAYFF, 67551.29*cm*RAYFF, 63363.36*cm*RAYFF,
-     59373.25*cm*RAYFF, 55574.61*cm*RAYFF, 51961.24*cm*RAYFF,
-     48527.00*cm*RAYFF, 45265.87*cm*RAYFF, 42171.94*cm*RAYFF,
-     39239.39*cm*RAYFF, 36462.50*cm*RAYFF, 33835.68*cm*RAYFF,
-     31353.41*cm*RAYFF, 29010.30*cm*RAYFF, 26801.03*cm*RAYFF,
-     24720.42*cm*RAYFF, 22763.36*cm*RAYFF, 20924.88*cm*RAYFF,
-     19200.07*cm*RAYFF, 17584.16*cm*RAYFF, 16072.45*cm*RAYFF,
-     14660.38*cm*RAYFF, 13343.46*cm*RAYFF, 12117.33*cm*RAYFF,
-     10977.70*cm*RAYFF, 9920.416*cm*RAYFF, 8941.407*cm*RAYFF,
-     8036.711*cm*RAYFF, 7202.470*cm*RAYFF, 6434.927*cm*RAYFF,
-     5730.429*cm*RAYFF, 5085.425*cm*RAYFF, 4496.467*cm*RAYFF,
-     3960.210*cm*RAYFF, 3473.413*cm*RAYFF, 3032.937*cm*RAYFF,
-     2635.746*cm*RAYFF, 2278.907*cm*RAYFF, 1959.588*cm*RAYFF,
-     1675.064*cm*RAYFF, 1422.710*cm*RAYFF, 1200.004*cm*RAYFF,
-     1004.528*cm*RAYFF, 833.9666*cm*RAYFF, 686.1063*cm*RAYFF
+     167024.4*CLHEP::cm*RAYFF, 158726.7*CLHEP::cm*RAYFF, 150742*CLHEP::cm*RAYFF,
+     143062.5*CLHEP::cm*RAYFF, 135680.2*CLHEP::cm*RAYFF, 128587.4*CLHEP::cm*RAYFF,
+     121776.3*CLHEP::cm*RAYFF, 115239.5*CLHEP::cm*RAYFF, 108969.5*CLHEP::cm*RAYFF,
+     102958.8*CLHEP::cm*RAYFF, 97200.35*CLHEP::cm*RAYFF, 91686.86*CLHEP::cm*RAYFF,
+     86411.33*CLHEP::cm*RAYFF, 81366.79*CLHEP::cm*RAYFF, 76546.42*CLHEP::cm*RAYFF,
+     71943.46*CLHEP::cm*RAYFF, 67551.29*CLHEP::cm*RAYFF, 63363.36*CLHEP::cm*RAYFF,
+     59373.25*CLHEP::cm*RAYFF, 55574.61*CLHEP::cm*RAYFF, 51961.24*CLHEP::cm*RAYFF,
+     48527.00*CLHEP::cm*RAYFF, 45265.87*CLHEP::cm*RAYFF, 42171.94*CLHEP::cm*RAYFF,
+     39239.39*CLHEP::cm*RAYFF, 36462.50*CLHEP::cm*RAYFF, 33835.68*CLHEP::cm*RAYFF,
+     31353.41*CLHEP::cm*RAYFF, 29010.30*CLHEP::cm*RAYFF, 26801.03*CLHEP::cm*RAYFF,
+     24720.42*CLHEP::cm*RAYFF, 22763.36*CLHEP::cm*RAYFF, 20924.88*CLHEP::cm*RAYFF,
+     19200.07*CLHEP::cm*RAYFF, 17584.16*CLHEP::cm*RAYFF, 16072.45*CLHEP::cm*RAYFF,
+     14660.38*CLHEP::cm*RAYFF, 13343.46*CLHEP::cm*RAYFF, 12117.33*CLHEP::cm*RAYFF,
+     10977.70*CLHEP::cm*RAYFF, 9920.416*CLHEP::cm*RAYFF, 8941.407*CLHEP::cm*RAYFF,
+     8036.711*CLHEP::cm*RAYFF, 7202.470*CLHEP::cm*RAYFF, 6434.927*CLHEP::cm*RAYFF,
+     5730.429*CLHEP::cm*RAYFF, 5085.425*CLHEP::cm*RAYFF, 4496.467*CLHEP::cm*RAYFF,
+     3960.210*CLHEP::cm*RAYFF, 3473.413*CLHEP::cm*RAYFF, 3032.937*CLHEP::cm*RAYFF,
+     2635.746*CLHEP::cm*RAYFF, 2278.907*CLHEP::cm*RAYFF, 1959.588*CLHEP::cm*RAYFF,
+     1675.064*CLHEP::cm*RAYFF, 1422.710*CLHEP::cm*RAYFF, 1200.004*CLHEP::cm*RAYFF,
+     1004.528*CLHEP::cm*RAYFF, 833.9666*CLHEP::cm*RAYFF, 686.1063*CLHEP::cm*RAYFF
      };*/
 
 
@@ -491,34 +491,34 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
    //Values extracted from Skdetsim
    G4double MIE_water[NUMENTRIES_water] = {
-     7790020*cm*MIEFF, 7403010*cm*MIEFF, 7030610*cm*MIEFF, 6672440*cm*MIEFF, 6328120*cm*MIEFF, 
-     5997320*cm*MIEFF, 5679650*cm*MIEFF, 5374770*cm*MIEFF, 5082340*cm*MIEFF, 4802000*cm*MIEFF, 
-     4533420*cm*MIEFF, 4276280*cm*MIEFF, 4030220*cm*MIEFF, 3794950*cm*MIEFF, 3570120*cm*MIEFF,
-     3355440*cm*MIEFF, 3150590*cm*MIEFF, 2955270*cm*MIEFF, 2769170*cm*MIEFF, 2592000*cm*MIEFF, 
-     2423470*cm*MIEFF, 2263300*cm*MIEFF, 2111200*cm*MIEFF, 1966900*cm*MIEFF, 1830120*cm*MIEFF, 
-     1700610*cm*MIEFF, 1578100*cm*MIEFF, 1462320*cm*MIEFF, 1353040*cm*MIEFF, 1250000*cm*MIEFF,
-     1152960*cm*MIEFF, 1061680*cm*MIEFF,  975936*cm*MIEFF,  895491*cm*MIEFF,  820125*cm*MIEFF, 
-      749619*cm*MIEFF,  683760*cm*MIEFF,  622339*cm*MIEFF,  565152*cm*MIEFF,  512000*cm*MIEFF, 
-      462688*cm*MIEFF,  417027*cm*MIEFF,  374832*cm*MIEFF,  335923*cm*MIEFF,  300125*cm*MIEFF,
-      267267*cm*MIEFF,  237184*cm*MIEFF,  209715*cm*MIEFF,  184704*cm*MIEFF,  162000*cm*MIEFF, 
-      141456*cm*MIEFF,  122931*cm*MIEFF,  106288*cm*MIEFF, 91395.2*cm*MIEFF,   78125*cm*MIEFF, 
-     66355.2*cm*MIEFF, 55968.2*cm*MIEFF, 46851.2*cm*MIEFF, 38896.2*cm*MIEFF,   32000*cm*MIEFF
+     7790020*CLHEP::cm*MIEFF, 7403010*CLHEP::cm*MIEFF, 7030610*CLHEP::cm*MIEFF, 6672440*CLHEP::cm*MIEFF, 6328120*CLHEP::cm*MIEFF, 
+     5997320*CLHEP::cm*MIEFF, 5679650*CLHEP::cm*MIEFF, 5374770*CLHEP::cm*MIEFF, 5082340*CLHEP::cm*MIEFF, 4802000*CLHEP::cm*MIEFF, 
+     4533420*CLHEP::cm*MIEFF, 4276280*CLHEP::cm*MIEFF, 4030220*CLHEP::cm*MIEFF, 3794950*CLHEP::cm*MIEFF, 3570120*CLHEP::cm*MIEFF,
+     3355440*CLHEP::cm*MIEFF, 3150590*CLHEP::cm*MIEFF, 2955270*CLHEP::cm*MIEFF, 2769170*CLHEP::cm*MIEFF, 2592000*CLHEP::cm*MIEFF, 
+     2423470*CLHEP::cm*MIEFF, 2263300*CLHEP::cm*MIEFF, 2111200*CLHEP::cm*MIEFF, 1966900*CLHEP::cm*MIEFF, 1830120*CLHEP::cm*MIEFF, 
+     1700610*CLHEP::cm*MIEFF, 1578100*CLHEP::cm*MIEFF, 1462320*CLHEP::cm*MIEFF, 1353040*CLHEP::cm*MIEFF, 1250000*CLHEP::cm*MIEFF,
+     1152960*CLHEP::cm*MIEFF, 1061680*CLHEP::cm*MIEFF,  975936*CLHEP::cm*MIEFF,  895491*CLHEP::cm*MIEFF,  820125*CLHEP::cm*MIEFF, 
+      749619*CLHEP::cm*MIEFF,  683760*CLHEP::cm*MIEFF,  622339*CLHEP::cm*MIEFF,  565152*CLHEP::cm*MIEFF,  512000*CLHEP::cm*MIEFF, 
+      462688*CLHEP::cm*MIEFF,  417027*CLHEP::cm*MIEFF,  374832*CLHEP::cm*MIEFF,  335923*CLHEP::cm*MIEFF,  300125*CLHEP::cm*MIEFF,
+      267267*CLHEP::cm*MIEFF,  237184*CLHEP::cm*MIEFF,  209715*CLHEP::cm*MIEFF,  184704*CLHEP::cm*MIEFF,  162000*CLHEP::cm*MIEFF, 
+      141456*CLHEP::cm*MIEFF,  122931*CLHEP::cm*MIEFF,  106288*CLHEP::cm*MIEFF, 91395.2*CLHEP::cm*MIEFF,   78125*CLHEP::cm*MIEFF, 
+     66355.2*CLHEP::cm*MIEFF, 55968.2*CLHEP::cm*MIEFF, 46851.2*CLHEP::cm*MIEFF, 38896.2*CLHEP::cm*MIEFF,   32000*CLHEP::cm*MIEFF
    };
 
    //Mie scattering length values when assuming 10 times larger than Rayleigh scattering. 
    /*G4double MIE_water[NUMENTRIES_water] = {
-      3869290*cm*MIEFF, 3662490*cm*MIEFF,  3463980*cm*MIEFF,  3273550*cm*MIEFF,  3090970*cm*MIEFF,  
-      2916030*cm*MIEFF, 2748530*cm*MIEFF,  2588250*cm*MIEFF,  2435000*cm*MIEFF,  2288560*cm*MIEFF,  
-      2148730*cm*MIEFF, 2015330*cm*MIEFF,  1888160*cm*MIEFF,  1767020*cm*MIEFF,  1651730*cm*MIEFF,
-      1542100*cm*MIEFF, 1437950*cm*MIEFF,  1339100*cm*MIEFF,  1245370*cm*MIEFF,  1156590*cm*MIEFF,  
-      1072580*cm*MIEFF,  993182*cm*MIEFF,   918222*cm*MIEFF,   847540*cm*MIEFF,   780973*cm*MIEFF, 
-       718365*cm*MIEFF,   65956*cm*MIEFF,   604406*cm*MIEFF,   552754*cm*MIEFF,   504456*cm*MIEFF,
-       459370*cm*MIEFF,  417352*cm*MIEFF,   378266*cm*MIEFF,   341976*cm*MIEFF,   308349*cm*MIEFF, 
-       277254*cm*MIEFF,  248566*cm*MIEFF,   222159*cm*MIEFF,   197913*cm*MIEFF,   175709*cm*MIEFF,   
-       155430*cm*MIEFF,  136966*cm*MIEFF,   120205*cm*MIEFF,   105041*cm*MIEFF,  91371.5*cm*MIEFF,
-      79094.5*cm*MIEFF,   68113*cm*MIEFF,  58332.5*cm*MIEFF,    49662*cm*MIEFF,  42013.6*cm*MIEFF, 
-      35302.8*cm*MIEFF, 29448.4*cm*MIEFF,  24372.8*cm*MIEFF,  20001.8*cm*MIEFF,    16265*cm*MIEFF, 
-      13095.5*cm*MIEFF, 10430.3*cm*MIEFF,  8210.16*cm*MIEFF,   6379.7*cm*MIEFF,  4887.54*cm*MIEFF
+      3869290*CLHEP::cm*MIEFF, 3662490*CLHEP::cm*MIEFF,  3463980*CLHEP::cm*MIEFF,  3273550*CLHEP::cm*MIEFF,  3090970*CLHEP::cm*MIEFF,  
+      2916030*CLHEP::cm*MIEFF, 2748530*CLHEP::cm*MIEFF,  2588250*CLHEP::cm*MIEFF,  2435000*CLHEP::cm*MIEFF,  2288560*CLHEP::cm*MIEFF,  
+      2148730*CLHEP::cm*MIEFF, 2015330*CLHEP::cm*MIEFF,  1888160*CLHEP::cm*MIEFF,  1767020*CLHEP::cm*MIEFF,  1651730*CLHEP::cm*MIEFF,
+      1542100*CLHEP::cm*MIEFF, 1437950*CLHEP::cm*MIEFF,  1339100*CLHEP::cm*MIEFF,  1245370*CLHEP::cm*MIEFF,  1156590*CLHEP::cm*MIEFF,  
+      1072580*CLHEP::cm*MIEFF,  993182*CLHEP::cm*MIEFF,   918222*CLHEP::cm*MIEFF,   847540*CLHEP::cm*MIEFF,   780973*CLHEP::cm*MIEFF, 
+       718365*CLHEP::cm*MIEFF,   65956*CLHEP::cm*MIEFF,   604406*CLHEP::cm*MIEFF,   552754*CLHEP::cm*MIEFF,   504456*CLHEP::cm*MIEFF,
+       459370*CLHEP::cm*MIEFF,  417352*CLHEP::cm*MIEFF,   378266*CLHEP::cm*MIEFF,   341976*CLHEP::cm*MIEFF,   308349*CLHEP::cm*MIEFF, 
+       277254*CLHEP::cm*MIEFF,  248566*CLHEP::cm*MIEFF,   222159*CLHEP::cm*MIEFF,   197913*CLHEP::cm*MIEFF,   175709*CLHEP::cm*MIEFF,   
+       155430*CLHEP::cm*MIEFF,  136966*CLHEP::cm*MIEFF,   120205*CLHEP::cm*MIEFF,   105041*CLHEP::cm*MIEFF,  91371.5*CLHEP::cm*MIEFF,
+      79094.5*CLHEP::cm*MIEFF,   68113*CLHEP::cm*MIEFF,  58332.5*CLHEP::cm*MIEFF,    49662*CLHEP::cm*MIEFF,  42013.6*CLHEP::cm*MIEFF, 
+      35302.8*CLHEP::cm*MIEFF, 29448.4*CLHEP::cm*MIEFF,  24372.8*CLHEP::cm*MIEFF,  20001.8*CLHEP::cm*MIEFF,    16265*CLHEP::cm*MIEFF, 
+      13095.5*CLHEP::cm*MIEFF, 10430.3*CLHEP::cm*MIEFF,  8210.16*CLHEP::cm*MIEFF,   6379.7*CLHEP::cm*MIEFF,  4887.54*CLHEP::cm*MIEFF
    };
    */
 
@@ -557,48 +557,48 @@ void WCSimDetectorConstruction::ConstructMaterials()
    
    
    //G4double ABSORPTION1[NUMENTRIES] =
-   //{344.8*cm,  408.2*cm,  632.9*cm,  917.4*cm, 1234.6*cm, 1388.9*cm,
-   // 1515.2*cm, 1724.1*cm, 1886.8*cm, 2000.0*cm, 2631.6*cm, 3571.4*cm,
-   // 4545.5*cm, 4761.9*cm, 5263.2*cm, 5263.2*cm, 5555.6*cm, 5263.2*cm,
-   // 5263.2*cm, 4761.9*cm, 4545.5*cm, 4166.7*cm, 3703.7*cm, 3333.3*cm,
-   // 3000.0*cm, 2850.0*cm, 2700.0*cm, 2450.0*cm, 2200.0*cm, 1950.0*cm,
-   // 1750.0*cm, 1450.0*cm };
+   //{344.8*CLHEP::cm,  408.2*CLHEP::cm,  632.9*CLHEP::cm,  917.4*CLHEP::cm, 1234.6*CLHEP::cm, 1388.9*CLHEP::cm,
+   // 1515.2*CLHEP::cm, 1724.1*CLHEP::cm, 1886.8*CLHEP::cm, 2000.0*CLHEP::cm, 2631.6*CLHEP::cm, 3571.4*CLHEP::cm,
+   // 4545.5*CLHEP::cm, 4761.9*CLHEP::cm, 5263.2*CLHEP::cm, 5263.2*CLHEP::cm, 5555.6*CLHEP::cm, 5263.2*CLHEP::cm,
+   // 5263.2*CLHEP::cm, 4761.9*CLHEP::cm, 4545.5*CLHEP::cm, 4166.7*CLHEP::cm, 3703.7*CLHEP::cm, 3333.3*CLHEP::cm,
+   // 3000.0*CLHEP::cm, 2850.0*CLHEP::cm, 2700.0*CLHEP::cm, 2450.0*CLHEP::cm, 2200.0*CLHEP::cm, 1950.0*CLHEP::cm,
+   // 1750.0*CLHEP::cm, 1450.0*CLHEP::cm };
    
    /*   
    G4double ABSORPTION_glass[NUMENTRIES] = 
-     { 100.0*cm, 110.0*cm, 120.0*cm, 130.0*cm, 140.0*cm, 150.0*cm, 160.0*cm,
-       165.0*cm, 170.0*cm, 175.0*cm, 180.0*cm, 185.0*cm, 190.0*cm, 195.0*cm,
-       200.0*cm, 200.0*cm, 200.0*cm, 200.0*cm, 200.0*cm, 195.0*cm, 190.0*cm,
-       185.0*cm, 180.0*cm, 175.0*cm, 170.0*cm, 160.0*cm, 150.0*cm, 140.0*cm,
-       130.0*cm, 120.0*cm, 110.0*cm, 100.0*cm };
+     { 100.0*CLHEP::cm, 110.0*CLHEP::cm, 120.0*CLHEP::cm, 130.0*CLHEP::cm, 140.0*CLHEP::cm, 150.0*CLHEP::cm, 160.0*CLHEP::cm,
+       165.0*CLHEP::cm, 170.0*CLHEP::cm, 175.0*CLHEP::cm, 180.0*CLHEP::cm, 185.0*CLHEP::cm, 190.0*CLHEP::cm, 195.0*CLHEP::cm,
+       200.0*CLHEP::cm, 200.0*CLHEP::cm, 200.0*CLHEP::cm, 200.0*CLHEP::cm, 200.0*CLHEP::cm, 195.0*CLHEP::cm, 190.0*CLHEP::cm,
+       185.0*CLHEP::cm, 180.0*CLHEP::cm, 175.0*CLHEP::cm, 170.0*CLHEP::cm, 160.0*CLHEP::cm, 150.0*CLHEP::cm, 140.0*CLHEP::cm,
+       130.0*CLHEP::cm, 120.0*CLHEP::cm, 110.0*CLHEP::cm, 100.0*CLHEP::cm };
    */
    // M Fechner : the quantum efficiency already takes glass abs into account
 
    G4double ABSORPTION_glass[NUMENTRIES_water]= 
-     { 1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm, 1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,1.0e9*cm,
-       1.0e9*cm, 1.0e9*cm };
+     { 1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm, 1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,1.0e9*CLHEP::cm,
+       1.0e9*CLHEP::cm, 1.0e9*CLHEP::cm };
    
    G4double BLACKABS_blacksheet[NUMENTRIES_water] =
-     { 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 
-       1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 
-       1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm, 1.0e-9*cm,
-       1.0e-9*cm, 1.0e-9*cm};
+     { 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 
+       1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 
+       1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm,
+       1.0e-9*CLHEP::cm, 1.0e-9*CLHEP::cm};
    
    
    //The following reflectivity for blacksheet is obtained from skdetsim
@@ -672,33 +672,33 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
    //utter fiction at this stage
    G4double EFFICIENCY[NUMENTRIES_water] =
-     { 0.001*m };
+     { 0.001*CLHEP::m };
       
    //utter fiction at this stage, does not matter
    G4double RAYLEIGH_air[NUMENTRIES_water] =
-     { 0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,
-       0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m};
+     { 0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,
+       0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m,0.001*CLHEP::m};
       
        //utter fiction at this stage, does not matter
    G4double MIE_air[NUMENTRIES_water] =
-     { 0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
-       0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m};
+     { 0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,
+       0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m,0.1*CLHEP::m};
 
    G4double MIE_air_const[3]={0.99,0.99,0.8};// gforward, gbackward, forward backward ratio
 
@@ -742,9 +742,9 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
    const G4int NUM = 2;
    //   G4double PP[NUM] =
-   //{ 2.038E-9*GeV, 4.144E-9*GeV };
+   //{ 2.038E-9*CLHEP::GeV, 4.144E-9*CLHEP::GeV };
 
-   G4double PP[NUM] = { 1.4E-9*GeV,6.2E-9*GeV};
+   G4double PP[NUM] = { 1.4E-9*CLHEP::GeV,6.2E-9*CLHEP::GeV};
    G4double RINDEX_blacksheet[NUM] =
      { 1.6, 1.6 };
 

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -128,7 +128,7 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   if (isEggShapedHyperK) logicWCBox = ConstructEggShapedHyperK();
   else logicWCBox = ConstructCylinder();
 
-  G4cout << " WCLength       = " << WCLength/m << " m"<< G4endl;
+  G4cout << " WCLength       = " << WCLength/CLHEP::m << " m"<< G4endl;
 
   //-------------------------------
 
@@ -137,7 +137,7 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
 
   G4double expHallLength = 3.*WCLength; //jl145 - extra space to simulate cosmic muons more easily
 
-  G4cout << " expHallLength = " << expHallLength / m << G4endl;
+  G4cout << " expHallLength = " << expHallLength / CLHEP::m << G4endl;
   G4double expHallHalfLength = 0.5*expHallLength;
 
   G4Box* solidExpHall = new G4Box("expHall",

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -275,9 +275,9 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
    //  jhfNtuple.vtx[0] = vtx[0]/1000.; // interaction vertex
    //jhfNtuple.vtx[1] = vtx[1]/1000.; // interaction vertex
    //jhfNtuple.vtx[2] = vtx[2]/1000.; // interaction vertex
-   jhfNtuple.vtx[0] = vtx[0]/cm; // interaction vertex
-   jhfNtuple.vtx[1] = vtx[1]/cm; // interaction vertex
-   jhfNtuple.vtx[2] = vtx[2]/cm; // interaction vertex
+   jhfNtuple.vtx[0] = vtx[0]/CLHEP::cm; // interaction vertex
+   jhfNtuple.vtx[1] = vtx[1]/CLHEP::cm; // interaction vertex
+   jhfNtuple.vtx[2] = vtx[2]/CLHEP::cm; // interaction vertex
    jhfNtuple.vecRecNumber = vecRecNumber; //vectorfile record number
    
    // mustop, pstop, npar will be filled later
@@ -307,9 +307,9 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
    jhfNtuple.pdir[npar][1] = beamenergy*beamdir[1]; // momentum-vector 
    jhfNtuple.pdir[npar][2] = beamenergy*beamdir[2]; // momentum-vector 
    // M Fechner, same as above
-   jhfNtuple.stop[npar][0] = vtx[0]/cm;  // stopping point (not meaningful)
-   jhfNtuple.stop[npar][1] = vtx[1]/cm;  // stopping point (not meaningful)
-   jhfNtuple.stop[npar][2] = vtx[2]/cm;  // stopping point (not meaningful)
+   jhfNtuple.stop[npar][0] = vtx[0]/CLHEP::cm;  // stopping point (not meaningful)
+   jhfNtuple.stop[npar][1] = vtx[1]/CLHEP::cm;  // stopping point (not meaningful)
+   jhfNtuple.stop[npar][2] = vtx[2]/CLHEP::cm;  // stopping point (not meaningful)
    jhfNtuple.parent[npar] = 0;
    
    npar++;
@@ -350,9 +350,9 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
   jhfNtuple.pdir[npar][1] = targetpmag*targetdir[1];  // momentum-vector 
   jhfNtuple.pdir[npar][2] = targetpmag*targetdir[2];  // momentum-vector 
   // M Fechner, same as above
-  jhfNtuple.stop[npar][0] = vtx[0]/cm;  // stopping point (not meaningful)
-  jhfNtuple.stop[npar][1] = vtx[1]/cm;  // stopping point (not meaningful)
-  jhfNtuple.stop[npar][2] = vtx[2]/cm;  // stopping point (not meaningful)
+  jhfNtuple.stop[npar][0] = vtx[0]/CLHEP::cm;  // stopping point (not meaningful)
+  jhfNtuple.stop[npar][1] = vtx[1]/CLHEP::cm;  // stopping point (not meaningful)
+  jhfNtuple.stop[npar][2] = vtx[2]/CLHEP::cm;  // stopping point (not meaningful)
   jhfNtuple.parent[npar] = 0;
 
   npar++;
@@ -675,8 +675,8 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       {
 	dir[l]= mom[l]/mommag; // direction 
 	pdir[l]=mom[l];        // momentum-vector 
-	stop[l]=Stop[l]/cm; // stopping point 
-	start[l]=Start[l]/cm; // starting point 
+	stop[l]=Stop[l]/CLHEP::cm; // stopping point 
+	start[l]=Start[l]/CLHEP::cm; // starting point 
 	G4cout<<"part 2 start["<<l<<"]: "<< start[l] <<G4endl;
       }
 

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -74,9 +74,9 @@ PMT20inch::PMT20inch() {}
 PMT20inch::~PMT20inch(){}
 
 G4String PMT20inch::GetPMTName() {G4String PMTName = "20inch"; return PMTName;}
-G4double PMT20inch::GetExposeHeight() {return .18*m;}
-G4double PMT20inch::GetRadius() {return .254*m;}
-G4double PMT20inch::GetPMTGlassThickness() {return 0.4*cm;}
+G4double PMT20inch::GetExposeHeight() {return .18*CLHEP::m;}
+G4double PMT20inch::GetRadius() {return .254*CLHEP::m;}
+G4double PMT20inch::GetPMTGlassThickness() {return 0.4*CLHEP::cm;}
 float PMT20inch::HitTimeSmearing(float Q) {
   float timingConstant = 10.0; 
   float timingResolution = 0.33 + sqrt(timingConstant/Q); 
@@ -248,9 +248,9 @@ PMT8inch::PMT8inch(){}
 PMT8inch::~PMT8inch(){}
 
 G4String PMT8inch::GetPMTName() {G4String PMTName = "8inch"; return PMTName;}
-G4double PMT8inch::GetExposeHeight() {return 91.6*mm;}
-G4double PMT8inch::GetRadius() {return 101.6*mm;}
-G4double PMT8inch::GetPMTGlassThickness() {return 0.55*cm;} //currently the same as 10inch
+G4double PMT8inch::GetExposeHeight() {return 91.6*CLHEP::mm;}
+G4double PMT8inch::GetRadius() {return 101.6*CLHEP::mm;}
+G4double PMT8inch::GetPMTGlassThickness() {return 0.55*CLHEP::cm;} //currently the same as 10inch
 G4float PMT8inch::HitTimeSmearing(float Q) { 
   float timingConstant = 1.890; 
   float timingResolution = 0.33 + sqrt(timingConstant/Q); 
@@ -409,9 +409,9 @@ PMT10inch::PMT10inch(){}
 PMT10inch::~PMT10inch(){}
 
 G4String PMT10inch::GetPMTName() {G4String PMTName = "10inch"; return PMTName;}
-G4double PMT10inch::GetExposeHeight() {return 117.*mm;}
-G4double PMT10inch::GetRadius() {return 127.*mm;}
-G4double PMT10inch::GetPMTGlassThickness() {return 0.55*cm;}
+G4double PMT10inch::GetExposeHeight() {return 117.*CLHEP::mm;}
+G4double PMT10inch::GetRadius() {return 127.*CLHEP::mm;}
+G4double PMT10inch::GetPMTGlassThickness() {return 0.55*CLHEP::cm;}
 float PMT10inch::HitTimeSmearing(float Q) { 
   float timingConstant = 2.0; 
   float timingResolution = 0.33 + sqrt(timingConstant/Q); 
@@ -571,9 +571,9 @@ PMT10inchHQE::PMT10inchHQE() {}
 PMT10inchHQE::~PMT10inchHQE(){}
 
 G4String PMT10inchHQE::GetPMTName() {G4String PMTName = "10inch"; return PMTName;}
-G4double PMT10inchHQE::GetExposeHeight() {return 117.*mm;}
-G4double PMT10inchHQE::GetRadius() {return 127.*mm;}
-G4double PMT10inchHQE::GetPMTGlassThickness() {return 0.55*cm;}
+G4double PMT10inchHQE::GetExposeHeight() {return 117.*CLHEP::mm;}
+G4double PMT10inchHQE::GetRadius() {return 127.*CLHEP::mm;}
+G4double PMT10inchHQE::GetPMTGlassThickness() {return 0.55*CLHEP::cm;}
 G4float PMT10inchHQE::HitTimeSmearing(float Q) {
   float timingConstant = 2.0; 
   float timingResolution = 0.33 + sqrt(timingConstant/Q); 
@@ -733,9 +733,9 @@ PMT12inchHQE::PMT12inchHQE(){}
 PMT12inchHQE::~PMT12inchHQE(){}
 
 G4String PMT12inchHQE::GetPMTName() {G4String PMTName = "12inch"; return PMTName;}
-G4double PMT12inchHQE::GetExposeHeight() {return 118.*mm;}
-G4double PMT12inchHQE::GetRadius() {return 152.4*mm;}
-G4double PMT12inchHQE::GetPMTGlassThickness() {return 0.55*cm;}
+G4double PMT12inchHQE::GetExposeHeight() {return 118.*CLHEP::mm;}
+G4double PMT12inchHQE::GetRadius() {return 152.4*CLHEP::mm;}
+G4double PMT12inchHQE::GetPMTGlassThickness() {return 0.55*CLHEP::cm;}
 G4float PMT12inchHQE::HitTimeSmearing(float Q) {
   float timingConstant = 2.0; 
   float timingResolution = 0.33 + sqrt(timingConstant/Q); 
@@ -908,9 +908,9 @@ HPD20inchHQE::HPD20inchHQE(){}
 HPD20inchHQE::~HPD20inchHQE(){}
 
 G4String HPD20inchHQE::GetPMTName() {G4String PMTName = "HPD20inchHQE"; return PMTName;}
-G4double HPD20inchHQE::GetExposeHeight() {return .192*m;}
-G4double HPD20inchHQE::GetRadius() {return .254*m;}
-G4double HPD20inchHQE::GetPMTGlassThickness() {return 0.3*cm;}
+G4double HPD20inchHQE::GetExposeHeight() {return .192*CLHEP::m;}
+G4double HPD20inchHQE::GetRadius() {return .254*CLHEP::m;}
+G4double HPD20inchHQE::GetPMTGlassThickness() {return 0.3*CLHEP::cm;}
 float HPD20inchHQE::HitTimeSmearing(float Q) {
   G4float sig_param[4]={0.6718,0.1264,0.4450,11.87};
   G4float lambda_param[2]={0.3255,0.1142};
@@ -1087,9 +1087,9 @@ HPD12inchHQE::HPD12inchHQE(){}
 HPD12inchHQE::~HPD12inchHQE(){}
 
 G4String HPD12inchHQE::GetPMTName() {G4String PMTName = "HPD12inchHQE"; return PMTName;}
-G4double HPD12inchHQE::GetExposeHeight() {return 118.*mm;} //Assumed to be the same as the PMT12inchHQE.
-G4double HPD12inchHQE::GetRadius() {return 152.4*mm;} //12 inches
-G4double HPD12inchHQE::GetPMTGlassThickness() {return 0.3*cm;} 
+G4double HPD12inchHQE::GetExposeHeight() {return 118.*CLHEP::mm;} //Assumed to be the same as the PMT12inchHQE.
+G4double HPD12inchHQE::GetRadius() {return 152.4*CLHEP::mm;} //12 inches
+G4double HPD12inchHQE::GetPMTGlassThickness() {return 0.3*CLHEP::cm;} 
 float HPD12inchHQE::HitTimeSmearing(float Q) {
   G4float sig_param[4]={0.6718,0.1264,0.4450,11.87};
   G4float lambda_param[2]={0.3255,0.1142};
@@ -1274,9 +1274,9 @@ BoxandLine20inchHQE::BoxandLine20inchHQE(){}
 BoxandLine20inchHQE::~BoxandLine20inchHQE(){}
 
 G4String BoxandLine20inchHQE::GetPMTName() {G4String PMTName = "BoxandLine20inchHQE"; return PMTName;}
-G4double BoxandLine20inchHQE::GetExposeHeight() {return .18*m;}
-G4double BoxandLine20inchHQE::GetRadius() {return .254*m;}
-G4double BoxandLine20inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
+G4double BoxandLine20inchHQE::GetExposeHeight() {return .18*CLHEP::m;}
+G4double BoxandLine20inchHQE::GetRadius() {return .254*CLHEP::m;}
+G4double BoxandLine20inchHQE::GetPMTGlassThickness() {return 0.4*CLHEP::cm;}
 
 float BoxandLine20inchHQE::HitTimeSmearing(float Q) {
   G4float sig_param[4]={0.6314,0.06260,0.5711,23.96};
@@ -1459,9 +1459,9 @@ BoxandLine12inchHQE::BoxandLine12inchHQE(){}
 BoxandLine12inchHQE::~BoxandLine12inchHQE(){}
 
 G4String BoxandLine12inchHQE::GetPMTName() {G4String PMTName = "BoxandLine12inchHQE"; return PMTName;}
-G4double BoxandLine12inchHQE::GetExposeHeight() {return 118.*mm;}
-G4double BoxandLine12inchHQE::GetRadius() {return 152.4*mm;}
-G4double BoxandLine12inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
+G4double BoxandLine12inchHQE::GetExposeHeight() {return 118.*CLHEP::mm;}
+G4double BoxandLine12inchHQE::GetRadius() {return 152.4*CLHEP::mm;}
+G4double BoxandLine12inchHQE::GetPMTGlassThickness() {return 0.4*CLHEP::cm;}
 
 float BoxandLine12inchHQE::HitTimeSmearing(float Q) {
   G4float sig_param[4]={0.6314,0.06260,0.5711,23.96};

--- a/src/WCSimPhysicsList.cc
+++ b/src/WCSimPhysicsList.cc
@@ -84,8 +84,9 @@ void WCSimPhysicsList::ConstructProcess()
 #include "G4MuBremsstrahlung.hh"
 #include "G4MuPairProduction.hh"
 #include "G4hIonisation.hh"
-#include "G4MuonMinusCaptureAtRest.hh"
 
+// FDL replaced in 4.9 by G4MuonMinusCapture
+#include "G4MuonMinusCapture.hh"
 //K.Z.: New MultipleScattering classes 
 #include "G4eMultipleScattering.hh"
 #include "G4MuMultipleScattering.hh"
@@ -99,16 +100,16 @@ void WCSimPhysicsList::ConstructEM()
   //replaced by new G4MultipleScattering classes for e+-, mu+-, hadron and ions.
   //K. Zbiri, 12/30/2009
 
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
-    G4ParticleDefinition* particle = theParticleIterator->value();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
     G4ProcessManager* pmanager = particle->GetProcessManager();
     G4String particleName = particle->GetParticleName();
      
     if (particleName == "gamma") {
     // gamma
       pmanager->AddDiscreteProcess(new G4GammaConversion());
-      pmanager->AddDiscreteProcess(new G4ComptonScattering());      
+      pmanager->AddDiscreteProcess(new G4ComptonScattering());
       pmanager->AddDiscreteProcess(new G4PhotoElectricEffect());
 
     } else if (particleName == "e-") {
@@ -122,7 +123,7 @@ void WCSimPhysicsList::ConstructEM()
       pmanager->AddProcess(theeminusMultipleScattering);
       pmanager->AddProcess(theeminusIonisation);
       pmanager->AddProcess(theeminusBremsstrahlung);
-      //      
+      //
       // set ordering for AlongStepDoIt
       pmanager->SetProcessOrdering(theeminusMultipleScattering,idxAlongStep,1);
       pmanager->SetProcessOrdering(theeminusIonisation,        idxAlongStep,2);
@@ -187,17 +188,17 @@ void WCSimPhysicsList::ConstructEM()
       // MF , stolen from CWW, april 2005
       if (particleName == "mu-")
         {
-          G4VProcess* aG4MuonMinusCaptureAtRest =
-            new G4MuonMinusCaptureAtRest();
-          pmanager->AddProcess(aG4MuonMinusCaptureAtRest);
-          pmanager->SetProcessOrdering(aG4MuonMinusCaptureAtRest,idxAtRest);
+	  // Change to G4MuonMinusCapture - FDL
+	  G4VProcess* aG4MuonMinusCapture = new G4MuonMinusCapture();
+          pmanager->AddProcess(aG4MuonMinusCapture);
+          pmanager->SetProcessOrdering(aG4MuonMinusCapture, idxAtRest);
         }
 
 
     } else if ((!particle->IsShortLived()) &&
 	       (particle->GetPDGCharge() != 0.0)&&
                (particle->GetParticleName() != "chargedgeantino")) {
-      // G4VProcess* aMultipleScattering = new G4MultipleScattering();
+
      G4VProcess* aMultipleScattering = new G4hMultipleScattering();
      G4VProcess* anIonisation        = new G4hIonisation();
      //
@@ -223,16 +224,16 @@ void WCSimPhysicsList::ConstructEM()
 void WCSimPhysicsList::ConstructlArStepLimiter(){
 
 #ifdef GEANT4_7_0
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
 
-    G4ParticleDefinition* particle = theParticleIterator->value();
+    G4ParticleDefinition* particle = aParticleIterator->value();
     G4ProcessManager* pmanager = particle->GetProcessManager();
 
      if ((!particle->IsShortLived()) &&
 	 (particle->GetPDGCharge() != 0.0)&&
 	 (particle->GetParticleName() != "chargedgeantino")) {
-       G4VProcess* stepLimiter = new G4StepLimiter();   
+       G4VProcess* stepLimiter = new G4StepLimiter();
        pmanager->AddProcess(stepLimiter);
        pmanager->SetProcessOrdering(stepLimiter,
 				    idxPostStep,
@@ -268,7 +269,7 @@ void WCSimPhysicsList::ConstructOp(){
   theMieHGScatteringProcess->SetVerboseLevel(0);
   theBoundaryProcess->SetVerboseLevel(0);
   theWLSProcess->SetVerboseLevel(0);
-  
+
   theWLSProcess->UseTimeProfile("exponential");
 
   G4int MaxNumPhotons = 300;
@@ -280,13 +281,13 @@ void WCSimPhysicsList::ConstructOp(){
   // theCherenkovProcess->SetMaxBetaChangePerStep(10.0);
   // theCherenkovProcess->SetTrackSecondariesFirst(true);
 
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() )
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() )
   {
-    G4ParticleDefinition* particle     = theParticleIterator->value();
+    G4ParticleDefinition* particle     = aParticleIterator->value();
     G4ProcessManager*     pmanager     = particle->GetProcessManager();
     G4String              particleName = particle->GetParticleName();
-    
+
     /*  if (theCherenkovProcess->IsApplicable(*particle))
 	pmanager->AddContinuousProcess(theCherenkovProcess);*/
 
@@ -294,9 +295,9 @@ void WCSimPhysicsList::ConstructOp(){
       pmanager->AddProcess(theCherenkovProcess);
       pmanager->SetProcessOrdering(theCherenkovProcess,idxPostStep);
       }
-    
-    
-    if (particleName == "opticalphoton") 
+
+
+    if (particleName == "opticalphoton")
       {
 	pmanager->AddDiscreteProcess(theAbsorptionProcess);
 	//     G4cout << "warning direct light only\n";
@@ -304,7 +305,7 @@ void WCSimPhysicsList::ConstructOp(){
 	pmanager->AddDiscreteProcess(theWLSProcess);
 	pmanager->AddDiscreteProcess(theMieHGScatteringProcess);
 	pmanager->AddDiscreteProcess(theBoundaryProcess);
-	
+
       }
   }
 }
@@ -316,11 +317,11 @@ void WCSimPhysicsList::ConstructGeneral()
 {
   // Add Decay Process
   G4Decay* theDecayProcess = new G4Decay();
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
-    G4ParticleDefinition* particle = theParticleIterator->value();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
     G4ProcessManager* pmanager = particle->GetProcessManager();
-    if (theDecayProcess->IsApplicable(*particle)) { 
+    if (theDecayProcess->IsApplicable(*particle)) {
       pmanager ->AddProcess(theDecayProcess);
       // set ordering for PostStepDoIt and AtRestDoIt
       pmanager ->SetProcessOrdering(theDecayProcess, idxPostStep);
@@ -344,45 +345,21 @@ void WCSimPhysicsList::ConstructGeneral()
 #include "G4NeutronInelasticProcess.hh"
 #include "G4AntiNeutronInelasticProcess.hh"
 #include "G4DeuteronInelasticProcess.hh"
+#include "G4INCLXXInterface.hh"
 #include "G4TritonInelasticProcess.hh"
+#include "G4BinaryLightIonReaction.hh"
 #include "G4AlphaInelasticProcess.hh"
 
 // Low-energy Models: < 20GeV
-#include "G4LElastic.hh"
-#include "G4LEPionPlusInelastic.hh"
-#include "G4LEPionMinusInelastic.hh"
-#include "G4LEKaonPlusInelastic.hh"
-#include "G4LEKaonZeroSInelastic.hh"
-#include "G4LEKaonZeroLInelastic.hh"
-#include "G4LEKaonMinusInelastic.hh"
-#include "G4LEProtonInelastic.hh"
-#include "G4LEAntiProtonInelastic.hh"
-#include "G4LENeutronInelastic.hh"
-#include "G4LEAntiNeutronInelastic.hh"
-#include "G4LEDeuteronInelastic.hh"
-#include "G4LETritonInelastic.hh"
-#include "G4LEAlphaInelastic.hh"
+#include "G4HadronElastic.hh"
 
-// High-energy Models: >20 GeV
-#include "G4HEPionPlusInelastic.hh"
-#include "G4HEPionMinusInelastic.hh"
-#include "G4HEKaonPlusInelastic.hh"
-#include "G4HEKaonZeroInelastic.hh"
-#include "G4HEKaonZeroInelastic.hh"
-#include "G4HEKaonMinusInelastic.hh"
-#include "G4HEProtonInelastic.hh"
-#include "G4HEAntiProtonInelastic.hh"
-#include "G4HENeutronInelastic.hh"
-#include "G4HEAntiNeutronInelastic.hh"
-
-// Neutron high-precision models: <20 MeV
+// Neutron high-precision models: <20 CLHEP::MeV
 #include "G4NeutronHPElastic.hh"
 #include "G4NeutronHPElasticData.hh"
 #include "G4NeutronHPCapture.hh"
 #include "G4NeutronHPCaptureData.hh"
 #include "G4NeutronHPInelastic.hh"
 #include "G4NeutronHPInelasticData.hh"
-#include "G4LCapture.hh"
 
 //=================================
 // Added by JLR 2005-07-05
@@ -392,245 +369,245 @@ void WCSimPhysicsList::ConstructGeneral()
 #include "G4BinaryCascade.hh"
 
 // Stopping processes
-#include "G4PiMinusAbsorptionAtRest.hh"
-#include "G4KaonMinusAbsorptionAtRest.hh"
-#include "G4AntiProtonAnnihilationAtRest.hh"
-#include "G4AntiNeutronAnnihilationAtRest.hh"
+#include "G4PiMinusAbsorptionBertini.hh"
+#include "G4KaonMinusAbsorptionBertini.hh"
+#include "G4AntiProtonAbsorptionFritiof.hh"
+ #include "G4AntiNeutronAnnihilationAtRest.hh"
+
+// Include the FTF model - FDL
+#include "G4FTFModel.hh"
+#include "G4LundStringFragmentation.hh"
+#include "G4ExcitedStringDecay.hh"
+#include "G4PreCompoundModel.hh"
+#include "G4GeneratorPrecompoundInterface.hh"
+#include "G4TheoFSGenerator.hh"
 
 void WCSimPhysicsList::ConstructHad() 
 {
 
-// Makes discrete physics processes for the hadrons, at present limited
-// to those particles with GHEISHA interactions (INTRC > 0).
-// The processes are: Elastic scattering and Inelastic scattering.
-// F.W.Jones  09-JUL-1998
-// 
 // This code stolen from:
 // examples/advanced/underground_physics/src/DMXPhysicsList.cc
 // CWW 2/23/05
 //
-  
+
   G4HadronElasticProcess* theElasticProcess = new G4HadronElasticProcess;
-  G4LElastic* theElasticModel = new G4LElastic;
+  G4HadronElastic* theElasticModel = new G4HadronElastic;
   theElasticProcess->RegisterMe(theElasticModel);
-  
-  theParticleIterator->reset();
-  while ((*theParticleIterator)()) 
+
+  aParticleIterator->reset();
+  while ((*aParticleIterator)()) 
     {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+
+     // Add the FRITIOF model - FDL
+      G4TheoFSGenerator* FTFP_model = new G4TheoFSGenerator();
+      G4GeneratorPrecompoundInterface* theCascade = new G4GeneratorPrecompoundInterface();
+      G4ExcitationHandler* theHandler = new G4ExcitationHandler();
+      G4PreCompoundModel* thePreEquilib = new G4PreCompoundModel(theHandler);
+      theCascade->SetDeExcitation(thePreEquilib);
+      FTFP_model->SetTransport(theCascade);
+      G4LundStringFragmentation* theFragmentation = new G4LundStringFragmentation();
+      G4ExcitedStringDecay* theStringDecay = new G4ExcitedStringDecay(theFragmentation);    
+      G4FTFModel* theStringModel = new G4FTFModel;
+      theStringModel->SetFragmentationModel(theStringDecay);
+      FTFP_model->SetHighEnergyGenerator(theStringModel);
+ 
+      G4ParticleDefinition* particle = aParticleIterator->value();
       G4ProcessManager* pmanager = particle->GetProcessManager();
       G4String particleName = particle->GetParticleName();
 
-      if (particleName == "pi+") 
+      if (particleName == "pi+")
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4PionPlusInelasticProcess* theInelasticProcess = 
 	    new G4PionPlusInelasticProcess();
-	  G4LEPionPlusInelastic* theLEInelasticModel = 
-	    new G4LEPionPlusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEPionPlusInelastic* theHEInelasticModel = 
-	    new G4HEPionPlusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
+
+	  // Added Bertini Model - FDL
+	  G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	  theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theBertiniModel);
+
+	  // Added FTFP Model - SS
+	  FTFP_model->SetMinEnergy(4.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
 	  pmanager->AddDiscreteProcess(theInelasticProcess);
 	} 
 
-      else if (particleName == "pi-") 
+      else if (particleName == "pi-")
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4PionMinusInelasticProcess* theInelasticProcess = 
-	    new G4PionMinusInelasticProcess();
-	  G4LEPionMinusInelastic* theLEInelasticModel = 
-	    new G4LEPionMinusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEPionMinusInelastic* theHEInelasticModel = 
-	    new G4HEPionMinusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	  G4String prcNam;
-	  pmanager->AddRestProcess(new G4PiMinusAbsorptionAtRest, ordDefault);
-	}
+	  G4PionMinusInelasticProcess* theInelasticProcess =
+ 	    new G4PionMinusInelasticProcess();
+	  
+	  // Added Bertini Model - FDL
+	  G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	  theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theBertiniModel);
+
+	  // Added FTFP Model - SS
+	  FTFP_model->SetMinEnergy(4.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	  G4String prcNam;
+	  pmanager->AddRestProcess(new G4PiMinusAbsorptionBertini, ordDefault);
+ 	}
+      else if (particleName == "kaon+")
+ 	{
+	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4KaonPlusInelasticProcess* theInelasticProcess =
+ 	    new G4KaonPlusInelasticProcess();
       
-      else if (particleName == "kaon+") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4KaonPlusInelasticProcess* theInelasticProcess = 
-	    new G4KaonPlusInelasticProcess();
-	  G4LEKaonPlusInelastic* theLEInelasticModel = 
-	    new G4LEKaonPlusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonPlusInelastic* theHEInelasticModel = 
-	    new G4HEKaonPlusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	}
-      
-      else if (particleName == "kaon0S") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4KaonZeroSInelasticProcess* theInelasticProcess = 
+	  // Added Bertini Model - FDL
+          G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+          theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
+          theInelasticProcess->RegisterMe(theBertiniModel);
+
+          // Added FTFP Model - SS
+          FTFP_model->SetMinEnergy(4.0*CLHEP::GeV);
+          theInelasticProcess->RegisterMe(FTFP_model);
+
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	}
+
+      else if (particleName == "kaon0S")
+ 	{
+ 	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4KaonZeroSInelasticProcess* theInelasticProcess =
 	    new G4KaonZeroSInelasticProcess();
-	  G4LEKaonZeroSInelastic* theLEInelasticModel = 
-	    new G4LEKaonZeroSInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonZeroInelastic* theHEInelasticModel = 
-	    new G4HEKaonZeroInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	}
 
-      else if (particleName == "kaon0L") 
+	  // Added Bertini Model - FDL
+	  G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	  theBertiniModel->SetMaxEnergy(10.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theBertiniModel);
+
+	  // Added FTFP Model - SS
+	  FTFP_model->SetMinEnergy(3.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+	  
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	}
+ 
+      else if (particleName == "kaon0L")
+ 	{
+ 	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4KaonZeroLInelasticProcess* theInelasticProcess =
+ 	    new G4KaonZeroLInelasticProcess();
+	  
+	  // Added Bertini Model - FDL
+	  G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	  theBertiniModel->SetMaxEnergy(10.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theBertiniModel);
+
+	  // Added FTFP Model - SS
+	  FTFP_model->SetMinEnergy(3.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	}
+ 
+      else if (particleName == "kaon-")
+ 	{
+ 	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4KaonMinusInelasticProcess* theInelasticProcess =
+ 	    new G4KaonMinusInelasticProcess();
+
+	  // Added Bertini Model - FDL
+	  G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	  theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theBertiniModel);
+
+	  // Added FTFP Model - SS
+	  FTFP_model->SetMinEnergy(4.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+	  pmanager->AddRestProcess(new G4KaonMinusAbsorptionBertini, ordDefault);
+ 	}
+ 
+      else if (particleName == "proton")
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4KaonZeroLInelasticProcess* theInelasticProcess = 
-	    new G4KaonZeroLInelasticProcess();
-	  G4LEKaonZeroLInelastic* theLEInelasticModel = 
-	    new G4LEKaonZeroLInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonZeroInelastic* theHEInelasticModel = 
-	    new G4HEKaonZeroInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	}
-
-      else if (particleName == "kaon-") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4KaonMinusInelasticProcess* theInelasticProcess = 
-	    new G4KaonMinusInelasticProcess();
-	  G4LEKaonMinusInelastic* theLEInelasticModel = 
-	    new G4LEKaonMinusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonMinusInelastic* theHEInelasticModel = 
-	    new G4HEKaonMinusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	  pmanager->AddRestProcess(new G4KaonMinusAbsorptionAtRest, ordDefault);
-	}
-
-      else if (particleName == "proton") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4ProtonInelasticProcess* theInelasticProcess = 
+	  G4ProtonInelasticProcess* theInelasticProcess =
 	    new G4ProtonInelasticProcess();
 
-	  
-	  //=================================
-	  // Added by JLR 2005-07-05
-	  //=================================
-	  // Options for secondary interaction models
-	  // Choice defined in jobOptions.mac, which is
-	  // read in before initialization of the run manager.
-	  // In the absence of this file, BINARY will be used.
-	  // Gheisha = Original Geant4 default 
-	  // Bertini = Bertini intra-nuclear cascade model
-	  // Binary  = Binary intra-nuclear cascade model
-	  if (gheishahad) {
-	    G4LEProtonInelastic* theLEInelasticModel = new G4LEProtonInelastic;
-	    theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  }
-	  else if (bertinihad) {
+	  if (bertinihad) {
 	    G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	    theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
 	    theInelasticProcess->RegisterMe(theBertiniModel);
 	  }
 	  else if (binaryhad) {
 	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
+	    theBinaryModel->SetMaxEnergy(5.0*CLHEP::GeV);
 	    theInelasticProcess->RegisterMe(theBinaryModel);
-
-	    G4LEProtonInelastic* theLEInelasticModel = new G4LEProtonInelastic;
-	    theLEInelasticModel->SetMinEnergy(10.1*GeV);
-	    theLEInelasticModel->SetMaxEnergy( 45.*GeV );
-	    theInelasticProcess->RegisterMe(theLEInelasticModel);
-
 	  }
 	  else {
-	    G4cout << "No secondary interaction model chosen! Using G4 BINARY." << G4endl;
-	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theInelasticProcess->RegisterMe(theBinaryModel);
+	    G4cout << "No secondary interaction model chosen! Using G4 BERTINI." << G4endl;
+	    G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+	    theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
+	    theInelasticProcess->RegisterMe(theBertiniModel);
 	  }
 
-	  G4HEProtonInelastic* theHEInelasticModel = new G4HEProtonInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
+	  // Use FTFP model - FDL
+	  FTFP_model->SetMinEnergy(4.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
 	  pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
-      else if (particleName == "anti_proton") 
+      else if (particleName == "anti_proton")
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4AntiProtonInelasticProcess* theInelasticProcess = 
+	  G4AntiProtonInelasticProcess* theInelasticProcess =
 	    new G4AntiProtonInelasticProcess();
-	  G4LEAntiProtonInelastic* theLEInelasticModel = 
-	    new G4LEAntiProtonInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEAntiProtonInelastic* theHEInelasticModel = 
-	    new G4HEAntiProtonInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
+	  theInelasticProcess->RegisterMe(FTFP_model);
 	  pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
-      else if (particleName == "neutron") 
+      else if (particleName == "neutron")
 	{
 	  // elastic scattering
-	  G4HadronElasticProcess* theNeutronElasticProcess = 
+	  G4HadronElasticProcess* theNeutronElasticProcess =
 	    new G4HadronElasticProcess;
-	  G4LElastic* theElasticModel1 = new G4LElastic;
+	  G4HadronElastic* theElasticModel1 = new G4HadronElastic;
 	  G4NeutronHPElastic * theElasticNeutron = new G4NeutronHPElastic;
 	  theNeutronElasticProcess->RegisterMe(theElasticModel1);
-	  theElasticModel1->SetMinEnergy(19*MeV);
+	  theElasticModel1->SetMinEnergy(19*CLHEP::MeV);
 	  theNeutronElasticProcess->RegisterMe(theElasticNeutron);
 	  G4NeutronHPElasticData * theNeutronData = new G4NeutronHPElasticData;
 	  theNeutronElasticProcess->AddDataSet(theNeutronData);
 	  pmanager->AddDiscreteProcess(theNeutronElasticProcess);
-	  
+
 	  // inelastic scattering
 	  G4NeutronInelasticProcess* theInelasticProcess =
 	    new G4NeutronInelasticProcess();
-	  
-	  //=================================
-	  // Added by JLR 2005-07-05
-	  //=================================
-	  // Options for secondary interaction models
-	  // Choice defined in jobOptions.mac, which is
-	  // read in before initialization of the run manager.
-	  // In the absence of this file, BINARY will be used.
-	  // GHEISHA = Original Geant4 default model 
-	  // BERTINI = Bertini intra-nuclear cascade model
-	  // BINARY  = Binary intra-nuclear cascade model
-	  if (gheishahad) {
-	    G4LENeutronInelastic* theInelasticModel = new G4LENeutronInelastic;
-	    theInelasticModel->SetMinEnergy(19*MeV);
-	    theInelasticProcess->RegisterMe(theInelasticModel);
-	  }
-	  else if (bertinihad) {
+	  if (bertinihad) {
 	    G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
-	    theBertiniModel->SetMinEnergy(19*MeV);
+	    theBertiniModel->SetMinEnergy(19*CLHEP::MeV);
+	    theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
 	    theInelasticProcess->RegisterMe(theBertiniModel);
 	  }
 	  else if (binaryhad) {
 	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theBinaryModel->SetMinEnergy(19*MeV);
+	    theBinaryModel->SetMinEnergy(19*CLHEP::MeV);
+	    theBinaryModel->SetMaxEnergy(5.0*CLHEP::GeV);
 	    theInelasticProcess->RegisterMe(theBinaryModel);
-
-      G4LENeutronInelastic* theInelasticModel = new G4LENeutronInelastic;
-      theInelasticModel->SetMinEnergy(10.1*GeV);
-      theInelasticModel->SetMaxEnergy( 45.*GeV );
-      theInelasticProcess->RegisterMe(theInelasticModel);
 	  }
 	  else {
-	    G4cout << "No secondary interaction model chosen! Using G4 BINARY." << G4endl;
-	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theBinaryModel->SetMinEnergy(19*MeV);
-	    theInelasticProcess->RegisterMe(theBinaryModel);
+	    G4cout << "No secondary interaction model chosen! Using G4 BERTINI." << G4endl;
+	    G4CascadeInterface* theBertiniModel = new G4CascadeInterface();
+	    theBertiniModel->SetMinEnergy(19*CLHEP::MeV);
+	    theBertiniModel->SetMaxEnergy(5.0*CLHEP::GeV);
+	    theInelasticProcess->RegisterMe(theBertiniModel);
 	  }
 	  
-	  G4HENeutronInelastic* theHEInelasticModel = new G4HENeutronInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  
+	  // Use FTFP - FDL
+	  FTFP_model->SetMinEnergy(4.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+
 	  G4NeutronHPInelastic * theLENeutronInelasticModel =
 	    new G4NeutronHPInelastic;
 	  theInelasticProcess->RegisterMe(theLENeutronInelasticModel);
 	  
-	  G4NeutronHPInelasticData * theNeutronData1 = 
+	  G4NeutronHPInelasticData * theNeutronData1 =
 	    new G4NeutronHPInelasticData;
 	  theInelasticProcess->AddDataSet(theNeutronData1);
 	  pmanager->AddDiscreteProcess(theInelasticProcess);
@@ -638,103 +615,95 @@ void WCSimPhysicsList::ConstructHad()
 	  // capture
 	  G4HadronCaptureProcess* theCaptureProcess =
 	    new G4HadronCaptureProcess;
-	  G4LCapture* theCaptureModel = new G4LCapture;
-	  theCaptureModel->SetMinEnergy(19*MeV);
-	  theCaptureProcess->RegisterMe(theCaptureModel);
-	  G4NeutronHPCapture * theLENeutronCaptureModel = new G4NeutronHPCapture;
-	  theCaptureProcess->RegisterMe(theLENeutronCaptureModel);
-	  G4NeutronHPCaptureData * theNeutronData3 = new G4NeutronHPCaptureData;
-	  theCaptureProcess->AddDataSet(theNeutronData3);
+	  G4NeutronHPCapture* theCaptureModelHP = new G4NeutronHPCapture();
+	  theCaptureProcess->RegisterMe(theCaptureModelHP);
+	  G4NeutronHPCaptureData* theNeutronCaptureData = new G4NeutronHPCaptureData;
+	  theCaptureProcess->AddDataSet(theNeutronCaptureData);
+
 	  pmanager->AddDiscreteProcess(theCaptureProcess);
-	  //  G4ProcessManager* pmanager = G4Neutron::Neutron->GetProcessManager();
-	  //  pmanager->AddProcess(new G4UserSpecialCuts(),-1,-1,1);
 	}
 
-      else if (particleName == "anti_neutron") 
+      else if (particleName == "anti_neutron")
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4AntiNeutronInelasticProcess* theInelasticProcess = 
+	  G4AntiNeutronInelasticProcess* theInelasticProcess =
 	    new G4AntiNeutronInelasticProcess();
-	  G4LEAntiNeutronInelastic* theLEInelasticModel = 
-	    new G4LEAntiNeutronInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEAntiNeutronInelastic* theHEInelasticModel = 
-	    new G4HEAntiNeutronInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
+	  theInelasticProcess->RegisterMe(FTFP_model);
 	  pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
-      else if (particleName == "deuteron") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4DeuteronInelasticProcess* theInelasticProcess = 
-	    new G4DeuteronInelasticProcess();
-	  G4LEDeuteronInelastic* theLEInelasticModel = 
-	    new G4LEDeuteronInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	}
+else if (particleName == "deuteron")
+ 	{
+ 	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4DeuteronInelasticProcess* theInelasticProcess =
+ 	    new G4DeuteronInelasticProcess();
+
+	  // Use INCL++ for low energy and FTFP for high energy - SS
+	  G4INCLXXInterface* theINCLXXModel = new G4INCLXXInterface();
+	  theINCLXXModel->SetMaxEnergy(3.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theINCLXXModel);
+	  FTFP_model->SetMinEnergy(3.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+	  
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	}
+       
+      else if (particleName == "triton")
+ 	{
+ 	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4TritonInelasticProcess* theInelasticProcess =
+ 	    new G4TritonInelasticProcess();
+
+	  // Use Binary Light Ion Reaction for low energy
+	  // and FTFP for high energy - SS
+	  G4BinaryLightIonReaction* ionModel = new G4BinaryLightIonReaction();
+	  ionModel->SetMaxEnergy(10.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(ionModel);
+	  FTFP_model->SetMinEnergy(3.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
+
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	}
       
-      else if (particleName == "triton") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4TritonInelasticProcess* theInelasticProcess = 
-	    new G4TritonInelasticProcess();
-	  G4LETritonInelastic* theLEInelasticModel = 
-	    new G4LETritonInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	}
+      else if (particleName == "alpha")
+ 	{
+ 	  pmanager->AddDiscreteProcess(theElasticProcess);
+	  G4AlphaInelasticProcess* theInelasticProcess =
+ 	    new G4AlphaInelasticProcess();
 
-      else if (particleName == "alpha") 
-	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4AlphaInelasticProcess* theInelasticProcess = 
-	    new G4AlphaInelasticProcess();
-	  G4LEAlphaInelastic* theLEInelasticModel = 
-	    new G4LEAlphaInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	}
+	  // Use Binary for low energy and FTFP for high energy - SS
+	  G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
+	  theBinaryModel->SetMaxEnergy(4.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(theBinaryModel);
+	  FTFP_model->SetMinEnergy(2.0*CLHEP::GeV);
+	  theInelasticProcess->RegisterMe(FTFP_model);
 
+ 	  pmanager->AddDiscreteProcess(theInelasticProcess);
+ 	}
     }
 }
 
-//=================================
-// Added by JLR 2005-07-05
-//=================================
-// Sets secondary hadronic interaction model 
-// Note: this is currently only implemented for
-// protons and neutrons -- not pions.
-// Gheisha = Original Geant4 default 
-// Bertini = Bertini intra-nuclear cascade model
-// Binary  = Binary intra-nuclear cascade model
 void WCSimPhysicsList::SetSecondaryHad(G4String hadval)
 {
+
   SecondaryHadModel = hadval;
 
-  if (SecondaryHadModel == "GHEISHA") {
-    G4cout << "Secondary interaction model set to GHEISHA" << G4endl;
-    gheishahad = true;
-    bertinihad = false;
-    binaryhad  = false;
-  }
-  else if (SecondaryHadModel == "BERTINI") {
+  if (SecondaryHadModel == "BERTINI") {
     G4cout << "Secondary interaction model set to BERTINI" << G4endl;
-    gheishahad = false;
+
     bertinihad = true;
     binaryhad  = false;
   }
   else if (SecondaryHadModel == "BINARY") {
     G4cout << "Secondary interaction model set to BINARY" << G4endl;
-    gheishahad = false;
+
     bertinihad = false;
     binaryhad  = true;
   }
   else {
     G4cout << "Secondary interaction model " << SecondaryHadModel
 	   << " is not a valid choice. BINARY model will be used." << G4endl;
-    gheishahad = false;
+
     bertinihad = false;
     binaryhad  = true;
   }

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -6,7 +6,7 @@
 
 WCSimPhysicsListFactory::WCSimPhysicsListFactory() :  G4VModularPhysicsList()
 {
- defaultCutValue = 1.0*mm;
+  defaultCutValue = 1.0*CLHEP::mm;
  SetVerboseLevel(1);
  
  PhysicsListName="NULL_LIST"; // default list is set in WCSimPhysicsListFactoryMessenger to QGSP_BERT

--- a/src/WCSimPhysicsMessenger.cc
+++ b/src/WCSimPhysicsMessenger.cc
@@ -14,14 +14,14 @@ WCSimPhysicsMessenger::WCSimPhysicsMessenger(WCSimPhysicsList* WCSimPhys)
   WCSimDir->SetGuidance("Commands to change secondary interaction model for protons");
 
   hadmodelCmd = new G4UIcmdWithAString("/WCSim/physics/secondaries/model",this);
-  hadmodelCmd->SetGuidance("Available options: GHEISHA BERTINI BINARY");
+  hadmodelCmd->SetGuidance("Available options for low energy (< 10 GeV): BERTINI BINARY (default is BERTINI)");
+hadmodelCmd->SetGuidance("(For energies > 10 GeV the FTFP model is used)");
   hadmodelCmd->SetGuidance("Description:");
-  hadmodelCmd->SetGuidance("GHEISHA = standard, fast G4 hadronic interaction model");
   hadmodelCmd->SetGuidance("BERTINI = Bertini cascade model");
   hadmodelCmd->SetGuidance("BINARY  = Binary cascade model (2KM default)");
   hadmodelCmd->SetParameterName("secondaries", true, false);
-  hadmodelCmd->SetDefaultValue("BINARY");
-  hadmodelCmd->SetCandidates("GHEISHA BERTINI BINARY");
+  hadmodelCmd->SetDefaultValue("BERTINI");
+  hadmodelCmd->SetCandidates("BERTINI BINARY");
 
 }
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -52,7 +52,7 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
   
   G4int n_particle = 1;
   particleGun = new G4ParticleGun(n_particle);
-  particleGun->SetParticleEnergy(1.0*GeV);
+  particleGun->SetParticleEnergy(1.0*CLHEP::GeV);
   particleGun->SetParticleMomentumDirection(G4ThreeVector(0.,0.,1.0));
 
   G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
@@ -61,7 +61,7 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
     SetParticleDefinition(particleTable->FindParticle(particleName="mu+"));
 
   particleGun->
-    SetParticlePosition(G4ThreeVector(0.*m,0.*m,0.*m));
+    SetParticlePosition(G4ThreeVector(0.*CLHEP::m,0.*CLHEP::m,0.*CLHEP::m));
     
   messenger = new WCSimPrimaryGeneratorMessenger(this);
   useMulineEvt = true;
@@ -138,9 +138,9 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	    // Read the Vertex line
 	    token = readInLine(inputFile, lineSize, inBuf);
-	    vtx = G4ThreeVector(atof(token[1])*cm,
-				atof(token[2])*cm,
-				atof(token[3])*cm);
+	    vtx = G4ThreeVector(atof(token[1])*CLHEP::cm,
+				atof(token[2])*CLHEP::cm,
+				atof(token[3])*CLHEP::cm);
 	    
             // true : Generate vertex in Rock , false : Generate vertex in WC tank
             SetGenerateVertexInRock(false);
@@ -151,7 +151,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	    token=readInLine(inputFile, lineSize, inBuf);
 	    beampdg = atoi(token[1]);
-	    beamenergy = atof(token[2])*MeV;
+	    beamenergy = atof(token[2])*CLHEP::MeV;
 	    beamdir = G4ThreeVector(atof(token[3]),
 				    atof(token[4]),
 				    atof(token[5]));
@@ -160,7 +160,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	    token=readInLine(inputFile, lineSize, inBuf);
 	    targetpdg = atoi(token[1]);
-	    targetenergy = atof(token[2])*MeV;
+	    targetenergy = atof(token[2])*CLHEP::MeV;
 	    targetdir = G4ThreeVector(atof(token[3]),
 				      atof(token[4]),
 				      atof(token[5]));
@@ -184,7 +184,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		if ( token[6] == "0")
 		  {
 		    G4int pdgid = atoi(token[1]);
-		    G4double energy = atof(token[2])*MeV;
+		    G4double energy = atof(token[2])*CLHEP::MeV;
 		    G4ThreeVector dir = G4ThreeVector(atof(token[3]),
 						      atof(token[4]),
 						      atof(token[5]));
@@ -212,12 +212,12 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 	
 	G4double random_z = ((myDetector->GetWaterTubePosition())
 			     - .5*(myDetector->GetWaterTubeLength()) 
-			     + 1.*m + 15.0*m*G4UniformRand())/m;
+			     + 1.*CLHEP::m + 15.0*CLHEP::m*G4UniformRand())/CLHEP::m;
 	zPos = random_z;
 	G4ThreeVector vtx = G4ThreeVector(xPos, yPos, random_z);
 	G4ThreeVector dir = G4ThreeVector(xDir,yDir,zDir);
 
-	particleGun->SetParticleEnergy(energy*MeV);
+	particleGun->SetParticleEnergy(energy*CLHEP::MeV);
 	particleGun->SetParticlePosition(vtx);
 	particleGun->SetParticleMomentumDirection(dir);
 	particleGun->GeneratePrimaryVertex(anEvent);
@@ -234,7 +234,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     G4int pdg        =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
 
     G4ThreeVector dir  = P.unit();
-    G4double E         = std::sqrt((P.dot(P))+(m*m));
+    G4double E         = std::sqrt((P.dot(P))+(CLHEP::m*CLHEP::m));
 
 //     particleGun->SetParticleEnergy(E);
 //     particleGun->SetParticlePosition(vtx);

--- a/src/WCSimStackingAction.cc
+++ b/src/WCSimStackingAction.cc
@@ -28,7 +28,7 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
   // Make sure it is an optical photon
   if( particleType == G4OpticalPhoton::OpticalPhotonDefinition() )
     {
-      G4float photonWavelength = (2.0*M_PI*197.3)/(aTrack->GetTotalEnergy()/eV);
+      G4float photonWavelength = (2.0*M_PI*197.3)/(aTrack->GetTotalEnergy()/CLHEP::eV);
       G4float ratio = 1./(1.0-0.25);
       G4float wavelengthQE = 0;
       if(aTrack->GetCreatorProcess()==NULL) {
@@ -38,7 +38,7 @@ G4ClassificationOfNewTrack WCSimStackingAction::ClassifyNewTrack
       }
       else if (((G4VProcess*)(aTrack->GetCreatorProcess()))->GetProcessType()!=3)
 	{
-	  G4float photonWavelength = (2.0*M_PI*197.3)/(aTrack->GetTotalEnergy()/eV);
+	  G4float photonWavelength = (2.0*M_PI*197.3)/(aTrack->GetTotalEnergy()/CLHEP::eV);
 	  // MF : translated from skdetsim : better to increase the number of photons
 	  // than to throw in a global factor  at Digitization time !
 	  G4float ratio = 1./(1.0-0.25);

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -60,7 +60,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
   if( aTrack->GetParentID()==0 || 
       ((creatorProcess!=0) && ProcessList.count(creatorProcess->GetProcessName()) ) || 
       (ParticleList.count(aTrack->GetDefinition()->GetPDGEncoding()) )
-      || (aTrack->GetDefinition()->GetPDGEncoding()==22 && aTrack->GetTotalEnergy() > 50.0*MeV)
+      || (aTrack->GetDefinition()->GetPDGEncoding()==22 && aTrack->GetTotalEnergy() > 50.0*CLHEP::MeV)
       )
   {
     // if so the track is worth saving

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -93,7 +93,9 @@ void WCSimTrajectory::ShowTrajectory(std::ostream& os) const
 void WCSimTrajectory::DrawTrajectory(G4int i_mode) const
 {
   // Invoke the default implementation in G4VTrajectory...
-  G4VTrajectory::DrawTrajectory(i_mode);
+  // i_mode is removed in 4.10 - FDL
+  //G4VTrajectory::DrawTrajectory(i_mode);
+  G4VTrajectory::DrawTrajectory();
   // ... or override with your own code here.
 }
 

--- a/src/WCSimWCHit.cc
+++ b/src/WCSimWCHit.cc
@@ -87,12 +87,12 @@ void WCSimWCHit::Print()
   G4cout << " Tube:"  << std::setw(4) << tubeID 
 	 << " Track:" << std::setw(6) << trackID 
 	 << " Pe:"    << totalPe
-	 << " Pos:"   << pos/cm << G4endl
+	 << " Pos:"   << pos/CLHEP::cm << G4endl
 	 << "\tTime: "; 
 
   for (int i = 0; i < totalPe; i++) 
   {
-    G4cout << time[i]/ns << " ";
+    G4cout << time[i]/CLHEP::ns << " ";
     if ( i%10 == 0 && i != 0) 
       G4cout << G4endl << "\t";
   }

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -88,7 +88,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   G4String volumeName        = aStep->GetTrack()->GetVolume()->GetName();
   
   //XQ Add the wavelength there
-  G4float  wavelength = (2.0*M_PI*197.3)/( aStep->GetTrack()->GetTotalEnergy()/eV);
+  G4float  wavelength = (2.0*M_PI*197.3)/( aStep->GetTrack()->GetTotalEnergy()/CLHEP::eV);
   
   G4double energyDeposition  = aStep->GetTotalEnergyDeposit();
   G4double hitTime           = aStep->GetPreStepPoint()->GetGlobalTime();


### PR DESCRIPTION
Update of WCSim to be compatible with 4.10.1 (though should work w/ 4.10.2).  Most changes are for CLHEP, though some updates to physics model.  Work done by Sam Short and Francesca Di Lodovico.  Base update can be read here:
[neutroncapturesgd_geant410_samshort_fdl.pdf](https://github.com/WCSim/WCSim/files/323655/neutroncapturesgd_geant410_samshort_fdl.pdf)

Some validation plots with the changes from 4.9.4 to 4.10.1 can be read here:
[wcsim_terri_docdump.pdf](https://github.com/WCSim/WCSim/files/323658/wcsim_terri_docdump.pdf)
(Note: 4.10.2 also has a change to the Cherenkov time step that GEANT uses, which should affect the number of hits and possibly the timing.  Don't know exactly how just yet.)
