### PR TITLE
Prevent digits from being saved multiple times in different trigger windows

### DIFF
--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -169,6 +169,27 @@ private:
 
   ///takes all trigger times, then loops over all Digits & fills the output DigitsCollection
   void FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, bool remove_hits, TriggerType_t save_triggerType);
+
+  ///sort the Trigger vectors (Time, Type, Info) by Trigger Time
+  void SortTriggersByTime() {
+    int i, j;
+    TriggerType_t index_type;
+    float index_time;
+    std::vector<float> index_info;
+    for (i = 1; i < (int) TriggerTimes.size(); ++i) {
+      index_time = TriggerTimes[i];
+      index_type = TriggerTypes[i];
+      index_info = TriggerInfos[i];
+      for (j = i; j > 0 && TriggerTimes[j-1] > index_time; j--) {
+	TriggerTimes[j] = TriggerTimes[j-1];
+	TriggerTypes[j] = TriggerTypes[j-1];
+	TriggerInfos[j] = TriggerInfos[j-1];
+      }//j
+      TriggerTimes[j] = index_time;
+      TriggerTypes[j] = index_type;
+      TriggerInfos[j] = index_info;
+    }//i
+  }
   
   static const double offset;        ///< Hit time offset (ns)
   static const double LongTime;      ///< An arbitrary long time to use in loops (ns)

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -306,6 +306,9 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
     save_triggerType = kTriggerFailure;
   }
 
+  //make sure the triggers are in time order
+  SortTriggersByTime();
+
   //Loop over trigger times
   for(unsigned int itrigger = 0; itrigger < TriggerTimes.size(); itrigger++) {
     TriggerType_t triggertype = TriggerTypes[itrigger];
@@ -318,6 +321,18 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
     //these are the boundary of the trigger gate: we want to add all digits within these bounds to the output collection
     float lowerbound = triggertime + GetPreTriggerWindow(triggertype);
     float upperbound = triggertime + GetPostTriggerWindow(triggertype);
+    //need to check for double-counting - check if the previous upperbound is above the lowerbound
+    if(itrigger) {
+      float upperbound_previous = TriggerTimes[itrigger - 1] + GetPostTriggerWindow(TriggerTypes[itrigger - 1]);
+      if(upperbound_previous > lowerbound) {
+	//also need to check whether the previous upperbound is above the lowerbound
+	//(different trigger windows for different trigger types can mean this trigger is completely contained within another)
+	// if it is, we skip it
+	if(upperbound_previous >= upperbound)
+	  continue;
+	lowerbound = upperbound_previous;
+      }
+    }
 
 #ifdef WCSIMWCTRIGGER_VERBOSE
     G4cout << "Saving trigger " << itrigger << " of type " << WCSimEnumerations::EnumAsString(triggertype)


### PR DESCRIPTION
Fixes #190

@cvilelasbu, could you make a tricolour plot to confirm it's working as expected

Standard verification. KS tests are 1

![electrontest_trigger_overlaps](https://cloud.githubusercontent.com/assets/11757479/19472318/b52bf86c-951e-11e6-860f-54a31fc931fc.png)
