### PR TITLE
Add improved application of QE in StackingAction

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -93,8 +93,14 @@ public:
 
   G4float GetPMTQE(G4String,G4float, G4int, G4float, G4float, G4float);
   G4float GetPMTCollectionEfficiency(G4float theta_angle, G4String CollectionName) { return GetPMTPointer(CollectionName)->GetCollectionEfficiency(theta_angle); };
+  G4float GetStackingPMTQE(std::vector<G4String>);
 
   WCSimPMTObject *CreatePMTObject(G4String, G4String);
+
+  WCSimBasicPMTObject *CreateCombinedPMTQE(std::vector<G4String>);
+  WCSimBasicPMTObject *CustomPMT;
+  void SetCustomPMTObject(WCSimBasicPMTObject *PMT){CustomPMT=PMT;}
+  WCSimBasicPMTObject* GetCustomPMTObject(){ return CustomPMT;}
 
   std::map<G4String, WCSimPMTObject*>  CollectionNameMap; 
   WCSimPMTObject * PMTptr;

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -93,14 +93,14 @@ public:
 
   G4float GetPMTQE(G4String,G4float, G4int, G4float, G4float, G4float);
   G4float GetPMTCollectionEfficiency(G4float theta_angle, G4String CollectionName) { return GetPMTPointer(CollectionName)->GetCollectionEfficiency(theta_angle); };
-  G4float GetStackingPMTQE(std::vector<G4String>);
+  G4float GetStackingPMTQE(G4float PhotonWavelength, G4int flag, G4float low_wl, G4float high_wl, G4float ratio);
 
   WCSimPMTObject *CreatePMTObject(G4String, G4String);
 
   void CreateCombinedPMTQE(std::vector<G4String>);
-  WCSimBasicPMTObject *CustomPMT;
-  void SetCustomPMTObject(WCSimBasicPMTObject *PMT){CustomPMT=PMT;}
-  WCSimBasicPMTObject* GetCustomPMTObject(){ return CustomPMT;}
+  WCSimBasicPMTObject *BasicPMT;
+  void SetBasicPMTObject(WCSimBasicPMTObject *PMT){BasicPMT=PMT;}
+  WCSimBasicPMTObject* GetBasicPMTObject(){ return BasicPMT;}
 
   std::map<G4String, WCSimPMTObject*>  CollectionNameMap; 
   WCSimPMTObject * PMTptr;
@@ -157,7 +157,7 @@ public:
   G4String GetODCollectionName(){return WCODCollectionName;}
 
   bool GetIsODConstructed(){return isODConstructed;}
-
+  bool GetIsCombinedPMTCollectionDefined(){return isCombinedPMTCollectionDefined;}
  
 private:
 
@@ -310,6 +310,7 @@ private:
   // ############################# //
 
   bool isODConstructed;
+  bool isCombinedPMTCollectionDefined;
 
   // Parameters controlled by user
   G4double WCODDiameter;

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -97,7 +97,7 @@ public:
 
   WCSimPMTObject *CreatePMTObject(G4String, G4String);
 
-  WCSimBasicPMTObject *CreateCombinedPMTQE(std::vector<G4String>);
+  void CreateCombinedPMTQE(std::vector<G4String>);
   WCSimBasicPMTObject *CustomPMT;
   void SetCustomPMTObject(WCSimBasicPMTObject *PMT){CustomPMT=PMT;}
   WCSimBasicPMTObject* GetCustomPMTObject(){ return CustomPMT;}

--- a/include/WCSimPMTObject.hh
+++ b/include/WCSimPMTObject.hh
@@ -235,5 +235,27 @@ protected:
   G4float* GetCollectionEfficiencyArray();
 };
 
