### PR TITLE
parse Windows line endings correctly

### DIFF
--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -30,7 +30,7 @@ inline vector<string> readInLine(fstream& inFile, int lineSize, char* inBuf)
 {
   // Read in line break it up into tokens
   inFile.getline(inBuf,lineSize);
-  return tokenize(" $", inBuf);
+  return tokenize(" $\r", inBuf);
 }
 
 inline float atof( const string& s ) {return std::atof( s.c_str() );}


### PR DESCRIPTION
A nuance-formatted input file created on Windows will usually have `\r\n` line endings instead of the Unix default `\n`. Let’s add `\r` to the list of ignored characters so those files get parsed correctly.

(Problem identified and solution suggested by Nick Prouse on the hkwg-software mailing list.)