### PR TITLE
ROOT wrapper: rootwc

### DIFF
--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -48,10 +48,9 @@ DOXYGEN_EXISTS = 0
 endif
 
 .PHONY: all
-all: rootcint lib bin shared libWCSim.a
+all: rootcint lib bin shared libWCSim.a rootwc
 
 # Note dependencies not yet set up right yet
-
 ROOTSO    := libWCSimRoot.so
 
 ROOTSRC  := ./src/WCSimRootEvent.cc ./include/WCSimRootEvent.hh ./src/WCSimRootGeom.cc ./include/WCSimRootGeom.hh ./include/WCSimPmtInfo.hh ./src/WCSimEnumerations.cc ./include/WCSimEnumerations.hh ./src/WCSimRootOptions.cc ./include/WCSimRootOptions.hh ./include/WCSimRootLinkDef.hh
@@ -84,6 +83,12 @@ clean_wcsim:
 	@if [ -d "doc/doxygen" ]; \
 		then \
 		rm -r doc/doxygen; \
-	fi	
+	fi
 
+rootwc: FORCE
+	@echo "** Copying scripts to bin..."
+	cp ${G4WORKDIR}/rootwc/rootwc ${G4WORKDIR}/bin/${G4SYSTEM}
+
+FORCE:
+	
 include $(G4INSTALL)/config/binmake.gmk

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -34,7 +34,7 @@ ROOTOBJS  := $(G4WORKDIR)/tmp/$(G4SYSTEM)/WCSim/WCSimRootEvent.o $(G4WORKDIR)/tm
 
 .PHONY: directories
 
-all: directories libWCSimRoot.so
+all: directories libWCSimRoot.so rootwc
 
 directories: $(G4TMPDIR)
 