+class WCSimBasicPMTObject
+{
+
+ public:
+  WCSimBasicPMTObject();
+  WCSimBasicPMTObject(G4float*,G4float*,G4float);
+  ~WCSimBasicPMTObject();
+
+ private:
+  G4float* QE;
+  G4float* QEWavelength;
+  G4float  maxQE;
+
+ public:
+  G4float* GetQE(){ return QE;};
+  G4float* GetQEWavelength(){ return QEWavelength;};
+  G4float  GetmaxQE(){ return maxQE;};
+
+  void SetQE(G4float* qe){ QE=qe;}
+  void SetQEWavelength(G4float* qe){ QEWavelength=qe;}
+  void SetmaxQE(G4float qe){ maxQE=qe;}
+};
 
 #endif

--- a/include/WCSimPMTObject.hh
+++ b/include/WCSimPMTObject.hh
@@ -250,12 +250,14 @@ class WCSimBasicPMTObject
 
  public:
   WCSimBasicPMTObject();
-  WCSimBasicPMTObject(G4float*,G4float*,G4float);
+  WCSimBasicPMTObject(std::map<G4float,G4float>);
+  WCSimBasicPMTObject(std::vector<G4float>,std::vector<G4float>,G4float);
   ~WCSimBasicPMTObject();
 
  private:
   std::vector<G4float> QE;
-  std::vector<G4float> QEWavelength;
+  std::vector<G4float> wavelength;
+  std::map<G4float,G4float> mapQE;
   G4float  maxQE;
   TGraph   *gQE;
 
@@ -263,16 +265,19 @@ class WCSimBasicPMTObject
   std::vector<G4float> GetQE(){ return QE;};
   void SetQE(std::vector<G4float> qe){ QE=qe;};
 
-  std::vector<G4float> GetQEWavelength(){ return QEWavelength;};
-  void SetQEWavelength(std::vector<G4float> qe){ QEWavelength=qe;};
+  std::vector<G4float> GetWavelength(){ return wavelength;};
+  void SetWavelength(std::vector<G4float> qe){ wavelength=qe;};
 
-  G4float  GetmaxQE(){ return maxQE;};
+  std::map<G4float,G4float> GetMapQE(){ return mapQE;};
+  void SetMapQE(std::map<G4float,G4float> qe){ mapQE=qe;};
+
+  G4float GetmaxQE(){ return maxQE;};
   void SetmaxQE(G4float qe){ maxQE=qe;};
 
   TGraph* GetgQE(){ return gQE;};
   void SetgQE(TGraph *g){ gQE=g;};
 
-  void DefineQEHist();
+  void DefineQEHist(std::map<G4float,G4float>);
 };
 
 #endif

--- a/include/WCSimPMTObject.hh
+++ b/include/WCSimPMTObject.hh
@@ -6,7 +6,8 @@
 #include "Randomize.hh"
 #include <map>
 #include <vector>
-
+#include <TH1F.h>
+#include <TGraph.h>
 
 class WCSimPMTObject
 {
@@ -24,6 +25,7 @@ public:
   virtual G4double GetPMTGlassThickness()=0;
   virtual G4float  GetDarkRate()=0;
   virtual G4float  GetDarkRateConversionFactor()=0;
+  virtual G4int    GetNbOfQEDefined()=0;
 protected:
   virtual G4float* GetCollectionEfficiencyArray();
   virtual G4float* GetCollectionEfficiencyAngle();
@@ -50,7 +52,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
-
+  G4int    GetNbOfQEDefined();
 
 };
 
@@ -74,6 +76,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
+  G4int    GetNbOfQEDefined();
 };
 
  class PMT10inch : public WCSimPMTObject
@@ -95,6 +98,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
+  G4int    GetNbOfQEDefined();
  };
 
  class PMT10inchHQE : public WCSimPMTObject
@@ -116,6 +120,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
+  G4int    GetNbOfQEDefined();
  };
 
  class PMT12inchHQE : public WCSimPMTObject
@@ -137,6 +142,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
+  G4int    GetNbOfQEDefined();
  };
 
 class HPD20inchHQE : public WCSimPMTObject
