### PR TITLE
Run options in output

### DIFF
--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -56,7 +56,7 @@ ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.hh $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
 
 shared: $(ROOTSRC) $(ROOTOBJS) 
 	g++ -shared -O $(ROOTOBJS) -o $(ROOTSO) $(ROOTLIBS)

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -54,9 +54,9 @@ all: rootcint lib bin shared libWCSim.a
 
 ROOTSO    := libWCSimRoot.so
 
-ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./include/WCSimRootLinkDef.hh
+ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.hh $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
 
 shared: $(ROOTSRC) $(ROOTOBJS) 
 	g++ -shared -O $(ROOTOBJS) -o $(ROOTSO) $(ROOTLIBS)
@@ -66,7 +66,7 @@ libWCSim.a : $(ROOTOBJS)
 	ar clq $@ $(ROOTOBJS) 
 
 ./src/WCSimRootDict.cc : $(ROOTSRC)
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootLinkDef.hh
+	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootLinkDef.hh
 
 rootcint: ./src/WCSimRootDict.cc
 

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -24,9 +24,9 @@ G4TMPDIR := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim
 
 ROOTSO    := libWCSimRoot.so
 
-ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./include/WCSimRootLinkDef.hh
+ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./include/WCSimRootLinkDef.hh
 
-ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootDict.o 
+ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootGeom.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimPmtInfo.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimEnumerations.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootOptions.o $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSim
 
 
 
@@ -48,7 +48,7 @@ libWCSimRoot.so : $(ROOTOBJS)
 
 ./src/WCSimRootDict.cc : $(ROOTSRC)
 	@echo Compiling rootcint ...
-	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootLinkDef.hh
+	rootcint  -f ./src/WCSimRootDict.cc -c -I./include -I$(shell root-config --incdir) WCSimRootEvent.hh WCSimRootGeom.hh  WCSimPmtInfo.hh WCSimEnumerations.hh WCSimRootOptions.hh WCSimRootLinkDef.hh
 
 rootcint: ./src/WCSimRootDict.cc
 

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -91,6 +91,10 @@ int main(int argc,char** argv)
 
 
   WCSimRunAction* myRunAction = new WCSimRunAction(WCSimdetector);
+
+  //save all the options from WCSimTuningParameters, WCSimPhysicsListFactory
+  tuningpars->SaveOptionsToOutput(myRunAction->GetRootOptions());
+
   runManager->SetUserAction(myRunAction);
 
   runManager->SetUserAction(new WCSimEventAction(myRunAction, WCSimdetector,

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -90,7 +90,7 @@ int main(int argc,char** argv)
   runManager->SetUserAction(myGeneratorAction);
 
 
-  WCSimRunAction* myRunAction = new WCSimRunAction(WCSimdetector);
+  WCSimRunAction* myRunAction = new WCSimRunAction(WCSimdetector, randomparameters);
 
   //save all the options from WCSimTuningParameters & WCSimPhysicsListFactory
   //(set in tuning_parameters.mac & jobOptions*.mac)

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -92,7 +92,8 @@ int main(int argc,char** argv)
 
   WCSimRunAction* myRunAction = new WCSimRunAction(WCSimdetector);
 
-  //save all the options from WCSimTuningParameters, WCSimPhysicsListFactory
+  //save all the options from WCSimTuningParameters & WCSimPhysicsListFactory
+  //(set in tuning_parameters.mac & jobOptions*.mac)
   tuningpars->SaveOptionsToOutput(myRunAction->GetRootOptions());
   physFactory->SaveOptionsToOutput(myRunAction->GetRootOptions());
 

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -94,6 +94,7 @@ int main(int argc,char** argv)
 
   //save all the options from WCSimTuningParameters, WCSimPhysicsListFactory
   tuningpars->SaveOptionsToOutput(myRunAction->GetRootOptions());
+  physFactory->SaveOptionsToOutput(myRunAction->GetRootOptions());
 
   runManager->SetUserAction(myRunAction);
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -3,6 +3,7 @@
 
 #include "WCSimPmtInfo.hh"
 #include "WCSimPMTObject.hh"
+#include "WCSimRootOptions.hh"
 
 #include "G4Transform3D.hh"
 #include "G4VUserDetectorConstruction.hh"
@@ -53,7 +54,9 @@ public:
 
   WCSimDetectorConstruction(G4int DetConfig,WCSimTuningParameters* WCSimTuningPars);
   ~WCSimDetectorConstruction();
-  
+
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+
   G4VPhysicalVolume* Construct();
 
   // Related to the WC geometry

--- a/include/WCSimEnumerations.hh
+++ b/include/WCSimEnumerations.hh
@@ -15,12 +15,19 @@ typedef enum EDigitizerType {
   kDigitizerSKI
 } DigitizerType_t;
 
+typedef enum ERandomGeneratorType {
+  RANDOM_E_RANLUX=1,
+  RANDOM_E_RANECU=2,
+  RANDOM_E_HEPJAMES=3
+} WCSimRandomGenerator_t;
+
 class WCSimEnumerations
 {
 public:
 
   static std::string EnumAsString(DigitizerType_t d);
   static std::string EnumAsString(TriggerType_t t);
+  static std::string EnumAsString(WCSimRandomGenerator_t r);
   static TriggerType_t TriggerTypeFromString(std::string s);
 
 };

--- a/include/WCSimEventAction.hh
+++ b/include/WCSimEventAction.hh
@@ -53,6 +53,7 @@ private:
   G4String DigitizerChoice;
   G4String TriggerChoice;
   bool     ConstructedDAQClasses;
+  bool     SavedDAQOptions;
 };
 
 

--- a/include/WCSimEventAction.hh
+++ b/include/WCSimEventAction.hh
@@ -53,7 +53,7 @@ private:
   G4String DigitizerChoice;
   G4String TriggerChoice;
   bool     ConstructedDAQClasses;
-  bool     SavedDAQOptions;
+  bool     SavedOptions;
 };
 
 

--- a/include/WCSimPhysicsList.hh
+++ b/include/WCSimPhysicsList.hh
@@ -19,7 +19,8 @@ class WCSimPhysicsList: public G4VPhysicsConstructor
   // This method sets the model for 
   // hadronic secondary interactions
   void SetSecondaryHad(G4String hadval);
-
+  G4String GetSecondaryHadModel() {return SecondaryHadModel;}
+  
   private:
     WCSimPhysicsMessenger* PhysicsMessenger;
 

--- a/include/WCSimPhysicsListFactory.hh
+++ b/include/WCSimPhysicsListFactory.hh
@@ -37,6 +37,8 @@ class WCSimPhysicsListFactory : public G4VModularPhysicsList
 
     WCSimPhysicsListFactoryMessenger* PhysicsMessenger;
     G4PhysListFactory* factory;
+
+    WCSimPhysicsList * WCSimPhysList;
 };
 
 #endif

--- a/include/WCSimPhysicsListFactory.hh
+++ b/include/WCSimPhysicsListFactory.hh
@@ -9,6 +9,7 @@
 
 #include "WCSimPhysicsListFactoryMessenger.hh"
 #include "WCSimPhysicsList.hh"
