### PR TITLE
modify timing resolution based on SKDetSim

### DIFF
--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -77,11 +77,21 @@ G4double PMT20inch::GetExposeHeight() {return .18*m;}
 G4double PMT20inch::GetRadius() {return .254*m;}
 G4double PMT20inch::GetPMTGlassThickness() {return 0.4*cm;}
 float PMT20inch::HitTimeSmearing(float Q) {
-  float timingConstant = 10.0; 
-  float timingResolution = 0.33 + sqrt(timingConstant/Q); 
-  // looking at SK's jitter function for 20" tubes
-  if (timingResolution < 0.58) timingResolution=0.58;
-  float Smearing_factor = G4RandGauss::shoot(0.0,timingResolution);
+  G4float sig_param[4]={2.395,0.649,0.6002,2.307};
+  G4float lambda_param[2]={0.7782,0.05526};
+  
+  G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
+  
+  G4float highcharge_param[2];
+  highcharge_param[0]=2*sig_param[0]*sig_param[1]*sig_param[3]*sqrt(sig_param[3])*exp(-sig_param[1]*sig_param[3]);
+  highcharge_param[1]=sig_param[0]*((1-2*sig_param[1]*sig_param[3])*exp(-sig_param[1]*sig_param[3])+sig_param[2]);
+  G4float sigma_highcharge = highcharge_param[0]/sqrt(Q)+highcharge_param[1];
+  
+  G4float sigma = sigma_lowcharge*(Q<sig_param[3])+sigma_highcharge*(Q>sig_param[3]);
+  G4float lambda = lambda_param[0]+lambda_param[1]*Q;
+  G4float totalsigma = sqrt(sigma*sigma+1/lambda/lambda);
+
+  float Smearing_factor = G4RandGauss::shoot(0.0,totalsigma);
   return Smearing_factor;
 }
 


### PR DESCRIPTION
Based on the #109, 20 inch PMT timing resolution function is modified.
(timing resolution table of SKDetSim is in /usr/local/sklib_g77/skofl_16c/const/tdcres.dat)

I checked the relationship between charge and the resolution between nominal PMT with 0.9-1.1 p.e. charge and the other PMTs.
the result is shown in the figure below.
![tres_q_withthr](https://cloud.githubusercontent.com/assets/8589041/23099082/fc4fe2a0-f6a1-11e6-9688-1e50708b72cb.png)
The red solid line is the expected value, dashed red line is expected value without correction at Q<0.5,
and black dots shows the MC result.
(Error bar is the fitting error of hit time )
Q<0.5 correction seems not to be introduced in SKDetSim, but this request does not correct it.

From this result, the MC result seems to follow the expected value.
