### PR TITLE
extend .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ make.rootcint.result
 make.result
 bin/
 tmp/
+doxygen/
 
 #ignore run results
-wcsim.root
+*.root
 geofile.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,14 @@ doxygen/
 #ignore run results
 *.root
 geofile.txt
+
+#ignore compiled ROOT scripts
+*_C.d
+*_C.so
+*_cxx.d
+*_cxx.so
+*_cc.d
+*_cc.so
+
+##ignore compiled python scripts
+*.pyc


### PR DESCRIPTION
Run results include `wcsim.root` (from `WCSim.mac`), `wcsimtest.root` (from `verifications-test-scripts/electrontest.mac`) and potentially outputs from a user’s own macros (with arbitrary file names), so let’s just ignore all `.root` files.

Also, once we start using doxygen (see #99), that’s another build results folder to ignore.
