### PR TITLE
Move hit time smearing from PMT to digit

### DIFF
--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -169,7 +169,11 @@ WCSimWCDigitizerSKI::~WCSimWCDigitizerSKI(){
 
 void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
   G4cout << "WCSimWCDigitizerSKI::DigitizeHits START WCHCPMT->entries() = " << WCHCPMT->entries() << G4endl;
-  
+
+  //Get the PMT info for hit time smearing
+  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
+  WCSimPMTObject * PMT = myDetector->GetPMTPointer(WCIDCollectionName);
+
   //loop over entires in WCHCPMT, each entry corresponds to
   //the photons on one PMT
   for (G4int i = 0 ; i < WCHCPMT->entries() ; i++)
@@ -266,9 +270,13 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 
 	    //Check if previous hit passed the threshold.  If so we will digitize the hit
 	    if(iflag == 0) {
+	      //apply time smearing
+	      float Q = (peSmeared > 0.5) ? peSmeared : 0.5;
 	      //digitize hit
 	      peSmeared *= efficiency;
-	      bool accepted = WCSimWCDigitizerBase::AddNewDigit(tube, digi_unique_id, intgr_start, peSmeared, digi_comp);
+	      bool accepted = WCSimWCDigitizerBase::AddNewDigit(tube, digi_unique_id,
+								intgr_start + PMT->HitTimeSmearing(Q),
+								peSmeared, digi_comp);
 	      if(accepted) {
 		digi_unique_id++;
 	      }

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -320,9 +320,13 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	      int iflag;
 	      WCSimWCDigitizerSKI::Threshold(peSmeared,iflag);
 	      if(iflag == 0) {
+		//apply time smearing
+		float Q = (peSmeared > 0.5) ? peSmeared : 0.5;
 		//digitize hit
 		peSmeared *= efficiency;
-		bool accepted = WCSimWCDigitizerBase::AddNewDigit(tube, digi_unique_id, intgr_start, peSmeared, digi_comp);
+		bool accepted = WCSimWCDigitizerBase::AddNewDigit(tube, digi_unique_id,
+								  intgr_start + PMT->HitTimeSmearing(Q),
+								  peSmeared, digi_comp);
 		if(accepted) {
 		  digi_unique_id++;
 		}

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -105,13 +105,14 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 
 	  for (G4int ip =0; ip < (*WCHC)[i]->GetTotalPe(); ip++){
 	    time_true = (*WCHC)[i]->GetTime(ip);
+	    time_PMT  = time_true; //currently no PMT time smearing applied
 	    peSmeared = rn1pe();
 	    int parent_id = (*WCHC)[i]->GetParentID(ip);
 
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();
 	      Digi->SetLogicalVolume((*WCHC)[0]->GetLogicalVolume());
-	      Digi->AddPe(time_PMT);	
+	      Digi->AddPe(time_PMT);
 	      Digi->SetTubeID(tube);
 	      Digi->SetPe(ip,peSmeared);
 	      Digi->SetTime(ip,time_PMT);

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -86,11 +86,6 @@ void WCSimWCPMT::Digitize()
 
 void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 { 
-
-  //Get the PMT info for hit time smearing
-  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
-  WCSimPMTObject * PMT = myDetector->GetPMTPointer(WCIDCollectionName);
-
   for (G4int i=0; i < WCHC->entries(); i++)
     {
 
@@ -112,10 +107,6 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	    time_true = (*WCHC)[i]->GetTime(ip);
 	    peSmeared = rn1pe();
 	    int parent_id = (*WCHC)[i]->GetParentID(ip);
-
-	    //apply time smearing
-	    float Q = (peSmeared > 0.5) ? peSmeared : 0.5;
-	    time_PMT = time_true + PMT->HitTimeSmearing(Q);
 
 	    if ( DigiHitMapPMT[tube] == 0) {
 	      WCSimWCDigi* Digi = new WCSimWCDigi();


### PR DESCRIPTION
Fixes bug described in #121 

Standard verification (with an added plot of digit time (absolute, not averaged digit time)):
ks test for # of digitized hits: 0.859294
ks test for average charge: 0.536054
ks test for average time: 0
ks test for time: 0

![electrontest_hit_time_smearing](https://cloud.githubusercontent.com/assets/11757479/19481281/46939e7e-9545-11e6-88e7-4aaa9ec0f123.png)

This makes sense from looking at the digit time plot. Now (red) PMT hits are not smeared, so the first hit in a digit has a much narrower spread between PMTs -> more symmetrical. They and have a smearing applied that is smaller than the previous smearing (smearing sigma goes as `C + D/Q`) -> narrower width

@cvilelasbu you might want to remake your comparison plots