@@ -62,3 +62,9 @@ clean :
 	@rm -f $(G4TMPDIR)/*.o
 	@rm -f ./src/WCSimRootDict.cc
 
+rootwc: FORCE
+	@echo "** Copying scripts to bin..."
+	cp ${G4WORKDIR}/rootwc/rootwc ${G4WORKDIR}/bin/${G4SYSTEM}
+
+FORCE:
+	

--- a/rootwc/loadincs.C
+++ b/rootwc/loadincs.C
@@ -1,0 +1,33 @@
+{
+  TString wcsim_topdir = gSystem->Getenv("WCSIMDIR");
+
+  TString mp = gROOT->GetMacroPath();
+  TString ip;
+
+  TString wcsim_inc = wcsim_topdir + "/include";
+
+  const char* p = wcsim_inc.Data();
+  if (p) {
+    mp += ":";
+    mp += p;
+    ip += " -I";
+    ip += p;
+  }
+
+  mp += ":/usr/local/include/";
+  ip += "  -I/usr/local/include/";
+
+  gROOT->SetMacroPath(mp.Data());
+  gSystem->SetIncludePath(ip);
+
+  // additions to .include must be done individually or CINT will
+  // try to quote all the spaces as a single path
+
+  TString dip = ".include ";
+  dip += wcsim_inc.Data();
+  gROOT->ProcessLine(dip.Data());
+
+  dip = ".include /usr/local/include/";
+  gROOT->ProcessLine(dip.Data());
+}
+

--- a/rootwc/loadlibs.C
+++ b/rootwc/loadlibs.C
@@ -1,0 +1,24 @@
+{
+  TString libs0 = gSystem->GetDynamicPath();
+  TString libswc = gSystem->Getenv("WCSIMDIR");
+  TString libsg4 = gSystem->Getenv("GEANT4_BASE_DIR/install/lib");
+  TString libs  = libs0 + ":" + libswc + ":" + libsg4 + ":/usr/lib:/usr/local/lib:/opt/lib:/opt/local/lib";
+  gSystem->SetDynamicPath(libs.Data());
+
+  gSystem->Load("libGpad");
+  gSystem->Load("libPhysics");
+  gSystem->Load("libMatrix");
+  gSystem->Load("libHist");
+  gSystem->Load("libGraf");
+  gSystem->Load("libTree");
+  gSystem->Load("libRIO");
+  gSystem->Load("libXMLIO");
+  gSystem->Load("libMinuit");
+  //gSystem->Load("libMinuit2");
+  gSystem->Load("libMathMore"); 
+
+  gSystem->Load("libG4global.so");
+  gSystem->Load("libWCSimRoot.so");
+  
+}
+

--- a/rootwc/rootwc
+++ b/rootwc/rootwc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+root -l $WCSIMDIR/rootwc/rootwc.C $*

--- a/rootwc/rootwc.C
+++ b/rootwc/rootwc.C
@@ -1,0 +1,129 @@
+void change_prompt()
+{
+    TRint* rint = dynamic_cast<TRint*>(gApplication);
+    if (!rint) return;
+
+    rint->SetPrompt("RootWC: For all your WCSim needs [%d] ");
+}
+
+void t2k_style()
+{
+  // T2K style definition
+  // Adopted from BaBar collaboration
+  // Add the following lines to the start of your rootlogon.C file
+  TStyle *t2kStyle= new TStyle("T2K","T2K approved plots style");
+
+  // use plain black on white colors
+  t2kStyle->SetFrameBorderMode(0);
+  t2kStyle->SetCanvasBorderMode(0);
+  t2kStyle->SetPadBorderMode(0);
+  t2kStyle->SetPadColor(0);
+  t2kStyle->SetCanvasColor(0);
+  t2kStyle->SetStatColor(0);
+  //t2kStyle->SetFillColor(0); // this doesn't seem to be over-ridable
+  t2kStyle->SetLegendBorderSize(1); 
+
+  // set the paper & margin sizes
+  t2kStyle->SetPaperSize(20,26);
+  t2kStyle->SetPadTopMargin(0.05);
+  t2kStyle->SetPadRightMargin(0.05);
+  t2kStyle->SetPadBottomMargin(0.16);
+  t2kStyle->SetPadLeftMargin(0.13);
+
+  // use large Times-Roman fonts
+  t2kStyle->SetTextFont(132);
+  t2kStyle->SetTextSize(0.08);
+  t2kStyle->SetLabelFont(132,"x");
+  t2kStyle->SetLabelFont(132,"y");
+  t2kStyle->SetLabelFont(132,"z");
+  t2kStyle->SetLabelSize(0.05,"x");
+  t2kStyle->SetTitleSize(0.06,"x");
+  t2kStyle->SetLabelSize(0.05,"y");
+  t2kStyle->SetTitleSize(0.06,"y");
+  t2kStyle->SetLabelSize(0.05,"z");
+  t2kStyle->SetTitleSize(0.06,"z");
+  t2kStyle->SetLabelFont(132,"t");
+  t2kStyle->SetTitleFont(132,"x");
+  t2kStyle->SetTitleFont(132,"y");
+  t2kStyle->SetTitleFont(132,"z");
+  t2kStyle->SetTitleFont(132,"t"); 
+  t2kStyle->SetTitleFillColor(0);
+  t2kStyle->SetTitleX(0.25);
+  t2kStyle->SetTitleFontSize(0.08);
+  t2kStyle->SetTitleFont(132,"pad");
+
+  // use bold lines and markers
+  t2kStyle->SetMarkerStyle(20);
+  t2kStyle->SetHistLineWidth(1.85);
+  t2kStyle->SetLineStyleString(2,"[12 12]"); // postscript dashes
+
+  // get rid of X error bars and y error bar caps
+  t2kStyle->SetErrorX(0.001);
+
+  // do not display any of the standard histogram decorations
+  t2kStyle->SetOptTitle(0);
+  t2kStyle->SetOptStat(0);
+  t2kStyle->SetOptFit(0);
+
+  // put tick marks on top and RHS of plots
+  t2kStyle->SetPadTickX(1);
+  t2kStyle->SetPadTickY(1);
+
+  //add the stat box
+  /*
+  t2kStyle->SetOptFit(1); // show fit results
+  t2kStyle->SetOptStat(1100); // show mean & RMS only
+  //t2kStyle->SetStatStyle(0); //make stat boxes see through
+  t2kStyle->SetStatBorderSize(0);
+  t2kStyle->SetTextFont(42); //less bold
+
+  // Add a greyscale palette for 2D plots
+  /*
+  int ncol=50;
+  double dcol = 1./float(ncol);
+  double gray = 1;
+  TColor **theCols = new TColor*[ncol];
+  for (int i=0;i<ncol;i++) theCols[i] = new TColor(999-i,0.0,0.7,0.7);
+  for (int j = 0; j < ncol; j++) {
+    theCols[j]->SetRGB(gray,gray,gray);
+    gray -= dcol;
+  }
+  int ColJul[100];
+  for  (int i=0; i<100; i++) ColJul[i]=999-i;
+  t2kStyle->SetPalette(ncol,ColJul);
+  */
+
+  //Define a nicer color palette (red->blue)
+  //Uncomment these lines for a color palette (default is B&W)
+  t2kStyle->SetPalette(1,0);  // use the nice red->blue palette
+  const Int_t NRGBs = 5;
+  const Int_t NCont = 255;
+
+  Double_t stops[NRGBs] = { 0.00, 0.34, 0.61, 0.84, 1.00 };
+  Double_t red[NRGBs]   = { 0.00, 0.00, 0.87, 1.00, 0.51 };
+  Double_t green[NRGBs] = { 0.00, 0.81, 1.00, 0.20, 0.00 };
+  Double_t blue[NRGBs]  = { 0.51, 1.00, 0.12, 0.00, 0.00 };
+  TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+  t2kStyle->SetNumberContours(NCont); 
+
+}//End of definition of t2kStyle
+
+void rootwc()
+{   
+    TString script_dir = gSystem->Getenv("WCSIMDIR");
+    script_dir += "/rootwc/";
+
+    TString curr_dir = gSystem->pwd();
+
+    gSystem->cd(script_dir.Data());
+
+    gROOT->ProcessLine(".x $WCSIMDIR/rootwc/loadincs.C");    
+    gROOT->ProcessLine(".x $WCSIMDIR/rootwc/loadlibs.C");    
+
+    gSystem->cd(curr_dir.Data());
+
+    change_prompt();
+
+    t2k_style();
+    gROOT->SetStyle("T2K");
+}

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -1,9 +1,21 @@
+#include "TSystem.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TCanvas.h"
+
 #include <iostream>
 #include <TH1F.h>
 #include <stdio.h>     