+#include "WCSimRootOptions.hh"
 
 //class WCSimPhysicsList;
 
@@ -26,6 +27,9 @@ class WCSimPhysicsListFactory : public G4VModularPhysicsList
     void ConstructParticle();
     void ConstructProcess();
     void SetCuts();
+
+    void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+
   private:
 
     G4String PhysicsListName;

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -7,6 +7,8 @@
 
 #include <fstream>
 
+#include "WCSimRootOptions.hh"
+
 class WCSimDetectorConstruction;
 class G4ParticleGun;
 class G4GeneralParticleSource;
@@ -50,6 +52,10 @@ public:
   G4double GetXDir() {return xDir;};
   G4double GetYDir() {return yDir;};
   G4double GetZDir() {return zDir;};
+
+  G4String GetGeneratorTypeString();
+  
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
 
 private:
   WCSimDetectorConstruction*      myDetector;

--- a/include/WCSimRandomParameters.hh
+++ b/include/WCSimRandomParameters.hh
@@ -1,16 +1,11 @@
 #ifndef WCSimRandomParameters_h
 #define WCSimRandomParameters_h 1
 #include "WCSimRandomMessenger.hh"
+#include "WCSimRootOptions.hh"
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Random/RanluxEngine.h"
 #include "CLHEP/Random/JamesRandom.h"
 #include "CLHEP/Random/RanecuEngine.h"
-
-typedef enum {
-  RANDOM_E_RANLUX=1,
-  RANDOM_E_RANECU=2,
-  RANDOM_E_HEPJAMES=3
-} WCSimRandomGenerator;
 
 class WCSimRandomParameters
 {
@@ -24,8 +19,8 @@ public:
     }
   ~WCSimRandomParameters() {delete RandomMessenger;}
 
-  WCSimRandomGenerator GetGenerator() {return generator; }
-  void SetGenerator(WCSimRandomGenerator rng) 
+  WCSimRandomGenerator_t GetGenerator() {return generator; }
+  void SetGenerator(WCSimRandomGenerator_t rng)
   {
     switch (rng)
       {
@@ -66,8 +61,14 @@ public:
       seed = iseed;
     }
 
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt)
+  {
+    wcopt->SetRandomSeed(seed);
+    wcopt->SetRandomGenerator(generator);
+  }
+
 private:
-  WCSimRandomGenerator generator;
+  WCSimRandomGenerator_t generator;
   int seed;
   WCSimRandomMessenger *RandomMessenger;
 };

--- a/include/WCSimRootLinkDef.hh
+++ b/include/WCSimRootLinkDef.hh
@@ -19,6 +19,6 @@
 #pragma link C++ class WCSimRootPMT+;
 #pragma link C++ class WCSimPmtInfo+;
 #pragma link C++ class WCSimEnumerations+;
-
+#pragma link C++ class WCSimRootOptions+;
 
 #endif

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -107,6 +107,13 @@ public:
   //WCSimPhysicsListFactory gets
   string GetPhysicsListName() {return PhysicsListName;}
   string GetSecondaryHadModel() {return SecondaryHadModel;}
+  //WCSimPrimaryGeneratorAction sets
+  void SetVectorFileName(string iVectorFileName) {VectorFileName = iVectorFileName;}
+  void SetGeneratorType(string iGeneratorType) {GeneratorType = iGeneratorType;}
+  //WCSimPrimaryGeneratorAction gets
+  string GetVectorFileName() {return VectorFileName;}
+  string GetGeneratorType() {return GeneratorType;}
+  
   
 private:
   //WCSimDetector*
@@ -155,6 +162,10 @@ private:
   //WCSimPhysicsListFactory
   string PhysicsListName;
   string SecondaryHadModel;
+
+  //WCSimPrimaryGeneratorAction
+  string VectorFileName;
+  string GeneratorType;
   
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -12,6 +12,8 @@
 #include "TClonesArray.h"
 #include <string>
 
+#include "WCSimEnumerations.hh"
+
 class TDirectory;
 using std::string;
 
@@ -113,8 +115,13 @@ public:
   //WCSimPrimaryGeneratorAction gets
   string GetVectorFileName() {return VectorFileName;}
   string GetGeneratorType() {return GeneratorType;}
-  
-  
+  //WCSimRandomParameters sets
+  void SetRandomSeed(int iRandomSeed) {RandomSeed = iRandomSeed;}
+  void SetRandomGenerator(WCSimRandomGenerator_t iRandomGenerator) {RandomGenerator = iRandomGenerator;}
+  //WCSimRandomParameters gets
+  int                    GetRandomSeed() {return RandomSeed;}
+  WCSimRandomGenerator_t GetRandomGenerator() {return RandomGenerator;}
+
 private:
   //WCSimDetector*
   string DetectorName;
@@ -166,6 +173,10 @@ private:
   //WCSimPrimaryGeneratorAction
   string VectorFileName;
   string GeneratorType;
+
+  //WCSimRandomParameters
+  int                    RandomSeed;
+  WCSimRandomGenerator_t RandomGenerator;
   
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -17,17 +17,36 @@ class TDirectory;
 
 class WCSimRootOptions : public TObject {
 
-private:
-
-
 public:
 
   WCSimRootOptions();
   virtual ~WCSimRootOptions();
+  void Print();
 
-  // Sets and gets
-
-
+  //WCSimWCAddDarkNoise sets
+  void SetPMTDarkRate(double iPMTDarkRate) {PMTDarkRate = iPMTDarkRate;}
+  void SetConvRate(double iConvRate) {ConvRate = iConvRate;}
+  void SetDarkHigh(double iDarkHigh) {DarkHigh = iDarkHigh;}
+  void SetDarkLow(double iDarkLow) {DarkLow = iDarkLow;}
+  void SetDarkWindow(double iDarkWindow) {DarkWindow = iDarkWindow;}
+  void SetDarkMode(int iDarkMode) {DarkMode = iDarkMode;}
+  //WCSimWCAddDarkNoise gets
+  double GetPMTDarkRate() {return PMTDarkRate;}
+  double GetConvRate() {return ConvRate;}
+  double GetDarkHigh() {return DarkHigh;}
+  double GetDarkLow() {return DarkLow;}
+  double GetDarkWindow() {return DarkWindow;}
+  int    GetDarkMode() {return DarkMode;}
+  
+private:
+  //WCSimWCAddDarkNoise
+  double PMTDarkRate; // kHz
+  double ConvRate; // kHz
+  double DarkHigh; //ns
+  double DarkLow; //ns
+  double DarkWindow; //ns
+  int    DarkMode;
+  
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };
 

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -25,6 +25,16 @@ public:
   virtual ~WCSimRootOptions();
   void Print();
 
