### PR TITLE
Add G4.10.x compatibility

### DIFF
--- a/include/WCSimPhysicsList.hh
+++ b/include/WCSimPhysicsList.hh
@@ -26,7 +26,6 @@ class WCSimPhysicsList: public G4VPhysicsConstructor
 
     G4String SecondaryHadModel;
 
-    G4bool gheishahad;
     G4bool bertinihad;
     G4bool binaryhad;
 

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -75,7 +75,7 @@ public: // with description
 
 // Other member functions
    virtual void ShowTrajectory(std::ostream& os=G4cout) const;
-   virtual void DrawTrajectory(G4int i_mode=0) const;
+   virtual void DrawTrajectory() const;
    virtual void AppendStep(const G4Step* aStep);
    virtual int GetPointEntries() const { return positionRecord->size(); }
    virtual G4VTrajectoryPoint* GetPoint(G4int i) const 

--- a/jobOptions2.mac
+++ b/jobOptions2.mac
@@ -6,9 +6,9 @@
 # Note: WCSim physics list only
 # Note2: Probably broken because this file is read before WCSim object instantiation
 # Options:
-#   GHEISHA   (Original Geant4 model)
-#   BERTINI   (Bertini intra-nuclear cascade model)
-#   BINARY    (Binary intra-nuclear cascade model) -- this is the default
-/WCSim/physics/secondaries/model BINARY
+#   GHEISHA   (Original Geant4 model) ## DISAPPEARED IN G4.10
+#   BERTINI   (Bertini intra-nuclear cascade model)  -- this is the default since G4.10
+#   BINARY    (Binary intra-nuclear cascade model)
+/WCSim/physics/secondaries/model BERTINI
 # Do not put any commands below this line
 

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -14,6 +14,9 @@
 #include "G4Tubs.hh"
 #include "G4Sphere.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 #include <sstream>
 #include <iomanip>
 

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -10,6 +10,9 @@
 #include "G4LogicalSkinSurface.hh"
 #include "G4OpBoundaryProcess.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 void WCSimDetectorConstruction::ConstructMaterials()
 {
   //****Materials Definitions****

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -17,6 +17,9 @@
 #include "G4LogicalVolumeStore.hh"
 #include "G4SolidStore.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 std::map<int, G4Transform3D> WCSimDetectorConstruction::tubeIDMap;
 //std::map<int, cyl_location>  WCSimDetectorConstruction::tubeCylLocation;
 hash_map<std::string, int, hash<std::string> > 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -26,6 +26,9 @@
 #include "G4UnitsTable.hh"
 #include "G4UIcmdWith3VectorAndUnit.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 #include <set>
 #include <iomanip>
 #include <string>

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -378,7 +378,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 	(WCSimTrajectory*)((*(evt->GetTrajectoryContainer()))[i]);
 
       if (trj->GetCharge() != 0.)
- 	trj->DrawTrajectory(50);
+ 	trj->DrawTrajectory();
     }
 
    G4cout << " Filling Root Event " << G4endl;

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -11,6 +11,9 @@
 #include "G4RotationMatrix.hh"
 #include "G4ThreeVector.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 #include "WCSimDetectorConstruction.hh"
 #include "WCSimPmtInfo.hh"
 