-#include <stdlib.h>    
+#include <stdlib.h>
+
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "WCSimRootEvent.hh"
+#include "WCSimRootGeom.hh"
+#include "WCSimRootOptions.hh"
+#endif
+
 // Simple example of reading a generated Root file
-void sample_readfile(char *filename=NULL, bool verbose=false)
+int sample_readfile(char *filename=NULL, bool verbose=false)
 {
   // Clear global scope
   //gROOT->Reset();
@@ -39,6 +51,8 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
   */
   // Load the library with class dictionary info
   // (create with "gmake shared")
+
+#if !defined(__MAKECINT__)
   char* wcsimdirenv;
   wcsimdirenv = getenv ("WCSIMDIR");
   if(wcsimdirenv !=  NULL){
@@ -46,7 +60,8 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
   }else{
     gSystem->Load("../libWCSimRoot.so");
   }
-
+#endif
+  
   TFile *file;
   // Open the file
   if (filename==NULL){
@@ -216,10 +231,10 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
 	if(verbose) printf("Total pe: %d times( ",peForTube);
 	for (int j = timeArrayIndex; j < timeArrayIndex + peForTube; j++)
 	{
-	  WCSimRootCherenkovHitTime HitTime = 
-	    dynamic_cast<WCSimRootCherenkovHitTime>(timeArray->At(j));
+	  WCSimRootCherenkovHitTime* HitTime = 
+	    dynamic_cast<WCSimRootCherenkovHitTime*>(timeArray->At(j));
 	  
-	  if(verbose) printf("%6.2f ", HitTime.GetTruetime() );	     
+	  if(verbose) printf("%6.2f ", HitTime->GetTruetime() );	     
 	}
 	if(verbose) cout << ")" << endl;
       }
@@ -278,4 +293,6 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
   c1->cd(4); h1->Draw();
   
   std::cout<<"num_trig "<<num_trig<<"\n";
+
+  return 0;
 }


### PR DESCRIPTION
A root wrapper (`rootwc`) that automatically loads the relevant WCSim libraries and includes, so as to make running root macros in compiled mode much easier (it is of course good practice to run macros in compiled mode, for both speed and debugging purposes).
This wrapper also loads the T2K plotting style, to give WCSim output some consistency. Of course, this can be modified/removed as required.
This pull request also modifies `sample_readfile.C` for running in compiled mode (adds includes, removes bugs)
This is part of #88, but I feel is a useful addition that people might want to use before the whole bulk of that gets put in (or not, depending on what the solution of #162)