+  //WCSimDetector* gets
+  void SetDetectorName(string iDetectorName) {DetectorName = iDetectorName;}
+  void SetSavePi0(bool iSavePi0) {SavePi0 = iSavePi0;}
+  void SetPMTQEMethod(bool iPMTQEMethod) {PMTQEMethod = iPMTQEMethod;}
+  void SetPMTCollEff(bool iPMTCollEff) {PMTCollEff = iPMTCollEff;}
+  //WCSimDetector* sets
+  string GetDetectorName() {return DetectorName;}
+  bool   GetSavePi0() {return SavePi0;}
+  int    GetPMTQEMethod() {return PMTQEMethod;}
+  int    GetPMTCollEff() {return PMTCollEff;}
   //WCSimWCAddDarkNoise sets
   void SetPMTDarkRate(double iPMTDarkRate) {PMTDarkRate = iPMTDarkRate;}
   void SetConvRate(double iConvRate) {ConvRate = iConvRate;}
@@ -75,8 +85,14 @@ public:
   double GetSaveFailuresTime() {return SaveFailuresTime;}
   int    GetSaveFailuresPreTriggerWindow() {return SaveFailuresPreTriggerWindow;}
   int    GetSaveFailuresPostTriggerWindow() {return SaveFailuresPostTriggerWindow;}
-
+  
 private:
+  //WCSimDetector*
+  string DetectorName;
+  bool   SavePi0;
+  int    PMTQEMethod;
+  int    PMTCollEff;
+  
   //WCSimWCAddDarkNoise
   double PMTDarkRate; // kHz
   double ConvRate; // kHz
@@ -104,8 +120,7 @@ private:
   double SaveFailuresTime; // ns
   int    SaveFailuresPreTriggerWindow; // ns
   int    SaveFailuresPostTriggerWindow; // ns
-
-
+  
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };
 

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -101,6 +101,10 @@ public:
   double GetMieff() {return Mieff;}
   double GetTvspacing() {return Tvspacing;}
   bool   GetTopveto() {return Topveto;}
+  //WCSimPhysicsListFactory sets
+  void SetPhysicsListName(string iPhysicsListName) {PhysicsListName = iPhysicsListName;}
+  //WCSimPhysicsListFactory gets
+  string GetPhysicsListName() {return PhysicsListName;}
   
 private:
   //WCSimDetector*
@@ -146,6 +150,8 @@ private:
   double Tvspacing;
   bool   Topveto;
 
+  //WCSimPhysicsListFactory
+  string PhysicsListName;
   
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -85,6 +85,22 @@ public:
   double GetSaveFailuresTime() {return SaveFailuresTime;}
   int    GetSaveFailuresPreTriggerWindow() {return SaveFailuresPreTriggerWindow;}
   int    GetSaveFailuresPostTriggerWindow() {return SaveFailuresPostTriggerWindow;}
+  //WCSimTuningParameters sets
+  void SetRayff(double iRayff) {Rayff = iRayff;}
+  void SetBsrff(double iBsrff) {Bsrff = iBsrff;}
+  void SetAbwff(double iAbwff) {Abwff = iAbwff;}
+  void SetRgcff(double iRgcff) {Rgcff = iRgcff;}
+  void SetMieff(double iMieff) {Mieff = iMieff;}
+  void SetTvspacing(double iTvspacing) {Tvspacing = iTvspacing;}
+  void SetTopveto(bool iTopveto) {Topveto = iTopveto;}
+  //WCSimTuningParameters gets
+  double GetRayff() {return Rayff;}
+  double GetBsrff() {return Bsrff;}
+  double GetAbwff() {return Abwff;}
+  double GetRgcff() {return Rgcff;}
+  double GetMieff() {return Mieff;}
+  double GetTvspacing() {return Tvspacing;}
+  bool   GetTopveto() {return Topveto;}
   
 private:
   //WCSimDetector*
@@ -120,6 +136,16 @@ private:
   double SaveFailuresTime; // ns
   int    SaveFailuresPreTriggerWindow; // ns
   int    SaveFailuresPostTriggerWindow; // ns
+
+  //WCSimTuningParameters
+  double Rayff;
+  double Bsrff;
+  double Abwff;
+  double Rgcff;
+  double Mieff;
+  double Tvspacing;
+  bool   Topveto;
+
   
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -1,0 +1,35 @@
+#ifndef WCSim_RootOptions
+#define WCSim_RootOptions
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      
+// WCSim_RootOptions                                                      
+//                                                                      
+// This class contains run option information
+//////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+#include "TClonesArray.h"
+
+class TDirectory;
+
+//////////////////////////////////////////////////////////////////////////
+
+class WCSimRootOptions : public TObject {
+
+private:
+
+
+public:
+
+  WCSimRootOptions();
+  virtual ~WCSimRootOptions();
+
+  // Sets and gets
+
+
+  ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
+};
+
+
+#endif

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -103,8 +103,10 @@ public:
   bool   GetTopveto() {return Topveto;}
   //WCSimPhysicsListFactory sets
   void SetPhysicsListName(string iPhysicsListName) {PhysicsListName = iPhysicsListName;}
+  void SetSecondaryHadModel(string iSecondaryHadModel) {SecondaryHadModel = iSecondaryHadModel;}
   //WCSimPhysicsListFactory gets
   string GetPhysicsListName() {return PhysicsListName;}
+  string GetSecondaryHadModel() {return SecondaryHadModel;}
   
 private:
   //WCSimDetector*
@@ -152,6 +154,7 @@ private:
 
   //WCSimPhysicsListFactory
   string PhysicsListName;
+  string SecondaryHadModel;
   
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -10,8 +10,10 @@
 
 #include "TObject.h"
 #include "TClonesArray.h"
+#include <string>
 
 class TDirectory;
+using std::string;
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -37,16 +39,73 @@ public:
   double GetDarkLow() {return DarkLow;}
   double GetDarkWindow() {return DarkWindow;}
   int    GetDarkMode() {return DarkMode;}
