### PR TITLE
Fix floating point exception error

### DIFF
--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -90,9 +90,6 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   G4int    trackID           = aStep->GetTrack()->GetTrackID();
   G4String volumeName        = aStep->GetTrack()->GetVolume()->GetName();
   
-  //XQ Add the wavelength there
-  G4float  wavelength = (2.0*M_PI*197.3)/( aStep->GetTrack()->GetTotalEnergy()/eV);
-  
   G4double energyDeposition  = aStep->GetTotalEnergyDeposit();
   G4double hitTime           = aStep->GetPreStepPoint()->GetGlobalTime();
 
@@ -144,7 +141,8 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   G4float effectiveAngularEfficiency;
 
 
-  
+  //XQ Add the wavelength there
+  G4float  wavelength = (2.0*M_PI*197.3)/( aStep->GetTrack()->GetTotalEnergy()/eV);
   G4float ratio = 1.;
   G4float maxQE;
   G4float photonQE;


### PR DESCRIPTION
I ran some particle guns with the new develop and encountered a few floating point exceptions (now handled by new Geant4's FPEdetection). These were caused by non-optical photons with a total energy of 0 in ProcessHits for which the wavelength calculation didn't make sense. Moved the wavelength calculation down to be only for optical photons.

The error encountered was: "ERROR: 8 - Floating point divide by zero."  This stops the full simulation and therefore this bugfix is urgent.