@@ -159,6 +165,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
+  G4int    GetNbOfQEDefined();
 protected:
   G4float* GetCollectionEfficiencyArray();
 };
@@ -183,6 +190,7 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
+  G4int    GetNbOfQEDefined();
 protected:
   G4float* GetCollectionEfficiencyArray();
 };
@@ -207,7 +215,8 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
-protected:
+  G4int    GetNbOfQEDefined();
+ protected:
   G4float* GetCollectionEfficiencyArray();
 };
 
@@ -231,7 +240,8 @@ public:
   G4double GetPMTGlassThickness();
   G4float  GetDarkRate();
   G4float  GetDarkRateConversionFactor();
-protected:
+  G4int    GetNbOfQEDefined();
+ protected:
   G4float* GetCollectionEfficiencyArray();
 };
 
@@ -244,18 +254,25 @@ class WCSimBasicPMTObject
   ~WCSimBasicPMTObject();
 
  private:
-  G4float* QE;
-  G4float* QEWavelength;
+  std::vector<G4float> QE;
+  std::vector<G4float> QEWavelength;
   G4float  maxQE;
+  TGraph   *gQE;
 
  public:
-  G4float* GetQE(){ return QE;};
-  G4float* GetQEWavelength(){ return QEWavelength;};
-  G4float  GetmaxQE(){ return maxQE;};
+  std::vector<G4float> GetQE(){ return QE;};
+  void SetQE(std::vector<G4float> qe){ QE=qe;};
 
-  void SetQE(G4float* qe){ QE=qe;}
-  void SetQEWavelength(G4float* qe){ QEWavelength=qe;}
-  void SetmaxQE(G4float qe){ maxQE=qe;}
+  std::vector<G4float> GetQEWavelength(){ return QEWavelength;};
+  void SetQEWavelength(std::vector<G4float> qe){ QEWavelength=qe;};
+
+  G4float  GetmaxQE(){ return maxQE;};
+  void SetmaxQE(G4float qe){ maxQE=qe;};
+
+  TGraph* GetgQE(){ return gQE;};
+  void SetgQE(TGraph *g){ gQE=g;};
+
+  void DefineQEHist();
 };
 
 #endif

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -299,6 +299,7 @@ void WCSimDetectorConstruction::SetHyperKWithODGeometry()
   WCColName.push_back(WCIDCollectionName);
   WCColName.push_back(WCODCollectionName);
   CreateCombinedPMTQE(WCColName);
+  isCombinedPMTCollectionDefined=true;
 }
 
 void WCSimDetectorConstruction::SetEggShapedHyperKGeometry()

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -294,6 +294,11 @@ void WCSimDetectorConstruction::SetHyperKWithODGeometry()
   WCODCapPMTSpacing  = (pi*WCIDDiameter/(round(WCIDDiameter*sqrt(pi*WCPMTODPercentCoverage)/(10.0*WCPMTODRadius))));
   WCODCapEdgeLimit = WCIDDiameter/2.0 - WCPMTODRadius;
 