-  
+  //WCSimWCDigitizer* sets
+  void SetDigitizerClassName(string iDigitizerClassName) {DigitizerClassName = iDigitizerClassName;}
+  void SetDigitizerDeadTime(int iDigitizerDeadTime) {DigitizerDeadTime = iDigitizerDeadTime;}
+  void SetDigitizerIntegrationWindow(int iDigitizerIntegrationWindow) {DigitizerIntegrationWindow = iDigitizerIntegrationWindow;}
+  //WCSimWCDigitizer* gets
+  string GetDigitizerClassName() {return DigitizerClassName;}
+  int    GetDigitizerDeadTime() {return DigitizerDeadTime;}
+  int    GetDigitizerIntegrationWindow() {return DigitizerIntegrationWindow;}
+  //WCSimWCTrigger* sets
+  void SetTriggerClassName(string itriggerClassName) {TriggerClassName = itriggerClassName;};
+  void SetMultiDigitsPerTrigger(bool imultiDigitsPerTrigger) {MultiDigitsPerTrigger = imultiDigitsPerTrigger;};
+  //ndigits
+  void SetNDigitsThreshold(int indigitsThreshold) {NDigitsThreshold = indigitsThreshold;};
+  void SetNDigitsWindow(int indigitsWindow) {NDigitsWindow = indigitsWindow;};
+  void SetNDigitsAdjustForNoise(bool indigitsAdjustForNoise) {NDigitsAdjustForNoise = indigitsAdjustForNoise;};
+  void SetNDigitsPreTriggerWindow(int indigitsPreTriggerWindow) {NDigitsPreTriggerWindow = indigitsPreTriggerWindow;};
+  void SetNDigitsPostTriggerWindow(int indigitsPostTriggerWindow) {NDigitsPostTriggerWindow = indigitsPostTriggerWindow;};
+  //savefailures
+  void SetSaveFailuresMode(int isaveFailuresMode) {SaveFailuresMode = isaveFailuresMode;};
+  void SetSaveFailuresTime(double isaveFailuresTime) {SaveFailuresTime = isaveFailuresTime;};
+  void SetSaveFailuresPreTriggerWindow(int isaveFailuresPreTriggerWindow) {SaveFailuresPreTriggerWindow = isaveFailuresPreTriggerWindow;};
+  void SetSaveFailuresPostTriggerWindow(int isaveFailuresPostTriggerWindow) {SaveFailuresPostTriggerWindow = isaveFailuresPostTriggerWindow;};
+  //WCSimWCTrigger* gets
+  string GetTriggerClassName() {return TriggerClassName;}
+  bool   GetMultiDigitsPerTrigger() {return MultiDigitsPerTrigger;}
+  //ndigits
+  int    GetNDigitsThreshold() {return NDigitsThreshold;}
+  int    GetNDigitsWindow() {return NDigitsWindow;}
+  bool   GetNDigitsAdjustForNoise() {return NDigitsAdjustForNoise;}
+  int    GetNDigitsPreTriggerWindow() {return NDigitsPreTriggerWindow;}
+  int    GetNDigitsPostTriggerWindow() {return NDigitsPostTriggerWindow;}
+  //savefailures
+  int    GetSaveFailuresMode() {return SaveFailuresMode;}
+  double GetSaveFailuresTime() {return SaveFailuresTime;}
+  int    GetSaveFailuresPreTriggerWindow() {return SaveFailuresPreTriggerWindow;}
+  int    GetSaveFailuresPostTriggerWindow() {return SaveFailuresPostTriggerWindow;}
+
 private:
   //WCSimWCAddDarkNoise
   double PMTDarkRate; // kHz
   double ConvRate; // kHz
-  double DarkHigh; //ns
-  double DarkLow; //ns
-  double DarkWindow; //ns
+  double DarkHigh; // ns
+  double DarkLow; // ns
+  double DarkWindow; // ns
   int    DarkMode;
-  
+
+  //WCSimWCDigitizer*
+  string DigitizerClassName;
+  int    DigitizerDeadTime; // ns
+  int    DigitizerIntegrationWindow; // ns
+
+  //WCSimWCTrigger*
+  string TriggerClassName;
+  bool   MultiDigitsPerTrigger;
+  //ndigits
+  int    NDigitsThreshold; // digitized hits
+  int    NDigitsWindow; // ns
+  bool   NDigitsAdjustForNoise;
+  int    NDigitsPreTriggerWindow; // ns
+  int    NDigitsPostTriggerWindow; // ns
+  //savefailures
+  int    SaveFailuresMode;
+  double SaveFailuresTime; // ns
+  int    SaveFailuresPreTriggerWindow; // ns
+  int    SaveFailuresPostTriggerWindow; // ns
+
+
   ClassDef(WCSimRootOptions,1)  //WCSimRootEvent structure
 };
 

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -11,6 +11,7 @@
 #include "WCSimRootGeom.hh"
 #include "WCSimRootOptions.hh"
 #include "WCSimDetectorConstruction.hh"
+#include "WCSimRandomParameters.hh"
 
 class G4Run;
 class WCSimRunActionMessenger;
