### PR TITLE
Run time & file size checking

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -149,5 +149,8 @@
 
 /WCSimIO/RootFile wcsim.root
 
+## set a timer running on WCSimRunAction
+#/WCSimIO/Timer false
+
 /run/beamOn 10
 #exit

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -7,6 +7,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include "TStopwatch.h"
 #include "WCSimRootEvent.hh"
 #include "WCSimRootGeom.hh"
 #include "WCSimDetectorConstruction.hh"
@@ -61,6 +62,9 @@ private:
 
   WCSimRunActionMessenger* messenger;
   int ntuples;  // 1 for ntuples to be written
+
+  bool useTimer; ///< Use the timer? Set by Messenger.
+  TStopwatch timer; ///< A timer for runtime analysis
 };
 
 #endif

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -45,6 +45,8 @@ public:
   void incrementCatcherHits()     { numberOfTimesCatcherHit++;}
   void SetNtuples(int ntup) {ntuples=ntup;}
 
+  void SetUseTimer(bool use) { useTimer = use; }
+  
 private:
   // MFechner : set by the messenger
   std::string RootFileName;

--- a/include/WCSimRunActionMessenger.hh
+++ b/include/WCSimRunActionMessenger.hh
@@ -4,6 +4,7 @@
 class WCSimRunAction;
 class G4UIdirectory;
 class G4UIcmdWithAString;
+class G4UIcmdWithABool;
 
 #include "G4UImessenger.hh"
 #include "globals.hh"
@@ -23,6 +24,7 @@ class WCSimRunActionMessenger: public G4UImessenger
  private: //commands
   G4UIdirectory*      WCSimIODir;
   G4UIcmdWithAString* RootFile;
+  G4UIcmdWithABool*   UseTimer;
 };
 
 #endif

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -26,7 +26,7 @@ int pawc_[500000];                // Declare the PAWC common
 struct ntupleStruct jhfNtuple;
 
 WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test)
-  : useTimer(true)
+  : useTimer(false)
 {
   ntuples = 1;
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -26,6 +26,7 @@ int pawc_[500000];                // Declare the PAWC common
 struct ntupleStruct jhfNtuple;
 
 WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test)
