### PR TITLE
Fix/root opts cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 
 ## WCSimRootDict.cc regeneration by rootcint
 ## Use ROOT 5.34.32 as some issues with PARSE_ARGUMENTS were found in older ROOT versions (ROOT 5.34.11)
-ROOT_GENERATE_DICTIONARY(${CMAKE_CURRENT_SOURCE_DIR}/src/WCSimRootDict ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootEvent.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootGeom.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimPmtInfo.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimEnumerations.hh LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
+ROOT_GENERATE_DICTIONARY(${CMAKE_CURRENT_SOURCE_DIR}/src/WCSimRootDict ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootEvent.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootGeom.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimPmtInfo.hh ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimEnumerations.hh  ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootOptions.hh LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
 
 
 ## Crucial for reading ROOT classes: make shared object library
-add_library(WCSimRoot SHARED ./src/WCSimRootEvent.cc ./src/WCSimRootGeom.cc ./src/WCSimPmtInfo.cc ./src/WCSimEnumerations.cc ./src/WCSimRootDict.cxx)
+add_library(WCSimRoot SHARED ./src/WCSimRootEvent.cc ./src/WCSimRootGeom.cc ./src/WCSimPmtInfo.cc ./src/WCSimEnumerations.cc ./src/WCSimRootOptions.cc ./src/WCSimRootDict.cxx)
 target_link_libraries(WCSimRoot  ${ROOT_LIBRARIES})
 
 

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -25,7 +25,7 @@ public:
 
   WCSimRootOptions();
   virtual ~WCSimRootOptions();
-  void Print();
+  void Print(Option_t *option = "") const;
 
   //WCSimDetector* gets
   void SetDetectorName(string iDetectorName) {DetectorName = iDetectorName;}

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -25,7 +25,7 @@ WCSimRootOptions::~WCSimRootOptions()
 }
 
 //______________________________________________________________________________
-void WCSimRootOptions::Print(Option_t *option) const
+void WCSimRootOptions::Print(Option_t *) const
 {
   cout
     << "Detector construction:" << endl

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -25,7 +25,7 @@ WCSimRootOptions::~WCSimRootOptions()
 }
 
 //______________________________________________________________________________
-void WCSimRootOptions::Print()
+void WCSimRootOptions::Print(Option_t *option) const
 {
   cout
     << "Detector construction:" << endl


### PR DESCRIPTION
Could not compile through cmake due to new RootOptions in ROOT output. This pull request fixes that by adding them to CMakeLists.txt. It also fixes compiler warning about hidden virtuals from TOption.
@tdealtry, can you quickly check the Print() fix? I think I fixed it correctly but a cross check to reduce that warning is helpful. 
Less compiler warning makes it easier to spot real compiler errors.