### PR TITLE
Fix issue149 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Useful cmake commands:
 * gamma = green
 * neutrino = yellow
 * electron = blue
-* muon = black
 * positron = red
-* muon+ = white
-* proton = magneta
-* neutron = grey
+* muon = white
+* muon+ = silver
+* proton = magenta
+* neutron = cyan
 
 ```
 WCSim development is supported by the United States National Science Foundation.

--- a/src/WCSimVisManager.cc
+++ b/src/WCSimVisManager.cc
@@ -125,7 +125,7 @@ void WCSimVisManager::RegisterGraphicsSystems () {
   mymodel->Set("e+","red");
   mymodel->Set("mu+",G4Colour(0.78, 0.78, 0.78));  //to distinguish mu+ from mu- on black background.
   mymodel->Set("proton","magenta");
-  mymodel->Set("neutron","Grey");
+  mymodel->Set("neutron","cyan");
 
   if (fVerbose > 0) {
     G4cout <<

--- a/src/WCSimVisManager.cc
+++ b/src/WCSimVisManager.cc
@@ -120,10 +120,10 @@ void WCSimVisManager::RegisterGraphicsSystems () {
   mymodel->Set("nu_mu","yellow");
   mymodel->Set("anti_nu_e","yellow");
   mymodel->Set("anti_nu_mu","yellow");
-  mymodel->Set("e-","blue");
-  mymodel->Set("mu-","black");
+  mymodel->Set("e-","blue");    
+  mymodel->Set("mu-","white");
   mymodel->Set("e+","red");
-  mymodel->Set("mu+","white");
+  mymodel->Set("mu+",G4Colour(0.78, 0.78, 0.78));  //to distinguish mu+ from mu- on black background.
   mymodel->Set("proton","magenta");
   mymodel->Set("neutron","Grey");
 

--- a/visOGLSX.mac
+++ b/visOGLSX.mac
@@ -21,4 +21,6 @@
 /vis/scene/add/trajectories
 /vis/scene/endOfEventAction accumulate
 
+# Default background for OGLSX is black, can change it here (but muons are white)
+#/vis/viewer/set/background 0 0 0 1
 

--- a/visRayTracer.mac
+++ b/visRayTracer.mac
@@ -22,3 +22,5 @@
 /vis/rayTracer/eyePosition 70 1 20
 /vis/rayTracer/trace g4RayTracer2.jpeg # Viewpoint is outside the detector again, but closer to the top cap in the z direction.
 
+# Make default RayTracer background black (RGB values) as OGL
+/vis/rayTracer/backgroundColour 0 0 0


### PR DESCRIPTION
This pull request addresses issue #149 by making mu-'s white, mu+'s silver and adding background colour options for visualizations. Now RayTracer is also black as OGLS's default.