+  : useTimer(true)
 {
   ntuples = 1;
 
@@ -42,6 +43,11 @@ WCSimRunAction::~WCSimRunAction()
 
 void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
 {
+  if(useTimer) {
+    timer.Reset();
+    timer.Start();
+  }
+  
 //   G4cout << "### Run " << aRun->GetRunID() << " start." << G4endl;
   numberOfEventsGenerated = 0;
   numberOfTimesWaterTubeHit = 0;
@@ -113,6 +119,12 @@ void WCSimRunAction::EndOfRunAction(const G4Run*)
   delete wcsimrootsuperevent; wcsimrootsuperevent=0;
   delete wcsimrootgeom; wcsimrootgeom=0;
 
+  if(useTimer) {
+    timer.Stop();
+    G4cout << "WCSimRunAction ran from BeginOfRunAction() to EndOfRunAction() in:"
+	   << "\t" << timer.CpuTime()  << " seconds (CPU)"
+	   << "\t" << timer.RealTime() << " seconds (real)" << G4endl;
+  }
 }
 
 void WCSimRunAction::FillGeoTree(){

--- a/src/WCSimRunActionMessenger.cc
+++ b/src/WCSimRunActionMessenger.cc
@@ -5,6 +5,7 @@
 #include "G4UIcommand.hh"
 #include "G4UIparameter.hh"
 #include "G4UIcmdWithAString.hh"
+#include "G4UIcmdWithABool.hh"
 
 WCSimRunActionMessenger::WCSimRunActionMessenger(WCSimRunAction* WCSimRA)
 :WCSimRun(WCSimRA)
@@ -18,11 +19,16 @@ WCSimRunActionMessenger::WCSimRunActionMessenger(WCSimRunAction* WCSimRA)
   RootFile->SetParameterName("RootFileName",true);
   RootFile->SetDefaultValue("wcsim.root");
 
+  UseTimer = new G4UIcmdWithABool("/WCSimIO/Timer",this);
+  UseTimer->SetGuidance("Use a timer for runtime");
+  UseTimer->SetParameterName("UseTimer",true);
+  UseTimer->SetDefaultValue(false);
 }
 
 WCSimRunActionMessenger::~WCSimRunActionMessenger()
 {
   delete RootFile;
+  delete UseTimer;
   delete WCSimIODir;
 }
 
@@ -33,6 +39,12 @@ void WCSimRunActionMessenger::SetNewValue(G4UIcommand* command,G4String newValue
     {
       WCSimRun->SetRootFileName(newValue);
       G4cout << "Output ROOT file set to " << newValue << G4endl;
+    }
+  else if(command == UseTimer)
+    {
+      bool use = UseTimer->GetNewBoolValue(newValue);
+      WCSimRun->SetUseTimer(use);
+      G4cout << "WCSimRunAction timer " << (use ? "ENABLED" : "DISABLED") << G4endl;
     }
 
 }

--- a/verification-test-scripts/README.md
+++ b/verification-test-scripts/README.md
@@ -29,7 +29,7 @@ This test prints to the screen the size of the output trees and top-level branch
 The optional `verbose` boolean flag allows sub-branch sizes to be printed.
 
 ### Usage
-To use the printSizes test in the default method, do the following steps:
+To use the printSizes test in the default method, do the following steps (note that the first 3 steps are equvialent to that for `verification_HitsChargeTime.C`):
 * clone a copy of the current code from GitHub into a directory called `WCSim_clean`. Compile the code. 
 * Go to `WCSim_clean/verification-test-scripts` and run `electrontest.mac` by typing: `../bin/Linux-g++/WCSim electrontest.mac`. This should produce an output file called `wcsimtest.root` in the `verification-test-scripts` directory of `WCSim_clean`. 
 * Go to the `verification-test-scripts` directory of your local WCSim (with your changes you wish to commit) and run the macro `electrontest.mac` in WCSim by typing `../bin/Linux-g++/WCSim electrontest.mac`. This should produce a file called `wcsimtest.root` in your `verification-test-scripts` directory. 

--- a/verification-test-scripts/README.md
+++ b/verification-test-scripts/README.md
@@ -13,11 +13,28 @@ A ks test is printed to the screen. This test also prints to the screen a compar
 
 ### Usage
 To use the verification_HitsChargeTime test in the default method, do the following steps:
-* clone a copy of the current code from GitHub into a directory called WCSim_clean. Compile the code. 
-* Go to WCSim_clean/verification-test-scripts and run electrontest.mac by typing: ../bin/Linux-g++/WCSim electrontest.mac . This should produce an output file called wcsimtest.root in the verification-test-scripts directory of WCSim_clean. 
-* Go to the verification-test-scripts directory of your local WCSim (with your changes you wish to commit) and run the macro electrontest.mac in WCSim by typing ../bin/Linux-g++/WCSim electrontest.mac. This should produce a file called wcsimtest.root in your verification-test-scripts directory. 
-* Still in the verification-test-scripts of your local WCSim directory, type: root verification_HitsChargeTime.C
+* clone a copy of the current code from GitHub into a directory called `WCSim_clean`. Compile the code. 
+* Go to `WCSim_clean/verification-test-scripts` and run `electrontest.mac` by typing: `../bin/Linux-g++/WCSim electrontest.mac`. This should produce an output file called `wcsimtest.root` in the `verification-test-scripts` directory of `WCSim_clean`. 
+* Go to the `verification-test-scripts` directory of your local WCSim (with your changes you wish to commit) and run the macro `electrontest.mac` in WCSim by typing `../bin/Linux-g++/WCSim electrontest.mac`. This should produce a file called `wcsimtest.root` in your `verification-test-scripts` directory. 
+* Still in the `verification-test-scripts` of your local WCSim directory, type: `root verification_HitsChargeTime.C`
 
 You can also use this test to compare any two files from any two directories. To use the script this way type:
-* root 
-* .x verification_HitsChargeTime.C("/path/to/first_file", "/path/to/second_file")
+* `root` 
+* `.x verification_HitsChargeTime.C("/path/to/first_file", "/path/to/second_file")`
+
+## printSizes.C:
+
+This script will test a .root output file from your version of WCSim against the committed version of the code.
+This test prints to the screen the size of the output trees and top-level branches.
+The optional `verbose` boolean flag allows sub-branch sizes to be printed.
+
+### Usage
+To use the printSizes test in the default method, do the following steps:
+* clone a copy of the current code from GitHub into a directory called `WCSim_clean`. Compile the code. 
+* Go to `WCSim_clean/verification-test-scripts` and run `electrontest.mac` by typing: `../bin/Linux-g++/WCSim electrontest.mac`. This should produce an output file called `wcsimtest.root` in the `verification-test-scripts` directory of `WCSim_clean`. 
+* Go to the `verification-test-scripts` directory of your local WCSim (with your changes you wish to commit) and run the macro `electrontest.mac` in WCSim by typing `../bin/Linux-g++/WCSim electrontest.mac`. This should produce a file called `wcsimtest.root` in your `verification-test-scripts` directory. 
+* Still in the `verification-test-scripts` of your local WCSim directory, type: `root printSizes.C`
+
+You can also use this test to compare any two files from any two directories. To use the script this way type:
+* `root` 
+* `.x printSizes.C("/path/to/first_file", "/path/to/second_file",verbose)`

--- a/verification-test-scripts/electrontest.mac
+++ b/verification-test-scripts/electrontest.mac
@@ -54,7 +54,7 @@
 
 
 # Or you can use the G4 Particle Gun
-/mygen/generator normal
+/mygen/generator gun
 /gun/particle e-
 #/gun/particle pi0
 /gun/energy 500 MeV
@@ -66,7 +66,7 @@
 /WCSimIO/RootFile wcsimtest.root
 
 ## set a timer running on WCSimRunAction
-#/WCSimIO/Timer true
+/WCSimIO/Timer true
 
 /run/beamOn 1000
 #exit

--- a/verification-test-scripts/electrontest.mac
+++ b/verification-test-scripts/electrontest.mac
@@ -65,5 +65,8 @@
 
 /WCSimIO/RootFile wcsimtest.root
 
+## set a timer running on WCSimRunAction
+#/WCSimIO/Timer true
+
 /run/beamOn 1000
 #exit

--- a/verification-test-scripts/printSizes.C
+++ b/verification-test-scripts/printSizes.C
@@ -4,7 +4,16 @@
 #include "TMemFile.h"
 #include "TKey.h"
 #include "TBranchRef.h"
- 
+#include "TSystem.h"
+
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "WCSimRootEvent.hh"
+#include "WCSimRootGeom.hh"
+#include "WCSimEnumerations.hh"
+#endif
+
+using namespace std;
+
 //
 // This macro can be used to get aggregate information on the size
 // take on disk or in memory by the various branches in a TTree.
@@ -191,6 +200,18 @@ int printSizes(const char *filename1="wcsimtest.root",
 	       const char *filename2="../../WCSim_clean/verification-test-scripts/wcsimtest.root",
 	       bool verbose = false)
 {
+#if !defined(__MAKECINT__)
+  // Load the library with class dictionary info
+  // (create with "gmake shared")
+  char* wcsimdirenv;
+  wcsimdirenv = getenv ("WCSIMDIR");
+  if(wcsimdirenv !=  NULL){
+    gSystem->Load("${WCSIMDIR}/libWCSimRoot.so");
+  }else{
+    gSystem->Load("../libWCSimRoot.so");
+  }
+#endif
+  
   cout << "Your version of WCSim assumes file: " << filename1 << endl
        << "Stable GitHub version of WCSim assumes file: " << filename2 << endl;
   TFile * f1 = OpenFile(filename1);

--- a/verification-test-scripts/printSizes.C
+++ b/verification-test-scripts/printSizes.C
@@ -1,0 +1,211 @@
+#include "TTree.h"
+#include "TBranch.h"
+#include "Riostream.h"
+#include "TMemFile.h"
+#include "TKey.h"
+#include "TBranchRef.h"
+ 
+//
+// This macro can be used to get aggregate information on the size
+// take on disk or in memory by the various branches in a TTree.
+// For example:
+/*
+
+root [] printTreeSummary(tree);
+The TTree "T" takes 3764343 bytes on disk
+  Its branch "event" takes 3760313 bytes on disk
+
+root [] printBranchSummary(tree->GetBranch("event"));
+The branch "event" takes 3760313 bytes on disk
+  Its sub-branch "TObject" takes 581 bytes on disk
+  Its sub-branch "fType[20]" takes 640 bytes on disk
+  Its sub-branch "fEventName" takes 855 bytes on disk
+  Its sub-branch "fNtrack" takes 506 bytes on disk
+  Its sub-branch "fNseg" takes 554 bytes on disk
+  Its sub-branch "fNvertex" takes 507 bytes on disk
+  Its sub-branch "fFlag" takes 420 bytes on disk
+  Its sub-branch "fTemperature" takes 738 bytes on disk
+  Its sub-branch "fMeasures[10]" takes 1856 bytes on disk
+  Its sub-branch "fMatrix[4][4]" takes 4563 bytes on disk
+  Its sub-branch "fClosestDistance" takes 2881 bytes on disk
+  Its sub-branch "fEvtHdr" takes 847 bytes on disk
+  Its sub-branch "fTracks" takes 3673982 bytes on disk
+  Its sub-branch "fHighPt" takes 59640 bytes on disk
+  Its sub-branch "fMuons" takes 1656 bytes on disk
+  Its sub-branch "fLastTrack" takes 785 bytes on disk
+  Its sub-branch "fWebHistogram" takes 596 bytes on disk
+  Its sub-branch "fH" takes 10076 bytes on disk
+  Its sub-branch "fTriggerBits" takes 1699 bytes on disk
+  Its sub-branch "fIsValid" takes 366 bytes on disk
+
+ */
+
+Long64_t GetTotalSize(TBranch * b, bool ondisk, bool inclusive);
+Long64_t GetBasketSize(TBranch * b, bool ondisk, bool inclusive);
+
+Long64_t GetBasketSize(TObjArray * branches, bool ondisk, bool inclusive) {
+   Long64_t result = 0;
+   size_t n = branches->GetEntries();
+   for( size_t i = 0; i < n; ++ i ) {
+      result += GetBasketSize( dynamic_cast<TBranch*>( branches->At( i ) ), ondisk, inclusive );
+   }
+   return result;
+}
+
+Long64_t GetBasketSize(TBranch * b, bool ondisk, bool inclusive) {
+   Long64_t result = 0;
+   if (b) {
+      if (ondisk && b->GetZipBytes() > 0) {
+         result = b->GetZipBytes();
+      } else {
+         result = b->GetTotBytes();
+      }
+      if (inclusive) {
+         result += GetBasketSize(b->GetListOfBranches(), ondisk, true);
+      }
+      return result;
+   }
+   return result;
+}
+
+Long64_t GetTotalSize( TBranch * br, bool ondisk, bool inclusive ) {
+   TMemFile f("buffer","CREATE");
+   if (br->GetTree()->GetCurrentFile()) {
+      f.SetCompressionSettings(br->GetTree()->GetCurrentFile()->GetCompressionSettings());
+   }
+   f.WriteObject(br,"thisbranch");
+   TKey* key = f.GetKey("thisbranch");
+   Long64_t size;
+   if (ondisk) 
+      size = key->GetNbytes();
+   else 
+      size = key->GetObjlen();      
+   return GetBasketSize(br, ondisk, inclusive) + size;
+}
+
+Long64_t GetTotalSize( TObjArray * branches, bool ondisk ) {
+   Long64_t result = 0;
+   size_t n = branches->GetEntries();
+   for( size_t i = 0; i < n; ++ i ) {
+      result += GetTotalSize( dynamic_cast<TBranch*>( branches->At( i ) ), ondisk, true );
+      cerr << "After " << branches->At( i )->GetName() << " " << result << endl;
+   }
+   return result;
+}
+
+Long64_t GetTotalSize(TTree *t, bool ondisk) {
+   TKey *key = 0;
+   if (t->GetDirectory()) {
+      key = t->GetDirectory()->GetKey(t->GetName());
+   }
+   Long64_t ondiskSize = 0;
+   Long64_t totalSize = 0;
+   if (key) {
+      ondiskSize = key->GetNbytes();
+      totalSize = key->GetObjlen();
+   } else {
+      TMemFile f("buffer","CREATE");
+      if (t->GetCurrentFile()) {
+         f.SetCompressionSettings(t->GetCurrentFile()->GetCompressionSettings());
+      }
+      f.WriteTObject(t);
+      key = f.GetKey(t->GetName());
+      ondiskSize = key->GetNbytes();
+      totalSize = key->GetObjlen();      
+   }
+   if (t->GetBranchRef() ) {
+      if (ondisk) {
+         ondiskSize += GetBasketSize(t->GetBranchRef(), true, true);
+      } else {
+         totalSize += GetBasketSize(t->GetBranchRef(), false, true);
+      }
+   }
+   if (ondisk) {      
+      return ondiskSize + GetBasketSize(t->GetListOfBranches(), /* ondisk */ true, /* inclusive */ true);
+   } else {
+      return totalSize + GetBasketSize(t->GetListOfBranches(), /* ondisk */ false, /* inclusive */ true);
+   }
+}
+
+Long64_t sizeOnDisk(TTree *t) { 
+   // Return the size on disk on this TTree.
+   
+   return GetTotalSize(t, true);
+}
+
+Long64_t sizeOnDisk(TBranch *branch, bool inclusive) 
+{
+   // Return the size on disk on this branch.
+   // If 'inclusive' is true, include also the size
+   // of all its sub-branches.
+
+   return GetTotalSize(branch, true, inclusive);
+}
+
+void printBranchSummary(TBranch *br)
+{
+   cout << "The branch \"" << br->GetName() << "\" takes " << sizeOnDisk(br,true) << " bytes on disk\n";
+   size_t n = br->GetListOfBranches()->GetEntries();
+   for( size_t i = 0; i < n; ++ i ) {
+      TBranch *subbr = dynamic_cast<TBranch*>(br->GetListOfBranches()->At(i));
+      cout << "  Its sub-branch \"" << subbr->GetName() << "\" takes " << sizeOnDisk(subbr,true) << " bytes on disk\n";
+   }   
+}
+
+void printTreeSummary(TTree *t)
+{
+   cout << "The TTree \"" << t->GetName() << "\" takes " << sizeOnDisk(t) << " bytes on disk\n";
+   size_t n = t->GetListOfBranches()->GetEntries();
+   for( size_t i = 0; i < n; ++ i ) {
+      TBranch *br =dynamic_cast<TBranch*>(t->GetListOfBranches()->At(i));
+      cout << "  Its branch \"" << br->GetName() << "\" takes " << sizeOnDisk(br,true) << " bytes on disk\n";
+   }
+}
+
+const int ntrees = 3;
+string wcsimtrees[ntrees] = {"wcsimGeoT", "wcsimT", "wcsimRootOptionsT"};
+string wcsimbranches[ntrees] = {"wcsimrootgeom", "wcsimrootevent", "wcsimrootoptions"};
+
+TFile * OpenFile(const char * filename)
+{
+  TFile *f = TFile::Open(filename);
+  if (!f->IsOpen()){
+    cout << "Error, could not open input file: " << filename << endl;
+    exit(-1);
+  }
+  return f;
+}
+
+Long64_t GetWCSimTreeSize(TFile * f, int itree, bool verbose)
+{
+  TTree *t;
+  f->GetObject(wcsimtrees[itree].c_str(), t);
+  if (!t) return 1;
+  printTreeSummary(t);
+  if(verbose)
+    printBranchSummary(t->GetBranch(wcsimbranches[itree].c_str()));
+  return sizeOnDisk(t);
+}
+
+int printSizes(const char *filename1="wcsimtest.root",
+	       const char *filename2="../../WCSim_clean/verification-test-scripts/wcsimtest.root",
+	       bool verbose = false)
+{
+  cout << "Your version of WCSim assumes file: " << filename1 << endl
+       << "Stable GitHub version of WCSim assumes file: " << filename2 << endl;
+  TFile * f1 = OpenFile(filename1);
+  TFile * f2 = OpenFile(filename2);  
+  for(int itree = 0; itree < ntrees; itree++) {
+    Long64_t s1 = GetWCSimTreeSize(f1, itree, verbose);
+    Long64_t s2 = GetWCSimTreeSize(f2, itree, verbose);
+    if(s1 == s2)
+      cout << "Trees sizes are identical!" << endl;
+    else {
+      double change = (s1 - s2) * 100. / (double)s2;
+      cout << "Your WCSim version tree is " << change << "% " << (change > 0 ? "larger" : "smaller")
+	   << " than the master GitHub version" << endl;
+    }
+  }//itree
+
+  return 0;
+}


### PR DESCRIPTION
For #198, I was asked to check changes to output file sizes and running time. Here's a pull request, so they can be reused in future:

- run time is the time from BeginOfRunAction() to EndOfRunAction(), and can be used/not with a .mac command. Default is off
- file size is a macro to be run on output files, and takes the same arguments as `verification_HitsChargeTime.C`