@@ -18,7 +19,7 @@ class WCSimRunActionMessenger;
 class WCSimRunAction : public G4UserRunAction
 {
 public:
-  WCSimRunAction(WCSimDetectorConstruction*);
+  WCSimRunAction(WCSimDetectorConstruction*, WCSimRandomParameters*);
   ~WCSimRunAction();
 
 public:
@@ -54,6 +55,7 @@ private:
   WCSimRootGeom* wcsimrootgeom;
   WCSimRootOptions* wcsimrootoptions;
   WCSimDetectorConstruction* wcsimdetector;
+  WCSimRandomParameters* wcsimrandomparameters;
 
   int numberOfEventsGenerated;
   int numberOfTimesWaterTubeHit;

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -9,6 +9,7 @@
 #include "TTree.h"
 #include "WCSimRootEvent.hh"
 #include "WCSimRootGeom.hh"
+#include "WCSimRootOptions.hh"
 #include "WCSimDetectorConstruction.hh"
 
 class G4Run;
@@ -28,13 +29,11 @@ public:
   void FillGeoTree();
   TTree* GetTree(){return WCSimTree;}
   TTree* GetGeoTree(){return geoTree;}
+  TTree* GetOptionsTree(){return optionsTree;}
   WCSimRootGeom* GetRootGeom(){return wcsimrootgeom;}
   WCSimRootEvent* GetRootEvent(){return wcsimrootsuperevent;}
+  WCSimRootOptions* GetRootOptions(){return wcsimrootoptions;}
 
-  void SetTree(TTree* tree){WCSimTree=tree;}
-  void SetGeoTree(TTree* tree){geoTree=tree;}
-  void SetRootEvent(WCSimRootEvent* revent){wcsimrootsuperevent=revent;}
-  void SetRootGeom(WCSimRootGeom* rgeom){wcsimrootgeom=rgeom;}
   int  GetNumberOfEventsGenerated() { return numberOfEventsGenerated;}
   int  GetNtuples(){return ntuples;}
 
@@ -50,8 +49,10 @@ private:
   //
   TTree* WCSimTree;
   TTree* geoTree;
+  TTree* optionsTree;
   WCSimRootEvent* wcsimrootsuperevent;
   WCSimRootGeom* wcsimrootgeom;
+  WCSimRootOptions* wcsimrootoptions;
   WCSimDetectorConstruction* wcsimdetector;
 
   int numberOfEventsGenerated;

--- a/include/WCSimTuningParameters.hh
+++ b/include/WCSimTuningParameters.hh
@@ -1,13 +1,14 @@
 #ifndef WCSimTuningParameters_h
 #define WCSimTuningParameters_h 1
 #include "WCSimTuningMessenger.hh"
+#include "WCSimRootOptions.hh"
 #include "globals.hh"
 
 class WCSimTuningParameters
 {
-  public:
-    WCSimTuningParameters();
-    ~WCSimTuningParameters();
+public:
+  WCSimTuningParameters();
+  ~WCSimTuningParameters();
 
 
   // Setters and getters
@@ -33,7 +34,9 @@ class WCSimTuningParameters
   G4bool GetTopVeto() {return topveto;}
   void SetTopVeto(G4double tparam) {topveto=tparam;}
 
-  private:
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+
+private:
 
   // The messenger
   WCSimTuningMessenger* TuningMessenger;

--- a/include/WCSimWCAddDarkNoise.hh
+++ b/include/WCSimWCAddDarkNoise.hh
@@ -6,6 +6,7 @@
 #include "G4VDigitizerModule.hh"
 #include "WCSimWCDigi.hh"
 #include "WCSimWCHit.hh"
+#include "WCSimRootOptions.hh"
 #include "globals.hh"
 #include "Randomize.hh"
 #include <map>
@@ -32,7 +33,8 @@ public:
   void SetDarkHigh(int idarkhigh){DarkHigh = idarkhigh;}
   void SetDarkLow(int idarklow){DarkLow = idarklow;}
   void SetDarkWindow(int idarkwindow){DarkWindow = idarkwindow;}
-
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+  
 private:
   void ReInitialize() { ranges.clear(); result.clear();}
   void SetPMTDarkDefaults();

--- a/include/WCSimWCDigitizer.hh
+++ b/include/WCSimWCDigitizer.hh
@@ -1,6 +1,7 @@
 #ifndef WCSimWCDigitizer_h
 #define WCSimWCDigitizer_h 1
 
+#include "WCSimRootOptions.hh"
 #include "WCSimDarkRateMessenger.hh"
 #include "WCSimWCDAQMessenger.hh"
 #include "WCSimDetectorConstruction.hh"
@@ -34,6 +35,9 @@ public:
   void SetDigitizerDeadTime         (int deadtime) { DigitizerDeadTime = deadtime;         }; ///< Override the default digitizer deadtime (ns)
   void SetDigitizerIntegrationWindow(int inttime ) { DigitizerIntegrationWindow = inttime; }; ///< Override the default digitizer integration window (ns)
 
+  ///Save current values of options
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+  
 protected:
   void ReInitialize() { DigiStoreHitMap.clear(); }
 
@@ -46,6 +50,7 @@ protected:
   std::map<int,int> DigiStoreHitMap;   ///< Used to check if a digit has already been created on a PMT
 
   //generic digitizer properties. Defaults set with the GetDefault*() methods. Overidden by .mac options
+  G4String DigitizerClassName;    ///< Name of the digitizer class being run
   int DigitizerDeadTime;          ///< Digitizer deadtime (ns)
   int DigitizerIntegrationWindow; ///< Digitizer integration window (ns)
 

--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -1,6 +1,7 @@
 #ifndef WCSimWCTrigger_h
 #define WCSimWCTrigger_h 1
 
+#include "WCSimRootOptions.hh"
 #include "WCSimEnumerations.hh"
 #include "WCSimWCDAQMessenger.hh"
 #include "WCSimDetectorConstruction.hh"
@@ -83,7 +84,9 @@ public:
   ///Knowledge of the dark rate (use for automatically adjusting for noise)
   void SetDarkRate(double idarkrate){ PMTDarkRate = idarkrate; }
 
-
+  ///Save current values of options
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+  
 protected:
 
   ///This should call the trigger algorithms, and handle any temporary DigitsCollection's

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -88,6 +88,17 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
   }
   geotree->GetEntry(0);
 
+  // Options tree - only need 1 "event"
+  TTree *opttree = (TTree*)file->Get("wcsimRootOptionsT");
+  WCSimRootOptions *opt = 0; 
+  opttree->SetBranchAddress("wcsimrootoptions", &opt);
+  if(verbose) std::cout << "Optree has " << opttree->GetEntries() << " entries" << std::endl;
+  if (opttree->GetEntries() == 0) {
+    exit(9);
+  }
+  opttree->GetEntry(0);
+  opt->Print();
+
   // start with the main "subevent", as it contains most of the info
   // and always exists.
   WCSimRootTrigger* wcsimrootevent;

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -257,3 +257,11 @@ WCSimPMTObject *WCSimDetectorConstruction::CreatePMTObject(G4String PMTType, G4S
 
   else { G4cout << PMTType << " is not a recognized PMT Type. Exiting WCSim." << G4endl; exit(1);}
 }
+
+void WCSimDetectorConstruction::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  wcopt->SetDetectorName(WCDetectorName);
+  wcopt->SetSavePi0(pi0Info_isSaved);
+  wcopt->SetPMTQEMethod(PMT_QE_Method);
+  wcopt->SetPMTCollEff(PMT_Coll_Eff);
+}

--- a/src/WCSimEnumerations.cc
+++ b/src/WCSimEnumerations.cc
@@ -35,6 +35,25 @@ std::string WCSimEnumerations::EnumAsString(TriggerType_t t)
   return "";
 }
 
+std::string WCSimEnumerations::EnumAsString(WCSimRandomGenerator_t r)
+{
+  switch(r) {
+  case (RANDOM_E_RANLUX) :
+    return "RANLUX";
+    break;
+  case (RANDOM_E_RANECU) :
+    return "RANECU";
+    break;
+  case (RANDOM_E_HEPJAMES) :
+    return "HEPJAMES";
+    break;
+  default:
+    return "";
+    break;
+  }
+  return "";
+}
+
 TriggerType_t WCSimEnumerations::TriggerTypeFromString(std::string s)
 {
   for(int i = int(kTriggerUndefined)+1; i <= kTriggerFailure; i++) {

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -60,7 +60,7 @@ WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
   :runAction(myRun), generatorAction(myGenerator), 
    detectorConstructor(myDetector),
    ConstructedDAQClasses(false),
-   SavedDAQOptions(false)
+   SavedOptions(false)
 {
   DAQMessenger = new WCSimWCDAQMessenger(this);
 
@@ -401,7 +401,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 
   //save DAQ options here. This ensures that when the user selects a default option
   // (e.g. with -99), the saved option value in the output reflects what was run
-  if(!SavedDAQOptions) {
+  if(!SavedOptions) {
     WCSimRootOptions * wcsimopt = runAction->GetRootOptions();
     //Dark noise
     WCDNM->SaveOptionsToOutput(wcsimopt);
@@ -409,8 +409,10 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     WCDM->SaveOptionsToOutput(wcsimopt);
     //Trigger
     WCTM->SaveOptionsToOutput(wcsimopt);
+    //Generator
+    generatorAction->SaveOptionsToOutput(wcsimopt);
     
-    SavedDAQOptions = true;
+    SavedOptions = true;
   }
 }
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -894,11 +894,10 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   
   TTree* tree = GetRunAction()->GetTree();
   tree->Fill();
-  TFile* hfile = tree->GetCurrentFile();
   // MF : overwrite the trees -- otherwise we have as many copies of the tree
   // as we have events. All the intermediate copies are incomplete, only the
   // last one is useful --> huge waste of disk space.
-  hfile->Write("",TObject::kOverwrite);
+  tree->Write("",TObject::kOverwrite);
   
   // M Fechner : reinitialize the super event after the writing is over
   wcsimrootsuperevent->ReInitialize();

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -59,7 +59,8 @@ WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
 				   WCSimPrimaryGeneratorAction* myGenerator)
   :runAction(myRun), generatorAction(myGenerator), 
    detectorConstructor(myDetector),
-   ConstructedDAQClasses(false)
+   ConstructedDAQClasses(false),
+   SavedDAQOptions(false)
 {
   DAQMessenger = new WCSimWCDAQMessenger(this);
 
@@ -120,8 +121,13 @@ void WCSimEventAction::CreateDAQInstances()
 
 void WCSimEventAction::BeginOfEventAction(const G4Event*)
 {
-  if(!ConstructedDAQClasses)
+  if(!ConstructedDAQClasses) {
     CreateDAQInstances();
+
+    //and save options in output file
+    G4DigiManager* DMman = G4DigiManager::GetDMpointer();
+
+  }
 }
 
 void WCSimEventAction::EndOfEventAction(const G4Event* evt)
@@ -393,6 +399,15 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 		WCDC_hits,
 		WCDC);
 
+  //save DAQ options here. This ensures that when the user selects a default option
+  // (e.g. with -99), the saved option value in the output reflects what was run
+  if(!SavedDAQOptions) {
+    WCSimRootOptions * wcsimopt = runAction->GetRootOptions();
+    //Dark noise
+    WCDNM->SaveOptionsToOutput(wcsimopt);
+
+    SavedDAQOptions = true;
+  }
 }
 
 G4int WCSimEventAction::WCSimEventFindStartingVolume(G4ThreeVector vtx)

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -405,7 +405,11 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     WCSimRootOptions * wcsimopt = runAction->GetRootOptions();
     //Dark noise
     WCDNM->SaveOptionsToOutput(wcsimopt);
-
+    //Digitizer
+    WCDM->SaveOptionsToOutput(wcsimopt);
+    //Trigger
+    WCTM->SaveOptionsToOutput(wcsimopt);
+    
     SavedDAQOptions = true;
   }
 }

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -1,4 +1,4 @@
-1;95;0c#include "WCSimPhysicsListFactory.hh"
+#include "WCSimPhysicsListFactory.hh"
 
 /* This code draws upon examples/extended/fields/field04 for inspiration */
 

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -93,3 +93,8 @@ void WCSimPhysicsListFactory::InitializeList(){
     G4cout << "Physics list " << PhysicsListName << " is not understood" << G4endl;
   }
 } 