+  // TEST combined PMT collection for stacking action
+  std::vector<G4String> WCColName;
+  WCColName.push_back(WCIDCollectionName);
+  WCColName.push_back(WCODCollectionName);
+  CreateCombinedPMTQE(WCColName);
 }
 
 void WCSimDetectorConstruction::SetEggShapedHyperKGeometry()

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -281,7 +281,7 @@ void WCSimDetectorConstruction::CreateCombinedPMTQE(std::vector<G4String> Collec
 
   // Define relevant variable
   // Create array of maps for CollectionName
-  std::vector<std::map<G4float,G4float>> QEMap;
+  std::vector< std::map<G4float,G4float> > QEMap;
   std::vector<G4float> maxQEVec;
   // Need size of QE array
   std::vector<G4int> NbOfWLBins;

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -360,7 +360,8 @@ void WCSimDetectorConstruction::CreateCombinedPMTQE(std::vector<G4String> Collec
   G4cout << G4endl;
 
   // Create a new PMT with an extended QE array containing all PMT collection
-  WCSimBasicPMTObject *newPMT = new WCSimBasicPMTObject();
-  newPMT->DefineQEHist();
-  SetCustomPMTObject(newPMT);
+  WCSimBasicPMTObject *newPMT = new WCSimBasicPMTObject(QE);
+  newPMT->SetmaxQE(*std::max_element(maxQEVec.begin(),maxQEVec.end()));
+  newPMT->DefineQEHist(QE);
+  SetBasicPMTObject(newPMT);
 }

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -270,3 +270,26 @@ void WCSimDetectorConstruction::SaveOptionsToOutput(WCSimRootOptions * wcopt)
   wcopt->SetPMTQEMethod(PMT_QE_Method);
   wcopt->SetPMTCollEff(PMT_Coll_Eff);
 }
+
+WCSimBasicPMTObject *WCSimDetectorConstruction::CreateCombinedPMTQE(std::vector<G4String> CollectionName){
+
+  // Define relevant variable
+  std::vector<G4float*> wavelength;
+  std::vector<G4float*> QE;
+  std::vector<G4float> maxQE;
+
+  // Recover QE for collection name
+  std::vector<WCSimPMTObject*> PMT;
+  for(unsigned int iPMT=0;iPMT<CollectionName.size();iPMT++){
+    PMT.push_back(GetPMTPointer(CollectionName[iPMT]));
+    wavelength.push_back(PMT[iPMT]->GetQEWavelength());
+    QE.push_back(PMT[iPMT]->GetQE());
+    maxQE.push_back(PMT[iPMT]->GetmaxQE());
+  }
+
+  // Create a new PMT with an extended QE array containing all PMT collection
+  WCSimBasicPMTObject *newPMT = new WCSimBasicPMTObject();
+
+  return newPMT;
+
+}

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -243,6 +243,11 @@ G4float PMT20inch::GetDarkRateConversionFactor(){
   return factor;
 }
 
