### PR TITLE
allow simulation of multiple primary vertices in an event

### DIFF
--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -4,6 +4,8 @@
 #include "G4VUserPrimaryGeneratorAction.hh"
 #include "G4ThreeVector.hh"
 #include "globals.hh"
+#include "jhfNtuple.h"
+#include <vector>
 
 #include <fstream>
 
@@ -14,6 +16,7 @@ class G4ParticleGun;
 class G4GeneralParticleSource;
 class G4Event;
 class WCSimPrimaryGeneratorMessenger;
+class G4Generator;
 
 class WCSimPrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
 {
@@ -25,23 +28,26 @@ public:
   void GeneratePrimaries(G4Event* anEvent);
 
   // Gun, laser & gps setting calls these functions to fill jhfNtuple and Root tree
-  void SetVtx(G4ThreeVector i)     { vtx = i; };
-  void SetBeamEnergy(G4double i)   { beamenergy = i; };
-  void SetBeamDir(G4ThreeVector i) { beamdir = i; };
-  void SetBeamPDG(G4int i)         { beampdg = i; };
+  void SetVtx(G4ThreeVector i)     { vtxs[0] = i; nvtxs = 1; };
+  void SetBeamEnergy(G4double i, G4int n = 0)   { beamenergies[n] = i;};
+  void SetBeamDir(G4ThreeVector i, G4int n = 0) { beamdirs[n] = i;};
+  void SetBeamPDG(G4int i, G4int n = 0)         { beampdgs[n] = i;};
+  void SetNvtxs(G4int i)     { nvtxs = i; };
+  void SetVtxs(G4int i, G4ThreeVector v)     { vtxs[i] = v; };
 
   // These go with jhfNtuple
   G4int GetVecRecNumber(){return vecRecNumber;}
   G4int GetMode() {return mode;};
-  G4int GetVtxVol() {return vtxvol;};
-  G4ThreeVector GetVtx() {return vtx;}
+  G4int GetNvtxs() {return nvtxs;};
+  G4int GetVtxVol(G4int n = 0) {return vtxsvol[n];};
+  G4ThreeVector GetVtx(G4int n = 0) {return vtxs[n];}
   G4int GetNpar() {return npar;};
-  G4int GetBeamPDG() {return beampdg;};
-  G4double GetBeamEnergy() {return beamenergy;};
-  G4ThreeVector GetBeamDir() {return beamdir;};
-  G4int GetTargetPDG() {return targetpdg;};
-  G4double GetTargetEnergy() {return targetenergy;};
-  G4ThreeVector GetTargetDir() {return targetdir;};
+  G4int GetBeamPDG(G4int n = 0) {return beampdgs[n];};
+  G4double GetBeamEnergy(G4int n = 0) {return beamenergies[n];};
+  G4ThreeVector GetBeamDir(G4int n = 0) {return beamdirs[n];};
+  G4int GetTargetPDG(G4int n = 0) {return targetpdgs[n];};
+  G4double GetTargetEnergy(G4int n = 0) {return targetenergies[n];};
+  G4ThreeVector GetTargetDir(G4int n = 0) {return targetdirs[n];};
 
   // older ...
   G4double GetNuEnergy() {return nuEnergy;};
@@ -74,12 +80,13 @@ private:
 
   // These go with jhfNtuple
   G4int mode;
-  G4int vtxvol;
-  G4ThreeVector vtx;
+  G4int nvtxs;
+  G4int vtxsvol[MAX_N_PRIMARIES];
+  G4ThreeVector vtxs[MAX_N_PRIMARIES];
   G4int npar;
-  G4int beampdg, targetpdg;
-  G4ThreeVector beamdir, targetdir;
-  G4double beamenergy, targetenergy;
+  G4int beampdgs[MAX_N_PRIMARIES], targetpdgs[MAX_N_PRIMARIES];
+  G4ThreeVector beamdirs[MAX_N_PRIMARIES], targetdirs[MAX_N_PRIMARIES];
+  G4double beamenergies[MAX_N_PRIMARIES], targetenergies[MAX_N_PRIMARIES];
   G4int vecRecNumber;
 
   G4double nuEnergy;

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -11,6 +11,8 @@
 #include "TClonesArray.h"
 #include <string>
 #include <vector>
+#include <iostream>
+#include "jhfNtuple.h"
 //#include <map>
 //#include "G4Transform3D.hh"
 
@@ -207,8 +209,9 @@ private:
   WCSimRootEventHeader    fEvtHdr;  // The header
   // See jhfNtuple.h for the meaning of these data members:
   Int_t                fMode;
-  Int_t                fVtxvol;
-  Float_t              fVtx[3];
+  Int_t                fNvtxs;
+  Int_t                fVtxsvol[MAX_N_PRIMARIES];
+  Float_t              fVtxs[MAX_N_PRIMARIES][3];
   Int_t                fVecRecNumber;       // "info event" number in inputvectorfile 
   Int_t                fJmu;
   Int_t                fJp;
@@ -251,8 +254,11 @@ public:
   void          SetTriggerInfo(TriggerType_t trigger_type, std::vector<Float_t> trigger_info);
   bool          IsASubEvent() {  return (fEvtHdr.GetSubEvtNumber()>=1); }
   void          SetMode(Int_t i) {fMode = i;}
-  void          SetVtxvol(Int_t i) {fVtxvol = i;}
-  void          SetVtx(Int_t i, Float_t f) {fVtx[i]= ( (i<3) ? f : 0);}
+  void          SetNvtxs(Int_t i) {fNvtxs = i;}
+  void          SetVtxvol(Int_t i) {fVtxsvol[0] = i;}
+  void          SetVtxsvol(Int_t i, Int_t v) {fVtxsvol[i] = v;}
+  void          SetVtx(Int_t i, Float_t f) {fNvtxs=1; fVtxs[0][i] = ( (i<3) ? f : 0);}
+  void          SetVtxs(Int_t n, Int_t i, Float_t f) {fVtxs[n][i]= ( (i<3) ? f : 0);}
   void          SetVecRecNumber(Int_t i) {fVecRecNumber = i;}
   void          SetJmu(Int_t i) {fJmu = i;}
   void          SetJp(Int_t i) {fJp = i;}
@@ -269,8 +275,11 @@ public:
   WCSimRootEventHeader *GetHeader()               {return &fEvtHdr; }
   WCSimRootPi0       *GetPi0Info()                 {return &fPi0; }
   Int_t               GetMode()               const {return fMode;}
-  Int_t               GetVtxvol()             const {return fVtxvol;}
-  Float_t             GetVtx(Int_t i=0)             {return (i<3) ? fVtx[i]: 0;}
+  Int_t               GetVtxvol()             const {return fVtxsvol[0];}
+  Float_t             GetVtx(Int_t i=0)             {return (i<3) ? fVtxs[0][i]: 0;}
+  Int_t               GetNvtxs()             const {return fNvtxs;}
+  Int_t               GetVtxsvol(Int_t i)             const {return fVtxsvol[i];}
+  Float_t             GetVtxs(Int_t n, Int_t i=0)             {return (i<3) ? fVtxs[n][i]: 0;}
   Int_t               GetVecRecNumber()       const {return fVecRecNumber;}
   Int_t               GetJmu()                const {return fJmu;}
   Int_t               GetJp()                 const {return fJp;}

--- a/include/jhfNtuple.h
+++ b/include/jhfNtuple.h
@@ -1,47 +1,53 @@
+#ifndef JHFNTUPLE_H
+#define JHFNTUPLE_H
+static const int MAX_N_PRIMARIES = 900;
+static const int MAX_N_ACTIVE_TUBES = 2000;
+static const int MAX_N_HITS_PER_TUBE = 90;
 struct ntupleStruct
 {
   int mode;             // interaction mode
-  int vtxvol;           // volume of vertex
-  float vtx[3];         // interaction vertex
+  int nvtxs;           // number of vertices
+  int vtxsvol[MAX_N_PRIMARIES];           // volume of vertices
+  float vtxs[MAX_N_PRIMARIES][3];         // interaction vertices
   int vecRecNumber;     // info event number in inputvetcotfile
   int  jmu;             // index to muon
   int  jp;              // index to proton
   int npar;             // number of final state particles
-  int ipnu[50];         // id of ith final state particle
-  int flag[50];         // flag: -1 = incoming neutrino
+  int ipnu[MAX_N_PRIMARIES];         // id of ith final state particle
+  int flag[MAX_N_PRIMARIES];         // flag: -1 = incoming neutrino
                         //       -2 = target
                         //        1 = outgoing lepton
                         //        2 = most energetic outgoing nucleon
-  float m[50];          // mass of ith final state particle
-  float p[50];          // momentum of ith final state particle
-  float E[50];          // energy of ith final state particle
-  int startvol[50];      // starting volume of ith final state particle
-  int stopvol[50];      // stopping volume of ith final state particle
-  float dir[50][3];     // direction of ith final state particle
-  float pdir[50][3];    // momentum-vector of ith final state particle
-  float stop[50][3];    // stopping point of ith final state particle
-  float start[50][3];   // starting point of ith final state particle
-  int parent[50];        // ID of parent of ith particle (0 if primary)
-  float time[50];       // creation time of the ith particle
+  float m[MAX_N_PRIMARIES];          // mass of ith final state particle
+  float p[MAX_N_PRIMARIES];          // momentum of ith final state particle
+  float E[MAX_N_PRIMARIES];          // energy of ith final state particle
+  int startvol[MAX_N_PRIMARIES];      // starting volume of ith final state particle
+  int stopvol[MAX_N_PRIMARIES];      // stopping volume of ith final state particle
+  float dir[MAX_N_PRIMARIES][3];     // direction of ith final state particle
+  float pdir[MAX_N_PRIMARIES][3];    // momentum-vector of ith final state particle
+  float stop[MAX_N_PRIMARIES][3];    // stopping point of ith final state particle
+  float start[MAX_N_PRIMARIES][3];   // starting point of ith final state particle
+  int parent[MAX_N_PRIMARIES];        // ID of parent of ith particle (0 if primary)
+  float time[MAX_N_PRIMARIES];       // creation time of the ith particle
 
   int   numTubesHit;        // Total number of tubes with hits
-  int   totalPe[500];       // The totalPE recorded at each tube
-  float truetime[500][90]; // The true time of each hit
+  int   totalPe[MAX_N_ACTIVE_TUBES];       // The totalPE recorded at each tube
+  float truetime[MAX_N_ACTIVE_TUBES][MAX_N_HITS_PER_TUBE]; // The true time of each hit
 
   int   numDigitizedTubes;  // Number of PMTs with digitized hits
-  float q[500];             // The readout digitized pe
-  float t[500];             // The readout digitized time
-  int tubeid[500];        // The readout tube ID
+  float q[MAX_N_ACTIVE_TUBES];             // The readout digitized pe
+  float t[MAX_N_ACTIVE_TUBES];             // The readout digitized time
+  int tubeid[MAX_N_ACTIVE_TUBES];        // The readout tube ID
   float sumq;             // sum of q(readout digitized pe) in event
 
   int   fvnumTubesHit;        // Total number of inner tubes with hits
-  int   fvtotalPe[500];       // The totalPE recorded at each innertube
-  float fvtruetime[500][90]; // The true time of each inner hit
+  int   fvtotalPe[MAX_N_ACTIVE_TUBES];       // The totalPE recorded at each innertube
+  float fvtruetime[MAX_N_ACTIVE_TUBES][MAX_N_HITS_PER_TUBE]; // The true time of each inner hit
 
   int   fvnumDigitizedTubes;  // Number of PMTs with digitized hits
-  float fvq[500];             // The readout digitized pe
-  float fvt[500];             // The readout digitized time
-  int fvtubeid[500];        // The readout tube ID
+  float fvq[MAX_N_ACTIVE_TUBES];             // The readout digitized pe
+  float fvt[MAX_N_ACTIVE_TUBES];             // The readout digitized time
+  int fvtubeid[MAX_N_ACTIVE_TUBES];        // The readout tube ID
   float fvsumq;             // sum of q(readout digitized pe) in event
 };
 
@@ -49,12 +55,13 @@ extern struct ntupleStruct jhfNtuple;
 
 static const char* ntDesc =
 "mode:I,"
-"vtxvol:I,"
-"vtx(3):R,"
+"nvtxs[0,MAX_N_PRIMARIES]:I,"
+"vtxsvol(npar):I,"
+"vtxs(3,npar):R,"
 "vecRecNumber:I,"
 "jmu:I,"
 "jp:I,"
-"npar[0,50]:I,"
+"npar[0,MAX_N_PRIMARIES]:I,"
 "ipnu(npar):I,"
 "flag(npar):I,"
 "m(npar):R,"
@@ -68,19 +75,20 @@ static const char* ntDesc =
 "startpos(3,npar):R,"
 "parent(npar):I,"
 "time(npar):R,"
-"numTubesHit[0,500]:I,"        
+"numTubesHit[0,MAX_N_ACTIVE_TUBES]:I,"        
 "totalPe(numTubesHit):I,"
-"truetime(90,numTubesHit):R,"
-"numDigTubes[0,500]:I,"
+"truetime(MAX_N_HITS_PER_TUBE,numTubesHit):R,"
+"numDigTubes[0,MAX_N_ACTIVE_TUBES]:I,"
 "q(numDigTubes):R,"            
 "t(numDigTubes):R,"
 "tubeid(numDigTubes):I"
-"fvnumTubesHit[0,500]:I,"        
+"fvnumTubesHit[0,MAX_N_ACTIVE_TUBES]:I,"        
 "fvtotalPe(fvnumTubesHit):I,"
-"fvtruetime(90,fvnumTubesHit):R,"
-"fvnumDigTubes[0,500]:I,"
+"fvtruetime(MAX_N_HITS_PER_TUBE,fvnumTubesHit):R,"
+"fvnumDigTubes[0,MAX_N_ACTIVE_TUBES]:I,"
 "fvq(fvnumDigTubes):R,"            
 "fvt(fvnumDigTubes):R,"
 "fvtubeid(fvnumDigTubes):I";
+#endif
 
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -33,6 +33,7 @@
 #include <iomanip>
 #include <string>
 #include <vector>
+#include <climits>
 
 #include "jhfNtuple.h"
 #include "TTree.h"
@@ -87,6 +88,7 @@ void WCSimEventAction::CreateDAQInstances()
 {
   if(ConstructedDAQClasses) {
     G4cerr << "WCSimEventAction::CreateDAQInstances() has already been called. Exiting..." << G4endl;
+    return;
     exit(-1);
   }
 
@@ -161,8 +163,14 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 
   G4int         event_id = evt->GetEventID();
   G4int         mode     = generatorAction->GetMode();
-  G4ThreeVector vtx      = generatorAction->GetVtx();
-  G4int         vtxvol   = WCSimEventFindStartingVolume(vtx);
+
+  G4int         nvtxs   = generatorAction->GetNvtxs();
+  G4ThreeVector vtxs[MAX_N_PRIMARIES];
+  G4int         vtxsvol[MAX_N_PRIMARIES];
+  for( Int_t u=0; u<nvtxs; u++ ){
+    vtxs[u]      = generatorAction->GetVtx(u);
+    vtxsvol[u]   = WCSimEventFindStartingVolume(vtxs[u]);
+  }
   G4int         vecRecNumber = generatorAction->GetVecRecNumber();
 
   // ----------------------------------------------------------------------
@@ -287,14 +295,14 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
   // ----------------------------------------------------------------------
 
    jhfNtuple.mode   = mode;         // interaction mode
-   jhfNtuple.vtxvol = vtxvol;       // volume of vertex
-   // unit mismatch between geant4 and reconstruction, M Fechner
-   //  jhfNtuple.vtx[0] = vtx[0]/1000.; // interaction vertex
-   //jhfNtuple.vtx[1] = vtx[1]/1000.; // interaction vertex
-   //jhfNtuple.vtx[2] = vtx[2]/1000.; // interaction vertex
-   jhfNtuple.vtx[0] = vtx[0]/cm; // interaction vertex
-   jhfNtuple.vtx[1] = vtx[1]/cm; // interaction vertex
-   jhfNtuple.vtx[2] = vtx[2]/cm; // interaction vertex
+   jhfNtuple.nvtxs = nvtxs;       // number of vertices
+   for( Int_t u=0; u<nvtxs; u++ ){
+     jhfNtuple.vtxsvol[u] = vtxsvol[u];       // volume of vertex
+     // unit mismatch between geant4 and reconstruction, M Fechner
+     jhfNtuple.vtxs[u][0] = vtxs[u][0]/cm; // interaction vertex
+     jhfNtuple.vtxs[u][1] = vtxs[u][1]/cm; // interaction vertex
+     jhfNtuple.vtxs[u][2] = vtxs[u][2]/cm; // interaction vertex
+   }
    jhfNtuple.vecRecNumber = vecRecNumber; //vectorfile record number
    
    // mustop, pstop, npar will be filled later
@@ -305,86 +313,208 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
    G4int npar = 0;
    
    // First two tracks are special: beam and target
+
+   for( Int_t u=0; u<nvtxs; u++ ){
+     /////////////////////////////////
+     // npar = 0        NEUTRINO /////
+     /////////////////////////////////
    
-   G4int         beampdg    = generatorAction->GetBeamPDG();
-   G4double      beamenergy = generatorAction->GetBeamEnergy();
-   G4ThreeVector beamdir    = generatorAction->GetBeamDir();
-   
-   jhfNtuple.ipnu[npar]    = beampdg;               // id
-   jhfNtuple.flag[npar]    = -1;                    // incoming neutrino
-   jhfNtuple.m[npar]       = 0.0;                   // mass (always a neutrino)
-   jhfNtuple.p[npar]       = beamenergy;            // momentum magnitude
-   jhfNtuple.E[npar]       = beamenergy;            // energy 
-   jhfNtuple.startvol[npar]= -1;                    // starting volume, vtxvol should be referred
-   jhfNtuple.stopvol[npar] = -1;                    // stopping volume 
-   jhfNtuple.dir[npar][0]  = beamdir[0];            // direction 
-   jhfNtuple.dir[npar][1]  = beamdir[1];            // direction 
-   jhfNtuple.dir[npar][2]  = beamdir[2];            // direction 
-   jhfNtuple.pdir[npar][0] = beamenergy*beamdir[0]; // momentum-vector 
-   jhfNtuple.pdir[npar][1] = beamenergy*beamdir[1]; // momentum-vector 
-   jhfNtuple.pdir[npar][2] = beamenergy*beamdir[2]; // momentum-vector 
-   // M Fechner, same as above
-   jhfNtuple.stop[npar][0] = vtx[0]/cm;  // stopping point (not meaningful)
-   jhfNtuple.stop[npar][1] = vtx[1]/cm;  // stopping point (not meaningful)
-   jhfNtuple.stop[npar][2] = vtx[2]/cm;  // stopping point (not meaningful)
-   jhfNtuple.parent[npar] = 0;
-   
-   npar++;
+     G4int         beampdg;
+     G4double      beamenergy;
+     G4ThreeVector beamdir;
+     
+     beampdg    = generatorAction->GetBeamPDG(u);
+     beamenergy = generatorAction->GetBeamEnergy(u);
+     beamdir    = generatorAction->GetBeamDir(u);
+  
+     jhfNtuple.ipnu[npar]    = beampdg;               // id
+     jhfNtuple.flag[npar]    = -1;                    // incoming neutrino
+     jhfNtuple.m[npar]       = 0.0;                   // mass (always a neutrino)
+     jhfNtuple.p[npar]       = beamenergy;            // momentum magnitude
+     jhfNtuple.E[npar]       = beamenergy;            // energy 
+     jhfNtuple.startvol[npar]= -1;                    // starting volume, vtxvol should be referred
+     jhfNtuple.stopvol[npar] = -1;                    // stopping volume 
+     jhfNtuple.dir[npar][0]  = beamdir[0];            // direction 
+     jhfNtuple.dir[npar][1]  = beamdir[1];            // direction 
+     jhfNtuple.dir[npar][2]  = beamdir[2];            // direction 
+     jhfNtuple.pdir[npar][0] = beamenergy*beamdir[0]; // momentum-vector 
+     jhfNtuple.pdir[npar][1] = beamenergy*beamdir[1]; // momentum-vector 
+     jhfNtuple.pdir[npar][2] = beamenergy*beamdir[2]; // momentum-vector 
+     // M Fechner, same as above
+     jhfNtuple.stop[npar][0] = vtxs[u][0]/cm;  // stopping point (not meaningful)
+     jhfNtuple.stop[npar][1] = vtxs[u][1]/cm;  // stopping point (not meaningful)
+     jhfNtuple.stop[npar][2] = vtxs[u][2]/cm;  // stopping point (not meaningful)
+     jhfNtuple.parent[npar] = 0;
 
-  G4double      targetpmag = 0.0, targetmass = 0.0;
-  G4int         targetpdg    = generatorAction->GetTargetPDG();
-  G4double      targetenergy = generatorAction->GetTargetEnergy();
-  G4ThreeVector targetdir    = generatorAction->GetTargetDir();
+     npar++;
+     /////////////////////////////////
+     // npar = 1        TARGET ///////
+     /////////////////////////////////
+     
+     G4double      targetpmag = 0.0, targetmass = 0.0;
+     G4int         targetpdg    = generatorAction->GetTargetPDG(u);
+     G4double      targetenergy = generatorAction->GetTargetEnergy(u);
+     G4ThreeVector targetdir    = generatorAction->GetTargetDir(u);
 
-  if (targetpdg!=0) {            // protects against seg-fault
-    if (targetpdg > 999)         // 16O nucleus not in pdg table
-      targetmass = targetenergy; // 16O is at rest, so E = m
-    else
-      targetmass = particleTable->FindParticle(targetpdg)->GetPDGMass();
-    if (targetenergy > targetmass) 
-      //      targetpmag = sqrt(targetenergy*targetenergy - targetmass*targetenergy);
-      // MF : bug fix
-      targetpmag = sqrt(targetenergy*targetenergy - targetmass*targetmass);
-    else // protect against NaN
-      targetpmag = 0.0;
-  }
+     if (targetpdg!=0) {            // protects against seg-fault
+       if (targetpdg > 999)         // 16O nucleus not in pdg table
+	 targetmass = targetenergy; // 16O is at rest, so E = m
+       else
+	 targetmass = particleTable->FindParticle(targetpdg)->GetPDGMass();
+       if (targetenergy > targetmass) 
+	 //      targetpmag = sqrt(targetenergy*targetenergy - targetmass*targetenergy);
+	 // MF : bug fix
+	 targetpmag = sqrt(targetenergy*targetenergy - targetmass*targetmass);
+       else // protect against NaN
+	 targetpmag = 0.0;
+     }
+     
+     jhfNtuple.ipnu[npar]     = targetpdg;    // id
+     jhfNtuple.flag[npar]    = -2;            // target
+     jhfNtuple.m[npar]       = targetmass;    // mass (always a neutrino)
+     jhfNtuple.p[npar]       = targetpmag;    // momentum magnitude
+     jhfNtuple.E[npar]       = targetenergy;  // energy (total!) 
+     jhfNtuple.startvol[npar] = -1;           // starting volume 
+     jhfNtuple.stopvol[npar] = -1;            // stopping volume 
+     jhfNtuple.dir[npar][0]  = targetdir[0];  // direction 
+     jhfNtuple.dir[npar][1]  = targetdir[1];  // direction 
+     jhfNtuple.dir[npar][2]  = targetdir[2];  // direction 
+     // MF feb9,2006 : we want the momentum, not the energy...
+     //  jhfNtuple.pdir[npar][0] = targetenergy*targetdir[0];  // momentum-vector 
+     //  jhfNtuple.pdir[npar][1] = targetenergy*targetdir[1];  // momentum-vector 
+     //  jhfNtuple.pdir[npar][2] = targetenergy*targetdir[2];  // momentum-vector 
+     jhfNtuple.pdir[npar][0] = targetpmag*targetdir[0];  // momentum-vector 
+     jhfNtuple.pdir[npar][1] = targetpmag*targetdir[1];  // momentum-vector 
+     jhfNtuple.pdir[npar][2] = targetpmag*targetdir[2];  // momentum-vector 
+     // M Fechner, same as above
+     jhfNtuple.stop[npar][0] = vtxs[u][0]/cm;  // stopping point (not meaningful)
+     jhfNtuple.stop[npar][1] = vtxs[u][1]/cm;  // stopping point (not meaningful)
+     jhfNtuple.stop[npar][2] = vtxs[u][2]/cm;  // stopping point (not meaningful)
+     jhfNtuple.parent[npar] = 0;
 
-  jhfNtuple.ipnu[npar]     = targetpdg;    // id
-  jhfNtuple.flag[npar]    = -2;            // target
-  jhfNtuple.m[npar]       = targetmass;    // mass (always a neutrino)
-  jhfNtuple.p[npar]       = targetpmag;    // momentum magnitude
-  jhfNtuple.E[npar]       = targetenergy;  // energy (total!) 
-  jhfNtuple.startvol[npar] = -1;           // starting volume 
-  jhfNtuple.stopvol[npar] = -1;            // stopping volume 
-  jhfNtuple.dir[npar][0]  = targetdir[0];  // direction 
-  jhfNtuple.dir[npar][1]  = targetdir[1];  // direction 
-  jhfNtuple.dir[npar][2]  = targetdir[2];  // direction 
-  // MF feb9,2006 : we want the momentum, not the energy...
-  //  jhfNtuple.pdir[npar][0] = targetenergy*targetdir[0];  // momentum-vector 
-  //  jhfNtuple.pdir[npar][1] = targetenergy*targetdir[1];  // momentum-vector 
-  //  jhfNtuple.pdir[npar][2] = targetenergy*targetdir[2];  // momentum-vector 
-  jhfNtuple.pdir[npar][0] = targetpmag*targetdir[0];  // momentum-vector 
-  jhfNtuple.pdir[npar][1] = targetpmag*targetdir[1];  // momentum-vector 
-  jhfNtuple.pdir[npar][2] = targetpmag*targetdir[2];  // momentum-vector 
-  // M Fechner, same as above
-  jhfNtuple.stop[npar][0] = vtx[0]/cm;  // stopping point (not meaningful)
-  jhfNtuple.stop[npar][1] = vtx[1]/cm;  // stopping point (not meaningful)
-  jhfNtuple.stop[npar][2] = vtx[2]/cm;  // stopping point (not meaningful)
-  jhfNtuple.parent[npar] = 0;
+     npar++;
+   }
 
-  npar++;
+  ////////////////////////
+  // npar > nvertices  ///
+  ////////////////////////
 
   // Draw Charged Tracks
+  G4int PDG_e=11,PDG_v_e=12,PDG_gam=22;
+  for( Int_t u=0; u<nvtxs; u++ ){
+    G4int trkid_e=INT_MAX,trkid_v_e=INT_MAX,trkid_gam=INT_MAX;
+    G4int idx_e=INT_MAX,idx_v_e=INT_MAX,idx_gam=INT_MAX;
+    for (G4int i=0; i < n_trajectories; i++) 
+      {
+	WCSimTrajectory* trj = 
+	  (WCSimTrajectory*)((*(evt->GetTrajectoryContainer()))[i]);
+	
+	if (trj->GetCharge() != 0.)
+	  trj->DrawTrajectory(50);
+	if(abs(trj->GetPDGEncoding()) == PDG_e && trj->GetParentID() == u+1 && trj->GetTrackID() < trkid_e) {
+	  trkid_e = trj->GetTrackID();
+	  idx_e = i;
+	}
+	if(abs(trj->GetPDGEncoding()) == PDG_v_e && trj->GetParentID() == u+1 && trj->GetTrackID() < trkid_v_e) {
+	  trkid_v_e = trj->GetTrackID();
+	  idx_v_e = i;
+	}
+	if(abs(trj->GetPDGEncoding()) == PDG_gam && trj->GetParentID() == u+1 && trj->GetTrackID() < trkid_gam) {
+	  trkid_gam = trj->GetTrackID();
+	  idx_gam = i;
+	}
+      }
 
-  for (G4int i=0; i < n_trajectories; i++) 
-    {
-      WCSimTrajectory* trj = 
-	(WCSimTrajectory*)((*(evt->GetTrajectoryContainer()))[i]);
-
-      if (trj->GetCharge() != 0.)
- 	trj->DrawTrajectory(50);
+    if(idx_e != INT_MAX) {
+      WCSimTrajectory* trj =
+	(WCSimTrajectory*)((*(evt->GetTrajectoryContainer()))[idx_e]);
+      jhfNtuple.ipnu[npar]     = trj->GetPDGEncoding();    // id
+      jhfNtuple.flag[npar]    = 0;            // target
+      jhfNtuple.m[npar]       = particleTable->FindParticle(trj->GetPDGEncoding())->GetPDGMass();    // mass (always a neutrino)
+      jhfNtuple.p[npar]       = trj->GetInitialMomentum().mag();    // momentum magnitude
+      jhfNtuple.E[npar]       = sqrt(jhfNtuple.m[npar]*jhfNtuple.m[npar]+jhfNtuple.p[npar]*jhfNtuple.p[npar]);  // energy (total!) 
+      jhfNtuple.startvol[npar] = -1;           // starting volume 
+      jhfNtuple.stopvol[npar] = -1;            // stopping volume 
+      jhfNtuple.dir[npar][0]  = trj->GetInitialMomentum().unit().getX();  // direction 
+      jhfNtuple.dir[npar][1]  = trj->GetInitialMomentum().unit().getY();  // direction 
+      jhfNtuple.dir[npar][2]  = trj->GetInitialMomentum().unit().getZ();  // direction 
+      // MF feb9,2006 : we want the momentum, not the energy...
+      //  jhfNtuple.pdir[npar][0] = targetenergy*targetdir[0];  // momentum-vector 
+      //  jhfNtuple.pdir[npar][1] = targetenergy*targetdir[1];  // momentum-vector 
+      //  jhfNtuple.pdir[npar][2] = targetenergy*targetdir[2];  // momentum-vector 
+      jhfNtuple.pdir[npar][0] = trj->GetInitialMomentum().getX();  // momentum-vector 
+      jhfNtuple.pdir[npar][1] = trj->GetInitialMomentum().getY();  // momentum-vector 
+      jhfNtuple.pdir[npar][2] = trj->GetInitialMomentum().getZ();  // momentum-vector 
+      // M Fechner, same as above
+      jhfNtuple.stop[npar][0] = vtxs[u][0]/cm;  // stopping point (not meaningful)
+      jhfNtuple.stop[npar][1] = vtxs[u][1]/cm;  // stopping point (not meaningful)
+      jhfNtuple.stop[npar][2] = vtxs[u][2]/cm;  // stopping point (not meaningful)
+      jhfNtuple.parent[npar] = 0;
+      
+      npar++; 
     }
+    
+    if(idx_v_e != INT_MAX) {
+      WCSimTrajectory* trj =
+	(WCSimTrajectory*)((*(evt->GetTrajectoryContainer()))[idx_v_e]);
+      jhfNtuple.ipnu[npar]     = trj->GetPDGEncoding();    // id
+      jhfNtuple.flag[npar]    = 0;            // target
+      jhfNtuple.m[npar]       = particleTable->FindParticle(trj->GetPDGEncoding())->GetPDGMass();    // mass (always a neutrino)
+      jhfNtuple.p[npar]       = trj->GetInitialMomentum().mag();    // momentum magnitude
+      jhfNtuple.E[npar]       = sqrt(jhfNtuple.m[npar]*jhfNtuple.m[npar]+jhfNtuple.p[npar]*jhfNtuple.p[npar]);  // energy (total!) 
+      jhfNtuple.startvol[npar] = -1;           // starting volume 
+      jhfNtuple.stopvol[npar] = -1;            // stopping volume 
+      jhfNtuple.dir[npar][0]  = trj->GetInitialMomentum().unit().getX();  // direction 
+      jhfNtuple.dir[npar][1]  = trj->GetInitialMomentum().unit().getY();  // direction 
+      jhfNtuple.dir[npar][2]  = trj->GetInitialMomentum().unit().getZ();  // direction 
+      // MF feb9,2006 : we want the momentum, not the energy...
+      //  jhfNtuple.pdir[npar][0] = targetenergy*targetdir[0];  // momentum-vector 
+      //  jhfNtuple.pdir[npar][1] = targetenergy*targetdir[1];  // momentum-vector 
+      //  jhfNtuple.pdir[npar][2] = targetenergy*targetdir[2];  // momentum-vector 
+      jhfNtuple.pdir[npar][0] = trj->GetInitialMomentum().getX();  // momentum-vector 
+      jhfNtuple.pdir[npar][1] = trj->GetInitialMomentum().getY();  // momentum-vector 
+      jhfNtuple.pdir[npar][2] = trj->GetInitialMomentum().getZ();  // momentum-vector 
+      // M Fechner, same as above
+      jhfNtuple.stop[npar][0] = vtxs[u][0]/cm;  // stopping point (not meaningful)
+      jhfNtuple.stop[npar][1] = vtxs[u][1]/cm;  // stopping point (not meaningful)
+      jhfNtuple.stop[npar][2] = vtxs[u][2]/cm;  // stopping point (not meaningful)
+      jhfNtuple.parent[npar] = 0;
+      
+      npar++; 
+    }
+    
+    
+    if(idx_gam != INT_MAX) {
+      WCSimTrajectory* trj =
+	(WCSimTrajectory*)((*(evt->GetTrajectoryContainer()))[idx_gam]);
+      jhfNtuple.ipnu[npar]     = trj->GetPDGEncoding();    // id
+      jhfNtuple.flag[npar]    = 0;            // target
+      jhfNtuple.m[npar]       = particleTable->FindParticle(trj->GetPDGEncoding())->GetPDGMass();    // mass (always a neutrino)
+      jhfNtuple.p[npar]       = trj->GetInitialMomentum().mag();    // momentum magnitude
+      jhfNtuple.E[npar]       = sqrt(jhfNtuple.m[npar]*jhfNtuple.m[npar]+jhfNtuple.p[npar]*jhfNtuple.p[npar]);  // energy (total!) 
+      jhfNtuple.startvol[npar] = -1;           // starting volume 
+      jhfNtuple.stopvol[npar] = -1;            // stopping volume 
+      jhfNtuple.dir[npar][0]  = trj->GetInitialMomentum().unit().getX();  // direction 
+      jhfNtuple.dir[npar][1]  = trj->GetInitialMomentum().unit().getY();  // direction 
+      jhfNtuple.dir[npar][2]  = trj->GetInitialMomentum().unit().getZ();  // direction 
+      // MF feb9,2006 : we want the momentum, not the energy...
+      //  jhfNtuple.pdir[npar][0] = targetenergy*targetdir[0];  // momentum-vector 
+      //  jhfNtuple.pdir[npar][1] = targetenergy*targetdir[1];  // momentum-vector 
+      //  jhfNtuple.pdir[npar][2] = targetenergy*targetdir[2];  // momentum-vector 
+      jhfNtuple.pdir[npar][0] = trj->GetInitialMomentum().getX();  // momentum-vector 
+      jhfNtuple.pdir[npar][1] = trj->GetInitialMomentum().getY();  // momentum-vector 
+      jhfNtuple.pdir[npar][2] = trj->GetInitialMomentum().getZ();  // momentum-vector 
+      // M Fechner, same as above
+      jhfNtuple.stop[npar][0] = vtxs[u][0]/cm;  // stopping point (not meaningful)
+      jhfNtuple.stop[npar][1] = vtxs[u][1]/cm;  // stopping point (not meaningful)
+      jhfNtuple.stop[npar][2] = vtxs[u][2]/cm;  // stopping point (not meaningful)
+      jhfNtuple.parent[npar] = 0;
+      
+      npar++; 
+    }
+  }
 
+  //fill correct variables for track from decay
    G4cout << " Filling Root Event " << G4endl;
 
    //   G4cout << "event_id: " << &event_id << G4endl;
@@ -399,6 +529,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
    // G4cout << "MRDxHC: " << &MRDxHC << G4endl;
    // G4cout << "MRDyHC: " << &MRDyHC << G4endl;
    
+   jhfNtuple.npar = npar;
 
   FillRootEvent(event_id,
 		jhfNtuple,
@@ -562,10 +693,13 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   // Fill other info for this event
 
   wcsimrootevent->SetMode(jhfNtuple.mode);
-  wcsimrootevent->SetVtxvol(jhfNtuple.vtxvol);
-  for (int j=0;j<3;j++)
-  {
-    wcsimrootevent->SetVtx(j,jhfNtuple.vtx[j]);
+  wcsimrootevent->SetNvtxs(jhfNtuple.nvtxs);
+  for( Int_t u=0; u<jhfNtuple.nvtxs; u++ ){
+    wcsimrootevent->SetVtxsvol(u,jhfNtuple.vtxsvol[u]);
+    for (int j=0;j<3;j++)
+      {
+	wcsimrootevent->SetVtxs(u,j,jhfNtuple.vtxs[u][j]);
+      }
   }
   wcsimrootevent->SetJmu(jhfNtuple.jmu);
   wcsimrootevent->SetJp(jhfNtuple.jp);
@@ -576,7 +710,8 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   // First two tracks come from jhfNtuple, as they are special
 
   int k;
-  for (k=0;k<2;k++) // should be just 2
+  //Modify to add decay products
+  for (k=0;k<jhfNtuple.npar;k++) // should be just 2
   {
     float dir[3];
     float pdir[3];
@@ -588,7 +723,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       pdir[l]=jhfNtuple.pdir[k][l];
       stop[l]=jhfNtuple.stop[k][l];
       start[l]=jhfNtuple.start[k][l];
-	G4cout<< "start[" << k << "][" << l <<"]: "<< jhfNtuple.start[k][l] <<G4endl;
+      //G4cout<< "start[" << k << "][" << l <<"]: "<< jhfNtuple.start[k][l] <<G4endl;
     }
 
     // Add the track to the TClonesArray
@@ -616,6 +751,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   // same, april 7th 2005
   std::set<int> pionList;
   std::set<int> antipionList;
+  std::set<int> primaryList;
 
   // Pi0 specific variables
   Float_t pi0Vtx[3];
@@ -646,6 +782,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     if ( trj->GetPDGEncoding() == 211 ) pionList.insert(trj->GetTrackID());
     if ( trj->GetPDGEncoding() == -211 ) antipionList.insert(trj->GetTrackID());
        
+    if( trj->GetParentID() == 0 ) primaryList.insert(trj->GetTrackID());
 
     // Process primary tracks or the secondaries from pizero or muons...
 
@@ -689,6 +826,8 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	parentType = -211;
       } else if (pionList.count(trj->GetParentID()) ) {
 	parentType = 211;
+      } else if (primaryList.count(trj->GetParentID()) ) {
+	parentType = 1;
       } else {  // no identified parent, but not a primary
 	parentType = 999;
       }
@@ -707,7 +846,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	pdir[l]=mom[l];        // momentum-vector 
 	stop[l]=Stop[l]/cm; // stopping point 
 	start[l]=Start[l]/cm; // starting point 
-	G4cout<<"part 2 start["<<l<<"]: "<< start[l] <<G4endl;
+	//G4cout<<"part 2 start["<<l<<"]: "<< start[l] <<G4endl;
       }
 
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -6,6 +6,7 @@
 #include "G4ParticleGun.hh"
 #include "G4GeneralParticleSource.hh"
 #include "G4ParticleTable.hh"
+#include "G4IonTable.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ThreeVector.hh"
 #include "globals.hh"
@@ -45,8 +46,11 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
 
   // Initialize to zero
   mode = 0;
-  vtxvol = 0;
-  vtx = G4ThreeVector(0.,0.,0.);
+  nvtxs = 0;
+  for( Int_t u=0; u<50; u++){
+    vtxsvol[u] = 0;
+    vtxs[u] = G4ThreeVector(0.,0.,0.);
+  }
   nuEnergy = 0.;
   _counterRock=0; // counter for generated in Rock
   _counterCublic=0; // counter generated
@@ -59,6 +63,7 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
   particleGun->SetParticleMomentumDirection(G4ThreeVector(0.,0.,1.0));
 
   G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
+  G4IonTable* ionTable = G4IonTable::GetIonTable();
   G4String particleName;
   particleGun->
     SetParticleDefinition(particleTable->FindParticle(particleName="mu+"));
@@ -92,6 +97,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
   // We will need a particle table
   G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
+  G4IonTable* ionTable = G4IonTable::GetIonTable();
 
   // Temporary kludge to turn on/off vector text format 
 
@@ -143,9 +149,9 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 	    // Read the Vertex line
 	    token = readInLine(inputFile, lineSize, inBuf);
-	    vtx = G4ThreeVector(atof(token[1])*cm,
-				atof(token[2])*cm,
-				atof(token[3])*cm);
+	    vtxs[0] = G4ThreeVector(atof(token[1])*cm,
+				    atof(token[2])*cm,
+				    atof(token[3])*cm);
 	    
             // true : Generate vertex in Rock , false : Generate vertex in WC tank
             SetGenerateVertexInRock(false);
@@ -155,20 +161,20 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 	    // First, the neutrino line
 
 	    token=readInLine(inputFile, lineSize, inBuf);
-	    beampdg = atoi(token[1]);
-	    beamenergy = atof(token[2])*MeV;
-	    beamdir = G4ThreeVector(atof(token[3]),
-				    atof(token[4]),
-				    atof(token[5]));
+	    beampdgs[0] = atoi(token[1]);
+	    beamenergies[0] = atof(token[2])*MeV;
+	    beamdirs[0] = G4ThreeVector(atof(token[3]),
+					atof(token[4]),
+					atof(token[5]));
 
 	    // Now read the target line
 
 	    token=readInLine(inputFile, lineSize, inBuf);
-	    targetpdg = atoi(token[1]);
-	    targetenergy = atof(token[2])*MeV;
-	    targetdir = G4ThreeVector(atof(token[3]),
-				      atof(token[4]),
-				      atof(token[5]));
+	    targetpdgs[0] = atoi(token[1]);
+	    targetenergies[0] = atof(token[2])*MeV;
+	    targetdirs[0] = G4ThreeVector(atof(token[3]),
+					  atof(token[4]),
+					  atof(token[5]));
 
 	    // Read the info line, basically a dummy
 	    token=readInLine(inputFile, lineSize, inBuf);
@@ -193,9 +199,38 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		    G4ThreeVector dir = G4ThreeVector(atof(token[3]),
 						      atof(token[4]),
 						      atof(token[5]));
-		    particleGun->
-		      SetParticleDefinition(particleTable->
-					    FindParticle(pdgid));
+		    std::cout<<"PDGcode "<<pdgid<<"\n";
+		    //must handle the case of an ion speratly from other particles
+		    //check PDG code if we have an ion.
+		    //PDG code format for ions ±10LZZZAAAI
+		    char strPDG[11];
+		    char strA[10]={0};
+		    char strZ[10]={0};
+		    
+
+		    long int A=0,Z=0;
+		    //		    A=strotl(strPDG,&str);
+		    if(abs(pdgid) >= 1000000000)
+		      {
+			//ion
+			sprintf(strPDG,"%i",abs(pdgid));
+			strncpy(strZ, &strPDG[3], 3);
+			strncpy(strA, &strPDG[6], 3);
+			strA[3]='\0';
+			strZ[3]='\0';
+			A=atoi(strA);
+			Z=atoi(strZ);
+			G4ParticleDefinition* ion;
+			ion =  ionTable->GetIon(Z, A, 0.);
+			particleGun->SetParticleDefinition(ion);
+			particleGun->SetParticleCharge(0);
+		      }
+		    else {
+		      //not ion
+		      particleGun->
+			SetParticleDefinition(particleTable->
+		      FindParticle(pdgid));
+		    }
 		    G4double mass = 
 		      particleGun->GetParticleDefinition()->GetPDGMass();
 
@@ -203,7 +238,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 		    particleGun->SetParticleEnergy(ekin);
 		    //G4cout << "Particle: " << pdgid << " KE: " << ekin << G4endl;
-		    particleGun->SetParticlePosition(vtx);
+		    particleGun->SetParticlePosition(vtxs[0]);
 		    particleGun->SetParticleMomentumDirection(dir);
 		    particleGun->GeneratePrimaryVertex(anEvent);
 		  }
@@ -233,11 +268,41 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   {      // manual gun operation
     particleGun->GeneratePrimaryVertex(anEvent);
 
+    //To prevent occasional seg fault from an un assigned targetpdg 
+    targetpdgs[0] = 2212; //ie. proton
+
     G4ThreeVector P  =anEvent->GetPrimaryVertex()->GetPrimary()->GetMomentum();
     G4ThreeVector vtx=anEvent->GetPrimaryVertex()->GetPosition();
     G4double m       =anEvent->GetPrimaryVertex()->GetPrimary()->GetMass();
     G4int pdg        =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
 
+    char strPDG[11];
+    char strA[10]={0};
+    char strZ[10]={0};
+    
+    
+    long int A=0,Z=0;
+    //		    A=strotl(strPDG,&str);
+    if(abs(pdg) >= 1000000000)
+      {
+	//ion
+	sprintf(strPDG,"%i",abs(pdg));
+	strncpy(strZ, &strPDG[3], 3);
+	strncpy(strA, &strPDG[6], 3);
+	strA[3]='\0';
+	strZ[3]='\0';
+	A=atoi(strA);
+	Z=atoi(strZ);
+
+	G4ParticleDefinition* ion   = G4IonTable::GetIonTable()->GetIon(Z, A, 0);
+	ion->SetPDGStable(false);
+	ion->SetPDGLifeTime(0.);
+	
+	G4ParticleDefinition* ion2   = G4IonTable::GetIonTable()->GetIon(Z, A, 0);
+	std::cout<<"ion2 "<<ion2->GetPDGLifeTime()<<"\n";
+      }
+    
+    
     G4ThreeVector dir  = P.unit();
     G4double E         = std::sqrt((P.dot(P))+(m*m));
 
@@ -252,6 +317,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   }
   else if (useLaserEvt)
     {
+      targetpdgs[0] = 2212; //ie. proton 
       //T. Akiri: Create the GPS LASER event
       MyGPS->GeneratePrimaryVertex(anEvent);
       
@@ -259,12 +325,12 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       G4ThreeVector vtx =anEvent->GetPrimaryVertex()->GetPosition();
       G4int pdg         =anEvent->GetPrimaryVertex()->GetPrimary()->GetPDGcode();
       
-      G4ThreeVector dir  = P.unit();
+      //     G4ThreeVector dir  = P.unit();
       G4double E         = std::sqrt((P.dot(P)));
       
-      SetVtx(vtx);
+      //SetVtx(vtx);
       SetBeamEnergy(E);
-      SetBeamDir(dir);
+      //SetBeamDir(dir);
       SetBeamPDG(pdg);
     }
   else if (useGPSEvt)

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -22,6 +22,11 @@ WCSimTrackingAction::WCSimTrackingAction()
   ParticleList.insert(-321); // kaon-
   ParticleList.insert(311); // kaon0
   ParticleList.insert(-311); // kaon0 bar
+  
+  ParticleList.insert(11);
+  ParticleList.insert(-11);
+  ParticleList.insert(12);
+  ParticleList.insert(-12);
   // don't put gammas there or there'll be too many
 }
 


### PR DESCRIPTION
add the possibility to create multiple primary vertices in each event.
This is needed to simulate the pile up of radioactive events.
previously here: https://github.com/WCSim/WCSim/pull/171