+
+void WCSimPhysicsListFactory::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  wcopt->SetPhysicsListName(PhysicsListName);
+}

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -1,10 +1,10 @@
-#include "WCSimPhysicsListFactory.hh"
+1;95;0c#include "WCSimPhysicsListFactory.hh"
 
 /* This code draws upon examples/extended/fields/field04 for inspiration */
 
 
 
-WCSimPhysicsListFactory::WCSimPhysicsListFactory() :  G4VModularPhysicsList()
+WCSimPhysicsListFactory::WCSimPhysicsListFactory() :  G4VModularPhysicsList(), WCSimPhysList(0)
 {
  defaultCutValue = 1.0*mm;
  SetVerboseLevel(1);
@@ -87,8 +87,9 @@ void WCSimPhysicsListFactory::InitializeList(){
     RegisterPhysics(new G4OpticalPhysics());
   } else if (PhysicsListName == "WCSim") {
     //G4cout << "WCSim physics list not yet implemented" << G4endl;
-    G4cout << "RegisterPhysics: WCSim" << G4endl; 
-    RegisterPhysics(new WCSimPhysicsList());
+    G4cout << "RegisterPhysics: WCSim" << G4endl;
+    WCSimPhysList = new WCSimPhysicsList();
+    RegisterPhysics(WCSimPhysList);
   } else {
     G4cout << "Physics list " << PhysicsListName << " is not understood" << G4endl;
   }
@@ -97,4 +98,8 @@ void WCSimPhysicsListFactory::InitializeList(){
 void WCSimPhysicsListFactory::SaveOptionsToOutput(WCSimRootOptions * wcopt)
 {
   wcopt->SetPhysicsListName(PhysicsListName);
+  if(WCSimPhysList)
+    wcopt->SetSecondaryHadModel(WCSimPhysList->GetSecondaryHadModel());
+  else
+    wcopt->SetSecondaryHadModel("NOTREQUIRED");
 }

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -35,7 +35,7 @@ inline int   atoi( const string& s ) {return std::atoi( s.c_str() );}
 
 WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
 					  WCSimDetectorConstruction* myDC)
-  :myDetector(myDC)
+  :myDetector(myDC), vectorFileName("")
 {
   //T. Akiri: Initialize GPS to allow for the laser use 
   MyGPS = new G4GeneralParticleSource();
@@ -262,6 +262,26 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       SetBeamDir(dir);
       SetBeamPDG(pdg);
     }
+}
+
+void WCSimPrimaryGeneratorAction::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  if(useMulineEvt)
+    wcopt->SetVectorFileName(vectorFileName);
+  else
+    wcopt->SetVectorFileName("");
+  wcopt->SetGeneratorType(GetGeneratorTypeString());
+}
+
+G4String WCSimPrimaryGeneratorAction::GetGeneratorTypeString()
+{
+  if(useMulineEvt)
+    return "muline";
+  else if(useNormalEvt)
+    return "gun";
+  else if(useLaserEvt)
+    return "laser";
+  return "";
 }
 
 // Returns a vector with the tokens

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -296,8 +296,10 @@ G4String WCSimPrimaryGeneratorAction::GetGeneratorTypeString()
 {
   if(useMulineEvt)
     return "muline";
-  else if(useNormalEvt)
+  else if(useGunEvt)
     return "gun";
+  else if(useGPSEvt)
+    return "gps";
   else if(useLaserEvt)
     return "laser";
   return "";

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -66,5 +66,7 @@ void WCSimRootOptions::Print()
     << "\tMieff: " << Mieff << endl
     << "\tTvspacing: " << Tvspacing << endl
     << "\tTopveto: " << Topveto << endl
+    << "Physics List Factory:" << endl
+    << "\tPhysicsListName: " << PhysicsListName << endl
     << endl;
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+
+#include "WCSimRootOptions.hh"
+
+#ifndef REFLEX_DICTIONARY
+ClassImp(WCSimRootOptions)
+#endif
+
+//______________________________________________________________________________
+WCSimRootOptions::WCSimRootOptions()
+{
+  // Create a WCSimRootOptions object.
+
+}
+
+//______________________________________________________________________________
+WCSimRootOptions::~WCSimRootOptions()
+{
+}

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -1,12 +1,16 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "TObject.h"
+#include <iostream>
 
 #include "WCSimRootOptions.hh"
 
 #ifndef REFLEX_DICTIONARY
 ClassImp(WCSimRootOptions)
 #endif
+
+using std::endl;
+using std::cout;
 
 //______________________________________________________________________________
 WCSimRootOptions::WCSimRootOptions()
@@ -18,4 +22,18 @@ WCSimRootOptions::WCSimRootOptions()
 //______________________________________________________________________________
 WCSimRootOptions::~WCSimRootOptions()
 {
+}
+
+//______________________________________________________________________________
+void WCSimRootOptions::Print()
+{
+  cout
+    << "Dark Noise options" << endl
+    << "\tPMTDarkRate: " << PMTDarkRate << " kHz" << endl
+    << "\tConvRate: " << ConvRate << " kHz" << endl
+    << "\tDarkHigh: " << DarkHigh << " ns" << endl
+    << "\tDarkLow: " << DarkLow << " ns" << endl
+    << "\tDarkWindow: " << DarkWindow << " ns" << endl
+    << "\tDarkMode: " << DarkMode << endl
+    << endl;
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -68,5 +68,6 @@ void WCSimRootOptions::Print()
     << "\tTopveto: " << Topveto << endl
     << "Physics List Factory:" << endl
     << "\tPhysicsListName: " << PhysicsListName << endl
+    << "\tSecondaryHadModel: " << SecondaryHadModel << endl
     << endl;
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -28,6 +28,11 @@ WCSimRootOptions::~WCSimRootOptions()
 void WCSimRootOptions::Print()
 {
   cout
+    << "Detector construction:" << endl
+    << "\tDetectorName: " << DetectorName << endl
+    << "\tSavePi0: " << SavePi0 << endl
+    << "\tPMTQEMethod: " << PMTQEMethod << endl
+    << "\tPMTCollEff: " << PMTCollEff << endl
     << "Dark Noise options:" << endl
     << "\tPMTDarkRate: " << PMTDarkRate << " kHz" << endl
     << "\tConvRate: " << ConvRate << " kHz" << endl

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -69,5 +69,8 @@ void WCSimRootOptions::Print()
     << "Physics List Factory:" << endl
     << "\tPhysicsListName: " << PhysicsListName << endl
     << "\tSecondaryHadModel: " << SecondaryHadModel << endl
+    << "WCSimPrimaryGeneratorAction" << endl
+    << "\tVectorFileName: " << VectorFileName << endl
+    << "\tGeneratorType: " << GeneratorType << endl
     << endl;
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -28,12 +28,30 @@ WCSimRootOptions::~WCSimRootOptions()
 void WCSimRootOptions::Print()
 {
   cout
-    << "Dark Noise options" << endl
+    << "Dark Noise options:" << endl
     << "\tPMTDarkRate: " << PMTDarkRate << " kHz" << endl
     << "\tConvRate: " << ConvRate << " kHz" << endl
     << "\tDarkHigh: " << DarkHigh << " ns" << endl
     << "\tDarkLow: " << DarkLow << " ns" << endl
     << "\tDarkWindow: " << DarkWindow << " ns" << endl
     << "\tDarkMode: " << DarkMode << endl
+    << "Digitizer options:" << endl
+    << "\tDigitizerClassName: " << DigitizerClassName << endl
+    << "\tDigitizerDeadTime: " << DigitizerDeadTime << " ns" << endl
+    << "\tDigitizerIntegrationWindow: " << DigitizerIntegrationWindow << " ns" << endl
+    << "Trigger options:" << endl
+    << "\tTriggerClassName: " << TriggerClassName << endl
+    << "\tMultiDigitsPerTrigger: " << MultiDigitsPerTrigger << endl
+    << "NDigits-style trigger options:" << endl
+    << "\tNDigitsThreshold: " << NDigitsThreshold << " digitized hits" << endl
+    << "\tNDigitsWindow: " << NDigitsWindow << " ns" << endl
+    << "\tNDigitsAdjustForNoise: " << NDigitsAdjustForNoise << endl
+    << "\tNDigitsPreTriggerWindow: " << NDigitsPreTriggerWindow << " ns" << endl
+    << "\tNDigitsPostTriggerWindow: " << NDigitsPostTriggerWindow << " ns" << endl
+    << "Save failures trigger options:" << endl
+    << "\tSaveFailuresMode: " << SaveFailuresMode << endl
+    << "\tSaveFailuresTime: " << SaveFailuresTime << " ns" << endl
+    << "\tSaveFailuresPreTriggerWindow: " << SaveFailuresPreTriggerWindow << " ns" << endl
+    << "\tSaveFailuresPostTriggerWindow: " << SaveFailuresPostTriggerWindow << " ns" << endl
     << endl;
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -58,5 +58,13 @@ void WCSimRootOptions::Print()
     << "\tSaveFailuresTime: " << SaveFailuresTime << " ns" << endl
     << "\tSaveFailuresPreTriggerWindow: " << SaveFailuresPreTriggerWindow << " ns" << endl
     << "\tSaveFailuresPostTriggerWindow: " << SaveFailuresPostTriggerWindow << " ns" << endl
+    << "Tuning parameters:" << endl
+    << "\tRayff: " << Rayff << endl
+    << "\tBsrff: " << Bsrff << endl
+    << "\tAbwff: " << Abwff << endl
+    << "\tRgcff: " << Rgcff << endl
+    << "\tMieff: " << Mieff << endl
+    << "\tTvspacing: " << Tvspacing << endl
+    << "\tTopveto: " << Topveto << endl
     << endl;
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -72,5 +72,8 @@ void WCSimRootOptions::Print()
     << "WCSimPrimaryGeneratorAction" << endl
     << "\tVectorFileName: " << VectorFileName << endl
     << "\tGeneratorType: " << GeneratorType << endl
+    << "WCSimPrimaryGeneratorAction" << endl
+    << "\tRandomSeed: " << RandomSeed << endl
+    << "\tRandomGenerator: " << WCSimEnumerations::EnumAsString(RandomGenerator) << endl
     << endl;
 }

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -25,7 +25,8 @@
 int pawc_[500000];                // Declare the PAWC common
 struct ntupleStruct jhfNtuple;
 
-WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test)
+WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test, WCSimRandomParameters* rand)
+  : wcsimrandomparameters(rand)
 {
   ntuples = 1;
 
@@ -90,8 +91,9 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
   optionsTree = new TTree("wcsimRootOptionsT","WCSim Options Tree");
   optionsTree->Branch("wcsimrootoptions", "WCSimRootOptions", &wcsimrootoptions, bufsize, 0);
 
-  //set detector options
+  //set detector & random options
   wcsimdetector->SaveOptionsToOutput(wcsimrootoptions);
+  wcsimrandomparameters->SaveOptionsToOutput(wcsimrootoptions);
 }
 
 void WCSimRunAction::EndOfRunAction(const G4Run*)

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -89,6 +89,9 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
   optionsTree = new TTree("wcsimRootOptionsT","WCSim Options Tree");
   wcsimrootoptions = new WCSimRootOptions();
   optionsTree->Branch("wcsimrootoptions", "WCSimRootOptions", &wcsimrootoptions, bufsize, 0);
+
+  //set detector options
+  wcsimdetector->SaveOptionsToOutput(wcsimrootoptions);
 }
 
 void WCSimRunAction::EndOfRunAction(const G4Run*)

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -33,6 +33,7 @@ WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test)
   wcsimdetector = test;
   messenger = new WCSimRunActionMessenger(this);
 
