### PR TITLE
Fix integer digit time bug

### DIFF
--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -197,7 +197,7 @@ void WCSimWCTriggerBase::AlgNDigits(WCSimWCDigitsCollection* WCDCPMT, bool remov
   int window_end_time   = WCSimWCTriggerBase::LongTime - ndigitsWindow;
   int window_step_size  = 5; //step the search window along this amount if no trigger is found
   float lasthit;
-  std::vector<int> digit_times;
+  std::vector<G4float> digit_times;
   bool first_loop = true;
 
   G4cout << "WCSimWCTriggerBase::AlgNDigits. Number of entries in input digit collection: " << WCDCPMT->entries() << G4endl;
@@ -221,7 +221,7 @@ void WCSimWCTriggerBase::AlgNDigits(WCSimWCDigitsCollection* WCDCPMT, bool remov
       //int tube=(*WCDCPMT)[i]->GetTubeID();
       //Loop over each Digit in this PMT
       for ( G4int ip = 0 ; ip < (*WCDCPMT)[i]->GetTotalPe() ; ip++) {
-	int digit_time = (*WCDCPMT)[i]->GetTime(ip);
+	G4float digit_time = (*WCDCPMT)[i]->GetTime(ip);
 	//hit in trigger window?
 	if(digit_time >= window_start_time && digit_time <= (window_start_time + ndigitsWindow)) {
 	  n_digits++;
@@ -334,7 +334,7 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
       int tube=(*WCDCPMT)[i]->GetTubeID();
       //loop over digits in this PMT
       for ( G4int ip = 0; ip < (*WCDCPMT)[i]->GetTotalPe(); ip++){
-	int digit_time  = (*WCDCPMT)[i]->GetTime(ip);
+	G4float digit_time  = (*WCDCPMT)[i]->GetTime(ip);
 	if(digit_time >= lowerbound && digit_time <= upperbound) {
 	  //hit in event window
 	  //add it to DigitsCollection


### PR DESCRIPTION
Digitized hit times are being floored to `int` in the trigger code, effectively being "rounded" to the previous nanosecond. This bug is present in the latest three tagged versions of WCSim `v1.5.0`, `v1.5.1` and `v1.6.0`.

Below are distributions of digitized hit times `WCSimRootCherenkovDigiHit::GetT()` for 600 MeV electron particle gun MC generated with WCSim `v1.4.0` (before the bug was introduced), the current state of the `develop` branch, and the code in this pull request.

![digitversioncomparefull](https://cloud.githubusercontent.com/assets/6059592/18067424/c1c44b78-6e0a-11e6-9a56-a474a3e3cdd6.png)

![digitversioncomparedetail](https://cloud.githubusercontent.com/assets/6059592/18067435/cda6d320-6e0a-11e6-8cb1-18ee3c403925.png)