+G4int PMT20inch::GetNbOfQEDefined(){
+  const G4int factor = 20;
+  return factor;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // 8 inch
 
@@ -401,6 +406,11 @@ G4float PMT8inch::GetDarkRate(){
 
 G4float PMT8inch::GetDarkRateConversionFactor(){
   const G4float factor = 1.367;
+  return factor;
+}
+
+G4int PMT8inch::GetNbOfQEDefined(){
+  const G4int factor = 20;
   return factor;
 }
 
@@ -566,6 +576,11 @@ G4float PMT10inch::GetDarkRateConversionFactor(){
   return factor;
 }
 
+G4int PMT10inch::GetNbOfQEDefined(){
+  const G4int factor = 20;
+  return factor;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // 10 inch HQE
 
@@ -725,6 +740,11 @@ G4float PMT10inchHQE::GetDarkRate(){
 
 G4float PMT10inchHQE::GetDarkRateConversionFactor(){
   const G4float factor = 1.367;
+  return factor;
+}
+
+G4int PMT10inchHQE::GetNbOfQEDefined(){
+  const G4int factor = 20;
   return factor;
 }
 
@@ -893,6 +913,10 @@ G4float PMT12inchHQE::GetDarkRateConversionFactor(){
   return factor;
 }
 
+G4int PMT12inchHQE::GetNbOfQEDefined(){
+  const G4int factor = 20;
+  return factor;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // 20 inch HPD
@@ -1080,6 +1104,11 @@ G4float HPD20inchHQE::GetDarkRateConversionFactor(){
   return factor;
 }
 
+G4int HPD20inchHQE::GetNbOfQEDefined(){
+  const G4int factor = 20;
+  return factor;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // 12 inch HPD
 
@@ -1255,6 +1284,11 @@ G4float HPD12inchHQE::GetDarkRate(){
 
 G4float HPD12inchHQE::GetDarkRateConversionFactor(){
   const G4float factor = 1.119;
+  return factor;
+}
+
+G4int HPD12inchHQE::GetNbOfQEDefined(){
+  const G4int factor = 20;
   return factor;
 }
 
@@ -1451,6 +1485,10 @@ G4float BoxandLine20inchHQE::GetDarkRateConversionFactor(){
   return factor;
 }
 
+G4int BoxandLine20inchHQE::GetNbOfQEDefined(){
+  const G4int factor = 20;
+  return factor;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // 12 inch HQE Box and Line PMT
@@ -1635,6 +1673,11 @@ G4float BoxandLine12inchHQE::GetDarkRateConversionFactor(){
   return factor;
 }
 
+G4int BoxandLine12inchHQE::GetNbOfQEDefined(){
+  const G4int factor = 20;
+  return factor;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // COMBINED PMTS CLASS
 // Goal is to instantiate purely virtual WCSimPMTObject Classes to contained an extended
@@ -1643,14 +1686,10 @@ G4float BoxandLine12inchHQE::GetDarkRateConversionFactor(){
 
 
 WCSimBasicPMTObject::WCSimBasicPMTObject(){
-  QE=NULL;
-  QEWavelength=NULL;
-  maxQE = 0;
 }
 
-WCSimBasicPMTObject::WCSimBasicPMTObject(G4float *qe, G4float *wl, G4float maxqe) : QE(qe), QEWavelength(wl),maxQE(maxqe){}
+void WCSimBasicPMTObject::DefineQEHist(){
+}
 
 WCSimBasicPMTObject::~WCSimBasicPMTObject(){
-  delete QE;
-  delete QEWavelength;
 }

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -1634,3 +1634,23 @@ G4float BoxandLine12inchHQE::GetDarkRateConversionFactor(){
   const G4float factor = 1.126;
   return factor;
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+// COMBINED PMTS CLASS
+// Goal is to instantiate purely virtual WCSimPMTObject Classes to contained an extended
+//  QE information of several PMTs collection
+// Useful for applying QE in stacking action when several PMTs collection are defined
+
+
+WCSimBasicPMTObject::WCSimBasicPMTObject(){
+  QE=NULL;
+  QEWavelength=NULL;
+  maxQE = 0;
+}
+
+WCSimBasicPMTObject::WCSimBasicPMTObject(G4float *qe, G4float *wl, G4float maxqe) : QE(qe), QEWavelength(wl),maxQE(maxqe){}
+
+WCSimBasicPMTObject::~WCSimBasicPMTObject(){
+  delete QE;
+  delete QEWavelength;
+}

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -1688,7 +1688,29 @@ G4int BoxandLine12inchHQE::GetNbOfQEDefined(){
 WCSimBasicPMTObject::WCSimBasicPMTObject(){
 }
 
-void WCSimBasicPMTObject::DefineQEHist(){
+WCSimBasicPMTObject::WCSimBasicPMTObject(std::map<G4float,G4float> mQE){
+  mapQE=mQE;
+  std::map<G4float, G4float>::iterator itr;
+  for(itr = mQE.begin(); itr != mQE.end(); itr++) {
+    wavelength.push_back(itr->first);
+    QE.push_back(itr->second);
+  }
+}
+
+WCSimBasicPMTObject::WCSimBasicPMTObject(std::vector<G4float> wl,std::vector<G4float> qe,G4float max){
+  wavelength=wl;
+  QE=qe;
+  maxQE=max;
+}
+
+void WCSimBasicPMTObject::DefineQEHist(std::map<G4float,G4float> mapQE){
+  gQE = new TGraph();
+  G4int iPt=0;
+  std::map<G4float, G4float>::iterator itr;
+  for(itr = mapQE.begin(); itr != mapQE.end(); itr++) {
+    gQE->SetPoint(iPt,itr->first,itr->second);
+    iPt++;
+  }
 }
 
 WCSimBasicPMTObject::~WCSimBasicPMTObject(){

--- a/src/WCSimPMTQE.cc
+++ b/src/WCSimPMTQE.cc
@@ -76,21 +76,27 @@ G4float WCSimDetectorConstruction::GetPMTQE(G4String CollectionName, G4float Pho
 }
 
 
-G4float WCSimDetectorConstruction::GetStackingPMTQE(std::vector<G4String> CollectionName) {
+G4float WCSimDetectorConstruction::GetStackingPMTQE(G4float PhotonWavelength, G4int flag, G4float low_wl, G4float high_wl, G4float ratio) {
 
-  // Define relevant variable
-  std::vector<G4float*> wavelength;
-  std::vector<G4float*> QE;
-  std::vector<G4float> maxQE;
-
-  // Recover QE for collection name
-  std::vector<WCSimPMTObject*> PMT;
-  for(unsigned int iPMT=0;iPMT<CollectionName.size();iPMT++){
-    PMT.push_back(GetPMTPointer(CollectionName[iPMT]));
-    wavelength.push_back(PMT[iPMT]->GetQEWavelength());
+  if (flag==1){
+    if (PhotonWavelength <= low_wl || PhotonWavelength >= high_wl || PhotonWavelength <=280 || PhotonWavelength >=660){
+      return 0;
+    }
+  }else if (flag==0){
+    if (PhotonWavelength <= low_wl || PhotonWavelength >= high_wl){
+      return 0;
+    }
   }
 
+  // Recover combined PMT object
+  WCSimBasicPMTObject *PMT;
+  PMT = GetBasicPMTObject();
+
   // Recover optical response of any WLS materials
-  // std::vector<WCSimWLSObject*> WLS;
+  // WCSimWLSObject *WLS;
+
+  if(flag==1) return (G4float)(PMT->GetgQE()->Eval(PhotonWavelength,0,"S"))*ratio;
+  else if (flag==0) return PMT->GetmaxQE()*ratio;
+  else return 0;
 
 }

--- a/src/WCSimPMTQE.cc
+++ b/src/WCSimPMTQE.cc
@@ -76,5 +76,21 @@ G4float WCSimDetectorConstruction::GetPMTQE(G4String CollectionName, G4float Pho
 }
 
 
+G4float WCSimDetectorConstruction::GetStackingPMTQE(std::vector<G4String> CollectionName) {
 
+  // Define relevant variable
+  std::vector<G4float*> wavelength;
+  std::vector<G4float*> QE;
+  std::vector<G4float> maxQE;
 
+  // Recover QE for collection name
+  std::vector<WCSimPMTObject*> PMT;
+  for(unsigned int iPMT=0;iPMT<CollectionName.size();iPMT++){
+    PMT.push_back(GetPMTPointer(CollectionName[iPMT]));
+    wavelength.push_back(PMT[iPMT]->GetQEWavelength());
+  }
+
+  // Recover optical response of any WLS materials
+  // std::vector<WCSimWLSObject*> WLS;
+
+}


### PR DESCRIPTION
Add a new way to apply the QE inside the StackingAction class to reduce the nb of photons processed by WCSim when several PMT collection are defined when PMT QE do not overlap. This is necessary to simulate WLS plates accurately without working in the QEPMTMethod mode 3 or 4, where all the photons are processed and the simulation is considerably slowed.
I had to add a new PMTObject method called GetNbOfQEDefined(), returning the nb of points (wavelength) for which the QE is defined.
I haven't remove the previous method applying the QE in StackingAction, which leaves the user to switch between the 2 algorithm accordingly. 
In my opinion, using a TGraph instead of the "manual extrapolation" of the QE could also increase the speed of the simulation. Validation plot are on-going.