### PR TITLE
Fix photocathode bug where photons were not going through the cathode.

### DIFF
--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -110,6 +110,18 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
       &&(particleDefinition == G4OpticalPhoton::OpticalPhotonDefinition()))
     return false;
 
+  G4StepPoint        *postStepPoint = aStep->GetPostStepPoint();
+  G4VPhysicalVolume  *postVol = postStepPoint->GetPhysicalVolume();
+  //if (thePhysical)  G4cout << " thePrePV:  " << thePhysical->GetName()  << G4endl;
+  //if (postVol) G4cout << " thePostPV: " << postVol->GetName() << G4endl;
+
+  //Optical Photon must pass through glass into PMT interior!
+  // What about the other way around? 
+  // TF: current interior won't keep photons alive like in reality
+  // Not an issue yet, because then interior needs to be a sensitive detector, when postStepPoint is the glass.
+  if(postVol->GetName() != "InteriorWCPMT")
+    return false;
+
   //  if ( particleDefinition ==  G4OpticalPhoton::OpticalPhotonDefinition() ) 
   // G4cout << volumeName << " hit by optical Photon! " << G4endl;
     


### PR DESCRIPTION
Problem: photons can go through the sensitive detector (glass)
and be killed in the next volume by Absorption, eg. in the BlackSheet, but will then
still be counted as hits here (issue #208 ). 
One solution would be to recode the cathode implementation as in G4/examples/extended/optical/LXe cathode implementation.
or easier: make sure they cross the cathode to be counted as a hit, as the logical Boundary "cathode" can't be a sensitive detector.
The latter fix is what this pull request does.