--- a/src/WCSimPhysicsList.cc
+++ b/src/WCSimPhysicsList.cc
@@ -66,7 +66,7 @@ void WCSimPhysicsList::ConstructProcess()
 {
   //AddTransportation();
   ConstructEM();
-  ConstructlArStepLimiter();
+  // ConstructlArStepLimiter();
   ConstructGeneral();
   ConstructOp();
   ConstructHad();
@@ -84,7 +84,8 @@ void WCSimPhysicsList::ConstructProcess()
 #include "G4MuBremsstrahlung.hh"
 #include "G4MuPairProduction.hh"
 #include "G4hIonisation.hh"
-#include "G4MuonMinusCaptureAtRest.hh"
+// FDL replaced in 4.9 by G4MuonMinusCapture
+#include "G4MuonMinusCapture.hh"
 
 //K.Z.: New MultipleScattering classes 
 #include "G4eMultipleScattering.hh"
@@ -99,9 +100,9 @@ void WCSimPhysicsList::ConstructEM()
   //replaced by new G4MultipleScattering classes for e+-, mu+-, hadron and ions.
   //K. Zbiri, 12/30/2009
 
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
-    G4ParticleDefinition* particle = theParticleIterator->value();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
     G4ProcessManager* pmanager = particle->GetProcessManager();
     G4String particleName = particle->GetParticleName();
      
@@ -163,8 +164,8 @@ void WCSimPhysicsList::ConstructEM()
                particleName == "mu-"    ) {
     //muon
       //G4VProcess* aMultipleScattering = new G4MultipleScattering();
-       G4VProcess* aMultipleScattering = new G4MuMultipleScattering();
-       G4VProcess* aBremsstrahlung     = new G4MuBremsstrahlung();
+			G4VProcess* aMultipleScattering = new G4MuMultipleScattering();
+			G4VProcess* aBremsstrahlung     = new G4MuBremsstrahlung();
       G4VProcess* aPairProduction     = new G4MuPairProduction();
       G4VProcess* anIonisation        = new G4MuIonisation();
       //
@@ -187,10 +188,10 @@ void WCSimPhysicsList::ConstructEM()
       // MF , stolen from CWW, april 2005
       if (particleName == "mu-")
         {
-          G4VProcess* aG4MuonMinusCaptureAtRest =
-            new G4MuonMinusCaptureAtRest();
-          pmanager->AddProcess(aG4MuonMinusCaptureAtRest);
-          pmanager->SetProcessOrdering(aG4MuonMinusCaptureAtRest,idxAtRest);
+          G4VProcess* aG4MuonMinusCapture =
+            new G4MuonMinusCapture();
+          pmanager->AddProcess(aG4MuonMinusCapture);
+          pmanager->SetProcessOrdering(aG4MuonMinusCapture,idxAtRest);
         }
 
 
@@ -223,10 +224,10 @@ void WCSimPhysicsList::ConstructEM()
 void WCSimPhysicsList::ConstructlArStepLimiter(){
 
 #ifdef GEANT4_7_0
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
 
-    G4ParticleDefinition* particle = theParticleIterator->value();
+    G4ParticleDefinition* particle = aParticleIterator->value();
     G4ProcessManager* pmanager = particle->GetProcessManager();
 
      if ((!particle->IsShortLived()) &&
@@ -280,10 +281,10 @@ void WCSimPhysicsList::ConstructOp(){
   // theCherenkovProcess->SetMaxBetaChangePerStep(10.0);
   // theCherenkovProcess->SetTrackSecondariesFirst(true);
 
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() )
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() )
   {
-    G4ParticleDefinition* particle     = theParticleIterator->value();
+    G4ParticleDefinition* particle     = aParticleIterator->value();
     G4ProcessManager*     pmanager     = particle->GetProcessManager();
     G4String              particleName = particle->GetParticleName();
     
@@ -316,9 +317,9 @@ void WCSimPhysicsList::ConstructGeneral()
 {
   // Add Decay Process
   G4Decay* theDecayProcess = new G4Decay();
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
-    G4ParticleDefinition* particle = theParticleIterator->value();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
     G4ProcessManager* pmanager = particle->GetProcessManager();
     if (theDecayProcess->IsApplicable(*particle)) { 
       pmanager ->AddProcess(theDecayProcess);
@@ -346,34 +347,10 @@ void WCSimPhysicsList::ConstructGeneral()
 #include "G4DeuteronInelasticProcess.hh"
 #include "G4TritonInelasticProcess.hh"
 #include "G4AlphaInelasticProcess.hh"
+#include "G4INCLXXInterface.hh"
 
-// Low-energy Models: < 20GeV
-#include "G4LElastic.hh"
-#include "G4LEPionPlusInelastic.hh"
-#include "G4LEPionMinusInelastic.hh"
-#include "G4LEKaonPlusInelastic.hh"
-#include "G4LEKaonZeroSInelastic.hh"
-#include "G4LEKaonZeroLInelastic.hh"
-#include "G4LEKaonMinusInelastic.hh"
-#include "G4LEProtonInelastic.hh"
-#include "G4LEAntiProtonInelastic.hh"
-#include "G4LENeutronInelastic.hh"
-#include "G4LEAntiNeutronInelastic.hh"
-#include "G4LEDeuteronInelastic.hh"
-#include "G4LETritonInelastic.hh"
-#include "G4LEAlphaInelastic.hh"
-
-// High-energy Models: >20 GeV
-#include "G4HEPionPlusInelastic.hh"
-#include "G4HEPionMinusInelastic.hh"
-#include "G4HEKaonPlusInelastic.hh"
-#include "G4HEKaonZeroInelastic.hh"
-#include "G4HEKaonZeroInelastic.hh"
-#include "G4HEKaonMinusInelastic.hh"
-#include "G4HEProtonInelastic.hh"
-#include "G4HEAntiProtonInelastic.hh"
-#include "G4HENeutronInelastic.hh"
-#include "G4HEAntiNeutronInelastic.hh"
+// FDL replaced with G4HadronElastic
+#include "G4HadronElastic.hh"
 
 // Neutron high-precision models: <20 MeV
 #include "G4NeutronHPElastic.hh"
@@ -382,7 +359,6 @@ void WCSimPhysicsList::ConstructGeneral()
 #include "G4NeutronHPCaptureData.hh"
 #include "G4NeutronHPInelastic.hh"
 #include "G4NeutronHPInelasticData.hh"
-#include "G4LCapture.hh"
 
 //=================================
 // Added by JLR 2005-07-05
@@ -392,9 +368,19 @@ void WCSimPhysicsList::ConstructGeneral()
 #include "G4BinaryCascade.hh"
 
 // Stopping processes
-#include "G4PiMinusAbsorptionAtRest.hh"
-#include "G4KaonMinusAbsorptionAtRest.hh"
-#include "G4AntiProtonAnnihilationAtRest.hh"
+// Replaced by below -FDL
+#include "G4PiMinusAbsorptionBertini.hh"
+#include "G4KaonMinusAbsorptionBertini.hh"
+#include "G4AntiProtonAbsorptionFritiof.hh"
+
+// Include the FTF model - FDL
+#include "G4FTFModel.hh"
+#include "G4LundStringFragmentation.hh"
+#include "G4ExcitedStringDecay.hh"
+#include "G4PreCompoundModel.hh"
+#include "G4GeneratorPrecompoundInterface.hh"
+#include "G4TheoFSGenerator.hh"
+
 #include "G4AntiNeutronAnnihilationAtRest.hh"
 
 void WCSimPhysicsList::ConstructHad() 
@@ -409,15 +395,35 @@ void WCSimPhysicsList::ConstructHad()
 // examples/advanced/underground_physics/src/DMXPhysicsList.cc
 // CWW 2/23/05
 //
-  
-  G4HadronElasticProcess* theElasticProcess = new G4HadronElasticProcess;
-  G4LElastic* theElasticModel = new G4LElastic;
-  theElasticProcess->RegisterMe(theElasticModel);
-  
-  theParticleIterator->reset();
-  while ((*theParticleIterator)()) 
+// In G4.10 GEISHA models have been deprecated.
+// see http://geant4.cern.ch/support/ReleaseNotes4.9.6.html
+// "Physics lists which depend on the CHIPS package
+// or on the parameterized (Gheisha-like) models (LEP/HEP)
+// are deprecated and will be removed in Geant4 10."
+//
+
+	G4HadronElasticProcess* theElasticProcess = new G4HadronElasticProcess;
+	// Add the FRITIOF model - FDL
+	G4TheoFSGenerator* FTFP_model = new G4TheoFSGenerator();
+	G4GeneratorPrecompoundInterface* theCascade = new G4GeneratorPrecompoundInterface();
+	G4ExcitationHandler* theHandler = new G4ExcitationHandler();
+	G4PreCompoundModel* thePreEquilib = new G4PreCompoundModel(theHandler);
+	theCascade->SetDeExcitation(thePreEquilib);
+	FTFP_model->SetTransport(theCascade);
+
+	G4LundStringFragmentation* theFragmentation = new G4LundStringFragmentation();
+	G4ExcitedStringDecay* theStringDecay = new G4ExcitedStringDecay(theFragmentation);
+	G4FTFModel* theStringModel = new G4FTFModel;
+	theStringModel->SetFragmentationModel(theStringDecay);
+	FTFP_model->SetHighEnergyGenerator(theStringModel);
+
+	G4HadronElastic* theElasticModel = new G4HadronElastic;
+	theElasticProcess->RegisterMe(theElasticModel);
+
+  aParticleIterator->reset();
+  while ((*aParticleIterator)())
     {
-      G4ParticleDefinition* particle = theParticleIterator->value();
+      G4ParticleDefinition* particle = aParticleIterator->value();
       G4ProcessManager* pmanager = particle->GetProcessManager();
       G4String particleName = particle->GetParticleName();
 
@@ -426,57 +432,72 @@ void WCSimPhysicsList::ConstructHad()
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4PionPlusInelasticProcess* theInelasticProcess = 
 	    new G4PionPlusInelasticProcess();
-	  G4LEPionPlusInelastic* theLEInelasticModel = 
-	    new G4LEPionPlusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEPionPlusInelastic* theHEInelasticModel = 
-	    new G4HEPionPlusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	} 
+
+		// Added Bertini Model - FDL
+		G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+		theBertiniModel->SetMaxEnergy(5.0*GeV);
+		theInelasticProcess->RegisterMe(theBertiniModel);
+
+		// Added FTFP Model - SS
+		FTFP_model->SetMinEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+		pmanager->AddDiscreteProcess(theInelasticProcess);
+	}
 
       else if (particleName == "pi-") 
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4PionMinusInelasticProcess* theInelasticProcess = 
 	    new G4PionMinusInelasticProcess();
-	  G4LEPionMinusInelastic* theLEInelasticModel = 
-	    new G4LEPionMinusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEPionMinusInelastic* theHEInelasticModel = 
-	    new G4HEPionMinusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	  G4String prcNam;
-	  pmanager->AddRestProcess(new G4PiMinusAbsorptionAtRest, ordDefault);
+
+		// Added Bertini Model - FDL
+		G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+		theBertiniModel->SetMaxEnergy(5.0*GeV);
+		theInelasticProcess->RegisterMe(theBertiniModel);
+
+		// Added FTFP Model - SS
+		FTFP_model->SetMinEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
+		G4String prcNam;
+		pmanager->AddRestProcess(new G4PiMinusAbsorptionBertini, ordDefault);
 	}
-      
+
       else if (particleName == "kaon+") 
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4KaonPlusInelasticProcess* theInelasticProcess = 
 	    new G4KaonPlusInelasticProcess();
-	  G4LEKaonPlusInelastic* theLEInelasticModel = 
-	    new G4LEKaonPlusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonPlusInelastic* theHEInelasticModel = 
-	    new G4HEKaonPlusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+
+		// Added Bertini Model - FDL
+		G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+		theBertiniModel->SetMaxEnergy(5.0*GeV);
+		theInelasticProcess->RegisterMe(theBertiniModel);
+
+		// Added FTFP Model - SS
+		FTFP_model->SetMinEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
-      
+
       else if (particleName == "kaon0S") 
 	{
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4KaonZeroSInelasticProcess* theInelasticProcess = 
 	    new G4KaonZeroSInelasticProcess();
-	  G4LEKaonZeroSInelastic* theLEInelasticModel = 
-	    new G4LEKaonZeroSInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonZeroInelastic* theHEInelasticModel = 
-	    new G4HEKaonZeroInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+
+		// Added Bertini Model - FDL
+		G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+		theBertiniModel->SetMaxEnergy(10.0*GeV);
+		theInelasticProcess->RegisterMe(theBertiniModel);
+
+		// Added FTFP Model - SS
+		FTFP_model->SetMinEnergy(3.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
       else if (particleName == "kaon0L") 
@@ -484,13 +505,17 @@ void WCSimPhysicsList::ConstructHad()
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4KaonZeroLInelasticProcess* theInelasticProcess = 
 	    new G4KaonZeroLInelasticProcess();
-	  G4LEKaonZeroLInelastic* theLEInelasticModel = 
-	    new G4LEKaonZeroLInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonZeroInelastic* theHEInelasticModel = 
-	    new G4HEKaonZeroInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+
+		// Added Bertini Model - FDL
+		G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+		theBertiniModel->SetMaxEnergy(10.0*GeV);
+		theInelasticProcess->RegisterMe(theBertiniModel);
+
+		// Added FTFP Model - SS
+		FTFP_model->SetMinEnergy(3.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
       else if (particleName == "kaon-") 
@@ -498,14 +523,17 @@ void WCSimPhysicsList::ConstructHad()
 	  pmanager->AddDiscreteProcess(theElasticProcess);
 	  G4KaonMinusInelasticProcess* theInelasticProcess = 
 	    new G4KaonMinusInelasticProcess();
-	  G4LEKaonMinusInelastic* theLEInelasticModel = 
-	    new G4LEKaonMinusInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEKaonMinusInelastic* theHEInelasticModel = 
-	    new G4HEKaonMinusInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
-	  pmanager->AddRestProcess(new G4KaonMinusAbsorptionAtRest, ordDefault);
+		// Added Bertini Model - FDL
+		G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+		theBertiniModel->SetMaxEnergy(5.0*GeV);
+		theInelasticProcess->RegisterMe(theBertiniModel);
+
+		// Added FTFP Model - SS
+		FTFP_model->SetMinEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
+		pmanager->AddRestProcess(new G4KaonMinusAbsorptionBertini, ordDefault);
 	}
 
       else if (particleName == "proton") 
@@ -522,66 +550,55 @@ void WCSimPhysicsList::ConstructHad()
 	  // Choice defined in jobOptions.mac, which is
 	  // read in before initialization of the run manager.
 	  // In the absence of this file, BINARY will be used.
-	  // Gheisha = Original Geant4 default 
+	  // Gheisha = Original Geant4 default // DISAPPEARED IN G4.10
 	  // Bertini = Bertini intra-nuclear cascade model
 	  // Binary  = Binary intra-nuclear cascade model
-	  if (gheishahad) {
-	    G4LEProtonInelastic* theLEInelasticModel = new G4LEProtonInelastic;
-	    theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  }
-	  else if (bertinihad) {
-	    G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
-	    theInelasticProcess->RegisterMe(theBertiniModel);
-	  }
-	  else if (binaryhad) {
-	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theInelasticProcess->RegisterMe(theBinaryModel);
+		if (bertinihad) {
+			G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+			theBertiniModel->SetMaxEnergy(5.0*GeV);
+			theInelasticProcess->RegisterMe(theBertiniModel);
+		}
+		else if (binaryhad) {
+			G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
+			theBinaryModel->SetMaxEnergy(5.0*GeV);
+			theInelasticProcess->RegisterMe(theBinaryModel);
+		}
+		else {
+			G4cout << "No secondary interaction model chosen! Using G4 BERTINI." << G4endl;
+			G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+			theBertiniModel->SetMaxEnergy(5.0*GeV);
+			theInelasticProcess->RegisterMe(theBertiniModel);
+		}
 
-	    G4LEProtonInelastic* theLEInelasticModel = new G4LEProtonInelastic;
-	    theLEInelasticModel->SetMinEnergy(10.1*GeV);
-	    theLEInelasticModel->SetMaxEnergy( 45.*GeV );
-	    theInelasticProcess->RegisterMe(theLEInelasticModel);
-
-	  }
-	  else {
-	    G4cout << "No secondary interaction model chosen! Using G4 BINARY." << G4endl;
-	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theInelasticProcess->RegisterMe(theBinaryModel);
-	  }
-
-	  G4HEProtonInelastic* theHEInelasticModel = new G4HEProtonInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		// Use FTFP model - FDL
+		FTFP_model->SetMinEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
       else if (particleName == "anti_proton") 
 	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4AntiProtonInelasticProcess* theInelasticProcess = 
-	    new G4AntiProtonInelasticProcess();
-	  G4LEAntiProtonInelastic* theLEInelasticModel = 
-	    new G4LEAntiProtonInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEAntiProtonInelastic* theHEInelasticModel = 
-	    new G4HEAntiProtonInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		pmanager->AddDiscreteProcess(theElasticProcess);
+		G4AntiProtonInelasticProcess* theInelasticProcess =
+			new G4AntiProtonInelasticProcess();
+		theInelasticProcess->RegisterMe(FTFP_model);
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
       else if (particleName == "neutron") 
 	{
 	  // elastic scattering
-	  G4HadronElasticProcess* theNeutronElasticProcess = 
-	    new G4HadronElasticProcess;
-	  G4LElastic* theElasticModel1 = new G4LElastic;
-	  G4NeutronHPElastic * theElasticNeutron = new G4NeutronHPElastic;
-	  theNeutronElasticProcess->RegisterMe(theElasticModel1);
-	  theElasticModel1->SetMinEnergy(19*MeV);
-	  theNeutronElasticProcess->RegisterMe(theElasticNeutron);
-	  G4NeutronHPElasticData * theNeutronData = new G4NeutronHPElasticData;
-	  theNeutronElasticProcess->AddDataSet(theNeutronData);
-	  pmanager->AddDiscreteProcess(theNeutronElasticProcess);
-	  
+    G4HadronElasticProcess* theNeutronElasticProcess =
+    	new G4HadronElasticProcess;
+		G4HadronElastic* theElasticModel1 = new G4HadronElastic;
+		G4NeutronHPElastic * theElasticNeutron = new G4NeutronHPElastic;
+		theNeutronElasticProcess->RegisterMe(theElasticModel1);
+		theElasticModel1->SetMinEnergy(19*MeV);
+		theNeutronElasticProcess->RegisterMe(theElasticNeutron);
+		G4NeutronHPElasticData * theNeutronData = new G4NeutronHPElasticData;
+		theNeutronElasticProcess->AddDataSet(theNeutronData);
+		pmanager->AddDiscreteProcess(theNeutronElasticProcess);
+
 	  // inelastic scattering
 	  G4NeutronInelasticProcess* theInelasticProcess =
 	    new G4NeutronInelasticProcess();
@@ -596,105 +613,106 @@ void WCSimPhysicsList::ConstructHad()
 	  // GHEISHA = Original Geant4 default model 
 	  // BERTINI = Bertini intra-nuclear cascade model
 	  // BINARY  = Binary intra-nuclear cascade model
-	  if (gheishahad) {
-	    G4LENeutronInelastic* theInelasticModel = new G4LENeutronInelastic;
-	    theInelasticModel->SetMinEnergy(19*MeV);
-	    theInelasticProcess->RegisterMe(theInelasticModel);
-	  }
-	  else if (bertinihad) {
-	    G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
-	    theBertiniModel->SetMinEnergy(19*MeV);
-	    theInelasticProcess->RegisterMe(theBertiniModel);
-	  }
-	  else if (binaryhad) {
-	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theBinaryModel->SetMinEnergy(19*MeV);
-	    theInelasticProcess->RegisterMe(theBinaryModel);
+		if (bertinihad) {
+			G4CascadeInterface* theBertiniModel = new G4CascadeInterface;
+			theBertiniModel->SetMinEnergy(19*MeV);
+			theBertiniModel->SetMaxEnergy(5.0*GeV);
+			theInelasticProcess->RegisterMe(theBertiniModel);
+		}
+		else if (binaryhad) {
+			G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
+			theBinaryModel->SetMinEnergy(19*MeV);
+			theBinaryModel->SetMaxEnergy(5.0*GeV);
+			theInelasticProcess->RegisterMe(theBinaryModel);
+		}
+		else {
+			G4cout << "No secondary interaction model chosen! Using G4 BERTINI." << G4endl;
+			G4CascadeInterface* theBertiniModel = new G4CascadeInterface();
+			theBertiniModel->SetMinEnergy(19*MeV);
+			theBertiniModel->SetMaxEnergy(5.0*GeV);
+			theInelasticProcess->RegisterMe(theBertiniModel);
+		}
 
-      G4LENeutronInelastic* theInelasticModel = new G4LENeutronInelastic;
-      theInelasticModel->SetMinEnergy(10.1*GeV);
-      theInelasticModel->SetMaxEnergy( 45.*GeV );
-      theInelasticProcess->RegisterMe(theInelasticModel);
-	  }
-	  else {
-	    G4cout << "No secondary interaction model chosen! Using G4 BINARY." << G4endl;
-	    G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
-	    theBinaryModel->SetMinEnergy(19*MeV);
-	    theInelasticProcess->RegisterMe(theBinaryModel);
-	  }
-	  
-	  G4HENeutronInelastic* theHEInelasticModel = new G4HENeutronInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  
-	  G4NeutronHPInelastic * theLENeutronInelasticModel =
-	    new G4NeutronHPInelastic;
-	  theInelasticProcess->RegisterMe(theLENeutronInelasticModel);
-	  
-	  G4NeutronHPInelasticData * theNeutronData1 = 
-	    new G4NeutronHPInelasticData;
-	  theInelasticProcess->AddDataSet(theNeutronData1);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		// Use FTFP - FDL
+		FTFP_model->SetMinEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
 
-	  // capture
-	  G4HadronCaptureProcess* theCaptureProcess =
-	    new G4HadronCaptureProcess;
-	  G4LCapture* theCaptureModel = new G4LCapture;
-	  theCaptureModel->SetMinEnergy(19*MeV);
-	  theCaptureProcess->RegisterMe(theCaptureModel);
-	  G4NeutronHPCapture * theLENeutronCaptureModel = new G4NeutronHPCapture;
-	  theCaptureProcess->RegisterMe(theLENeutronCaptureModel);
-	  G4NeutronHPCaptureData * theNeutronData3 = new G4NeutronHPCaptureData;
-	  theCaptureProcess->AddDataSet(theNeutronData3);
-	  pmanager->AddDiscreteProcess(theCaptureProcess);
-	  //  G4ProcessManager* pmanager = G4Neutron::Neutron->GetProcessManager();
-	  //  pmanager->AddProcess(new G4UserSpecialCuts(),-1,-1,1);
+		G4NeutronHPInelastic * theLENeutronInelasticModel =
+			new G4NeutronHPInelastic;
+		theInelasticProcess->RegisterMe(theLENeutronInelasticModel);
+
+		G4NeutronHPInelasticData * theNeutronData1 =
+			new G4NeutronHPInelasticData;
+		theInelasticProcess->AddDataSet(theNeutronData1);
+		pmanager->AddDiscreteProcess(theInelasticProcess);
+
+		// capture
+		G4HadronCaptureProcess* theCaptureProcess =
+			new G4HadronCaptureProcess;
+		G4NeutronHPCapture* theCaptureModelHP = new G4NeutronHPCapture();
+		theCaptureProcess->RegisterMe(theCaptureModelHP);
+		G4NeutronHPCaptureData* theNeutronCaptureData = new G4NeutronHPCaptureData;
+		theCaptureProcess->AddDataSet(theNeutronCaptureData);
+
+		pmanager->AddDiscreteProcess(theCaptureProcess);
 	}
 
       else if (particleName == "anti_neutron") 
 	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4AntiNeutronInelasticProcess* theInelasticProcess = 
-	    new G4AntiNeutronInelasticProcess();
-	  G4LEAntiNeutronInelastic* theLEInelasticModel = 
-	    new G4LEAntiNeutronInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  G4HEAntiNeutronInelastic* theHEInelasticModel = 
-	    new G4HEAntiNeutronInelastic;
-	  theInelasticProcess->RegisterMe(theHEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		pmanager->AddDiscreteProcess(theElasticProcess);
+		G4AntiNeutronInelasticProcess* theInelasticProcess =
+			new G4AntiNeutronInelasticProcess();
+		theInelasticProcess->RegisterMe(FTFP_model);
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
       else if (particleName == "deuteron") 
 	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4DeuteronInelasticProcess* theInelasticProcess = 
-	    new G4DeuteronInelasticProcess();
-	  G4LEDeuteronInelastic* theLEInelasticModel = 
-	    new G4LEDeuteronInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		pmanager->AddDiscreteProcess(theElasticProcess);
+		G4DeuteronInelasticProcess* theInelasticProcess =
+			new G4DeuteronInelasticProcess();
+
+		// Use INCL++ for low energy and FTFP for high energy - SS
+		G4INCLXXInterface* theINCLXXModel = new G4INCLXXInterface();
+		theINCLXXModel->SetMaxEnergy(3.0*GeV);
+		theInelasticProcess->RegisterMe(theINCLXXModel);
+		FTFP_model->SetMinEnergy(3.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
       
       else if (particleName == "triton") 
 	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4TritonInelasticProcess* theInelasticProcess = 
-	    new G4TritonInelasticProcess();
-	  G4LETritonInelastic* theLEInelasticModel = 
-	    new G4LETritonInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		pmanager->AddDiscreteProcess(theElasticProcess);
+		G4TritonInelasticProcess* theInelasticProcess =
+			new G4TritonInelasticProcess();
+
+		// Use Binary Light Ion Reaction for low energy
+		// and FTFP for high energy - SS
+		G4BinaryLightIonReaction* ionModel = new G4BinaryLightIonReaction();
+		ionModel->SetMaxEnergy(10.0*GeV);
+		theInelasticProcess->RegisterMe(ionModel);
+		FTFP_model->SetMinEnergy(3.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
       else if (particleName == "alpha") 
 	{
-	  pmanager->AddDiscreteProcess(theElasticProcess);
-	  G4AlphaInelasticProcess* theInelasticProcess = 
-	    new G4AlphaInelasticProcess();
-	  G4LEAlphaInelastic* theLEInelasticModel = 
-	    new G4LEAlphaInelastic;
-	  theInelasticProcess->RegisterMe(theLEInelasticModel);
-	  pmanager->AddDiscreteProcess(theInelasticProcess);
+		pmanager->AddDiscreteProcess(theElasticProcess);
+		G4AlphaInelasticProcess* theInelasticProcess =
+			new G4AlphaInelasticProcess();
+
+		// Use Binary for low energy and FTFP for high energy - SS
+		G4BinaryCascade* theBinaryModel = new G4BinaryCascade();
+		theBinaryModel->SetMaxEnergy(4.0*GeV);
+		theInelasticProcess->RegisterMe(theBinaryModel);
+		FTFP_model->SetMinEnergy(2.0*GeV);
+		theInelasticProcess->RegisterMe(FTFP_model);
+
+		pmanager->AddDiscreteProcess(theInelasticProcess);
 	}
 
     }
@@ -706,37 +724,28 @@ void WCSimPhysicsList::ConstructHad()
 // Sets secondary hadronic interaction model 
 // Note: this is currently only implemented for
 // protons and neutrons -- not pions.
-// Gheisha = Original Geant4 default 
+// Gheisha = Original Geant4 default // DISAPPEARED IN G4.10
 // Bertini = Bertini intra-nuclear cascade model
 // Binary  = Binary intra-nuclear cascade model
 void WCSimPhysicsList::SetSecondaryHad(G4String hadval)
 {
   SecondaryHadModel = hadval;
 
-  if (SecondaryHadModel == "GHEISHA") {
-    G4cout << "Secondary interaction model set to GHEISHA" << G4endl;
-    gheishahad = true;
-    bertinihad = false;
-    binaryhad  = false;
-  }
-  else if (SecondaryHadModel == "BERTINI") {
+  if (SecondaryHadModel == "BERTINI") {
     G4cout << "Secondary interaction model set to BERTINI" << G4endl;
-    gheishahad = false;
     bertinihad = true;
     binaryhad  = false;
   }
   else if (SecondaryHadModel == "BINARY") {
     G4cout << "Secondary interaction model set to BINARY" << G4endl;
-    gheishahad = false;
     bertinihad = false;
     binaryhad  = true;
   }
   else {
     G4cout << "Secondary interaction model " << SecondaryHadModel
 	   << " is not a valid choice. BINARY model will be used." << G4endl;
-    gheishahad = false;
-    bertinihad = false;
-    binaryhad  = true;
+    bertinihad = true;
+    binaryhad  = false;
   }
 
 

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -1,5 +1,8 @@
 #include "WCSimPhysicsListFactory.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 /* This code draws upon examples/extended/fields/field04 for inspiration */
 
 

--- a/src/WCSimPhysicsMessenger.cc
+++ b/src/WCSimPhysicsMessenger.cc
@@ -14,14 +14,13 @@ WCSimPhysicsMessenger::WCSimPhysicsMessenger(WCSimPhysicsList* WCSimPhys)
   WCSimDir->SetGuidance("Commands to change secondary interaction model for protons");
 
   hadmodelCmd = new G4UIcmdWithAString("/WCSim/physics/secondaries/model",this);
-  hadmodelCmd->SetGuidance("Available options: GHEISHA BERTINI BINARY");
+  hadmodelCmd->SetGuidance("Available options: BERTINI BINARY");
   hadmodelCmd->SetGuidance("Description:");
-  hadmodelCmd->SetGuidance("GHEISHA = standard, fast G4 hadronic interaction model");
-  hadmodelCmd->SetGuidance("BERTINI = Bertini cascade model");
+  hadmodelCmd->SetGuidance("BERTINI = Bertini cascade model (Geant4.10 default)");
   hadmodelCmd->SetGuidance("BINARY  = Binary cascade model (2KM default)");
   hadmodelCmd->SetParameterName("secondaries", true, false);
-  hadmodelCmd->SetDefaultValue("BINARY");
-  hadmodelCmd->SetCandidates("GHEISHA BERTINI BINARY");
+  hadmodelCmd->SetDefaultValue("BERTINI");
+  hadmodelCmd->SetCandidates("BERTINI BINARY");
 
 }
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -17,6 +17,9 @@
 #include "G4Navigator.hh"
 #include "G4TransportationManager.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 using std::vector;
 using std::string;
 using std::fstream;

--- a/src/WCSimStackingAction.cc
+++ b/src/WCSimStackingAction.cc
@@ -11,6 +11,9 @@
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTypes.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 //class WCSimDetectorConstruction;
 
 WCSimStackingAction::WCSimStackingAction(WCSimDetectorConstruction* myDet):DetConstruct(myDet) {;}

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -7,6 +7,9 @@
 #include "G4VProcess.hh"
 #include "WCSimTrackInformation.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 WCSimTrackingAction::WCSimTrackingAction()
 {
   ProcessList.insert("Decay") ;

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -8,6 +8,9 @@
 #include "G4UnitsTable.hh"
 #include "G4VProcess.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 #include <sstream>
 
 //G4Allocator<WCSimTrajectory> aTrajectoryAllocator;
@@ -93,7 +96,7 @@ void WCSimTrajectory::ShowTrajectory(std::ostream& os) const
 void WCSimTrajectory::DrawTrajectory(G4int i_mode) const
 {
   // Invoke the default implementation in G4VTrajectory...
-  G4VTrajectory::DrawTrajectory(i_mode);
+  G4VTrajectory::DrawTrajectory();
   // ... or override with your own code here.
 }
 

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -93,7 +93,7 @@ void WCSimTrajectory::ShowTrajectory(std::ostream& os) const
   // ... or override with your own code here.
 }
 
-void WCSimTrajectory::DrawTrajectory(G4int i_mode) const
+void WCSimTrajectory::DrawTrajectory() const
 {
   // Invoke the default implementation in G4VTrajectory...
   G4VTrajectory::DrawTrajectory();

--- a/src/WCSimWCHit.cc
+++ b/src/WCSimWCHit.cc
@@ -8,6 +8,9 @@
 #include "G4RotationMatrix.hh"
 #include <iomanip>
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 G4int WCSimWCHit::maxPe = 0;
 
 G4Allocator<WCSimWCHit> WCSimWCHitAllocator;

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -9,6 +9,9 @@
 #include "Randomize.hh"
 #include "G4ios.hh"
 
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+
 #include <sstream>
 
 #include "WCSimDetectorConstruction.hh"


### PR DESCRIPTION
This is the implementation of G4.10 inside WCSim.

Tests have been run to compare if there is a difference between version of Geant4 9.4.4 and Geant4 10.1.3 and results shows no differences for electrons and muons between [100-1000] MeV.
As a recommendation by Geant4 developers, the BERTINI physics list is set to the default one in file joboption2.mac.

It's worth noticing that the GEISHA models have been depreciated and are now removed from WCSim.

The biggest changes can be found in the WCSimPhysicsList class. Other changes are mainly made to incorporate the new headers for physical constants introduced by Geant4 version 10.

This work is based on Sam Short and Francesca Di Lodovico implementation. See #178 

EDIT : Validation plots can be find here from electrons, muons and pions :
[G4FinalResults_Update.pdf](https://github.com/WCSim/WCSim/files/770389/G4FinalResults_Update.pdf)
[G4Validation_yoshida_v2.pdf](https://github.com/WCSim/WCSim/files/770390/G4Validation_yoshida_v2.pdf)