+  wcsimrootoptions = new WCSimRootOptions();
 }
 
 WCSimRunAction::~WCSimRunAction()
@@ -87,7 +88,6 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
 
   // Options tree
   optionsTree = new TTree("wcsimRootOptionsT","WCSim Options Tree");
-  wcsimrootoptions = new WCSimRootOptions();
   optionsTree->Branch("wcsimrootoptions", "WCSimRootOptions", &wcsimrootoptions, bufsize, 0);
 
   //set detector options

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -65,9 +65,8 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
   hfile->SetCompressionLevel(2);
 
   // Event tree
-  TTree* tree = new TTree("wcsimT","WCSim Tree");
+  WCSimTree = new TTree("wcsimT","WCSim Tree");
 
-  SetTree(tree);
   wcsimrootsuperevent = new WCSimRootEvent(); //empty list
   //  wcsimrootsuperevent->AddSubEvent(); // make at least one event
   wcsimrootsuperevent->Initialize(); // make at least one event
@@ -76,16 +75,20 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
   Int_t bufsize = 64000;
 
   //  TBranch *branch = tree->Branch("wcsimrootsuperevent", "Jhf2kmrootsuperevent", &wcsimrootsuperevent, bufsize,0);
-  TBranch *branch = tree->Branch("wcsimrootevent", "WCSimRootEvent", &wcsimrootsuperevent, bufsize,2);
+  TBranch *branch = WCSimTree->Branch("wcsimrootevent", "WCSimRootEvent", &wcsimrootsuperevent, bufsize,2);
 
   // Geometry tree
 
   geoTree = new TTree("wcsimGeoT","WCSim Geometry Tree");
