### PR TITLE
Addition of .travis.yml for Travis-ci build integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+
+language: cpp
+
+compiler: gcc
+dist: trusty
+
+services:
+  - docker
+
+before_install:
+  - docker pull brichards64/wcsim
+
+install:
+  - docker run -v `pwd`:/root/HyperK/WCSim brichards64/wcsim:simplebuild /bin/sh -c " source /root/HyperK/env-WCSim.sh; cd /root/HyperK/WCSim; make clean; make rootcint; make;  ls"
+
+script:
+  - docker run -v `pwd`:/root/HyperK/WCSim brichards64/wcsim:simplebuild /bin/sh -c "source /root/HyperK/env-WCSim.sh; cd /root/HyperK/WCSim; ./exe/bin/Linux-g++/WCSim WCSim.mac"
+  - if [ -e ./exe/bin/Linux-g++/WCSim ]; then true; else false; fi
+  - if [ -e wcsim.root ]; then true; else false; fi
+
+notifications:
+  email:
+    recipients:
+      - b.richards@qmul.ac.uk
+      - erin.osullivan@fysik.su.se
+    on_success: never # default: change
+    on_failure: always # default: always


### PR DESCRIPTION
This pull request is to add a file that is needed to instruct Travis-ci system how to build the WCSim code.

It the first stage of the automated build and validation integration. At the moment it just checks out the code when pushed to the repo or pull requests that contain a .travis.yml file. it builds it then runs the code with the supplied wcsim.mac. This first level just provides simple tests that it compiled successfully making an executable and that an output root file is made.

The next stage will add the automatic physics validation and plots.