-  SetGeoTree(geoTree);
   wcsimrootgeom = new WCSimRootGeom();
   TBranch *geoBranch = geoTree->Branch("wcsimrootgeom", "WCSimRootGeom", &wcsimrootgeom, bufsize,0);
 
   FillGeoTree();
+
+  // Options tree
+  optionsTree = new TTree("wcsimRootOptionsT","WCSim Options Tree");
+  wcsimrootoptions = new WCSimRootOptions();
+  optionsTree->Branch("wcsimrootoptions", "WCSimRootOptions", &wcsimrootoptions, bufsize, 0);
 }
 
 void WCSimRunAction::EndOfRunAction(const G4Run*)
@@ -102,6 +105,11 @@ void WCSimRunAction::EndOfRunAction(const G4Run*)
 //  G4cout << (float(numberOfTimesCatcherHit)/float(numberOfEventsGenerated))*100.
 //        << "% through-going (hit Catcher)" << G4endl;
 
+  //Write the options tree
+  G4cout << "EndOfRunAction" << G4endl;
+  optionsTree->Fill();
+  optionsTree->Write();
+  
   // Close the Root file at the end of the run
 
   TFile* hfile = WCSimTree->GetCurrentFile();
@@ -183,6 +191,5 @@ void WCSimRunAction::FillGeoTree(){
   wcsimrootgeom-> SetWCNumPMT(numpmt);
   
   geoTree->Fill();
-  TFile* hfile = geoTree->GetCurrentFile();
-  hfile->Write(); 
+  geoTree->Write();
 }

--- a/src/WCSimTuningParameters.cc
+++ b/src/WCSimTuningParameters.cc
@@ -27,3 +27,13 @@ WCSimTuningParameters::~WCSimTuningParameters()
   TuningMessenger = 0;
 }
 
+void WCSimTuningParameters::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  wcopt->SetRayff(rayff);
+  wcopt->SetBsrff(bsrff);
+  wcopt->SetAbwff(abwff);
+  wcopt->SetRgcff(rgcff);
+  wcopt->SetMieff(mieff);
+  wcopt->SetTvspacing(tvspacing);
+  wcopt->SetTopveto(topveto);
+}

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -280,3 +280,13 @@ void WCSimWCAddDarkNoise::FindDarkNoiseRanges(WCSimWCDigitsCollection* WCHCPMT, 
   //now we should have a vector of non-overlapping range pairs to pass to the
   //dark noise routine
 }
+
+void WCSimWCAddDarkNoise::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  wcopt->SetPMTDarkRate(PMTDarkRate);
+  wcopt->SetConvRate(ConvRate);
+  wcopt->SetDarkHigh(DarkHigh);
+  wcopt->SetDarkLow(DarkLow);
+  wcopt->SetDarkWindow(DarkWindow);
+  wcopt->SetDarkMode(DarkMode);
+}

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -35,7 +35,8 @@ WCSimWCDigitizerBase::WCSimWCDigitizerBase(G4String name,
 					   WCSimDetectorConstruction* inDetector,
 					   WCSimWCDAQMessenger* myMessenger,
 					   DigitizerType_t digitype)
-  :G4VDigitizerModule(name), myDetector(inDetector), DAQMessenger(myMessenger), DigitizerType(digitype)
+  :G4VDigitizerModule(name), myDetector(inDetector), DAQMessenger(myMessenger), DigitizerType(digitype),
+   DigitizerClassName("")
 {
   G4String colName = "WCDigitizedStoreCollection";
   collectionName.push_back(colName);
@@ -151,6 +152,13 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, float digihittime, fl
   }
 }
 
+void WCSimWCDigitizerBase::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  wcopt->SetDigitizerClassName(DigitizerClassName);
+  wcopt->SetDigitizerDeadTime(DigitizerDeadTime);
+  wcopt->SetDigitizerIntegrationWindow(DigitizerIntegrationWindow);
+}
+
 
 // *******************************************
 // DERIVED CLASS
@@ -161,6 +169,7 @@ WCSimWCDigitizerSKI::WCSimWCDigitizerSKI(G4String name,
 					 WCSimWCDAQMessenger* myMessenger)
   : WCSimWCDigitizerBase(name, myDetector, myMessenger, kDigitizerSKI)
 {
+  DigitizerClassName = "SKI";
   GetVariables();
 }
 
@@ -353,3 +362,4 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
   }//idigi
 #endif
 }
+

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -394,6 +394,22 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
 
 }
 
+void WCSimWCTriggerBase::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+{
+  wcopt->SetTriggerClassName(triggerClassName);;
+  wcopt->SetMultiDigitsPerTrigger(multiDigitsPerTrigger);;
+  //ndigits
+  wcopt->SetNDigitsThreshold(ndigitsThreshold);;
+  wcopt->SetNDigitsWindow(ndigitsWindow);;
+  wcopt->SetNDigitsAdjustForNoise(ndigitsAdjustForNoise);;
+  wcopt->SetNDigitsPreTriggerWindow(ndigitsPreTriggerWindow);;
+  wcopt->SetNDigitsPostTriggerWindow(ndigitsPostTriggerWindow);;
+  //savefailures
+  wcopt->SetSaveFailuresMode(saveFailuresMode);;
+  wcopt->SetSaveFailuresTime(saveFailuresTime);;
+  wcopt->SetSaveFailuresPreTriggerWindow(saveFailuresPreTriggerWindow);;
+  wcopt->SetSaveFailuresPostTriggerWindow(saveFailuresPostTriggerWindow);;
+}
 
 
 


### PR DESCRIPTION
Solves #132 
I ran the standard verification; no changes are observed.
Everything from the WCSim messenger classes are saved (I think!), but other things (e.g. particle gun options) controlled by standard G4 classes are not. Requests for extra information to save are welcomed!
I put a new tree (with one entry) with one branch (the new class) - this branch could be put in `wcsimGeoT` (another tree with one entry & one branch) instead, but should probably be renamed, which is why I've gone down the new tree route to start with.
#195 can either be cancelled or kept (the detector name is in `WCSimRootOptions` here, and it can also be in `WCSimRootGeom`, as in #195, without conflict)
I'll put a pull request in at [WCSim-Documentation](https://github.com/WCSim/WCSim-Documentation) with information about how to add new options to the output when you've approved this format.