### PR TITLE
Added new multi-vertex event generator using particle gun and nuance-…

### DIFF
--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -74,6 +74,7 @@ private:
   G4bool   useGunEvt;
   G4bool   useLaserEvt;  //T. Akiri: Laser flag
   G4bool   useGPSEvt;
+  G4bool   useMultiVertEvt; // Thiesse: use multi-vertex per event
   std::fstream inputFile;
   G4String vectorFileName;
   G4bool   GenerateVertexInRock;
@@ -110,6 +111,9 @@ public:
 
   inline void SetGPSEvtGenerator(G4bool choice) { useGPSEvt = choice; }
   inline G4bool IsUsingGPSEvtGenerator()  { return useGPSEvt; }
+
+  inline void SetMultiVertEvtGenerator(G4bool choice) { useMultiVertEvt = choice; }
+  inline G4bool IsUsingMultiVertEvtGenerator() { return useMultiVertEvt; }
 
   inline void OpenVectorFile(G4String fileName) 
   {

--- a/src/WCSimPrimaryGeneratorMessenger.cc
+++ b/src/WCSimPrimaryGeneratorMessenger.cc
@@ -13,11 +13,11 @@ WCSimPrimaryGeneratorMessenger::WCSimPrimaryGeneratorMessenger(WCSimPrimaryGener
   genCmd = new G4UIcmdWithAString("/mygen/generator",this);
   genCmd->SetGuidance("Select primary generator.");
   //T. Akiri: Addition of laser
-  genCmd->SetGuidance(" Available generators : muline, gun, laser, gps");
+  genCmd->SetGuidance(" Available generators : muline, gun, laser, gps, multivert");
   genCmd->SetParameterName("generator",true);
   genCmd->SetDefaultValue("muline");
   //T. Akiri: Addition of laser
-  genCmd->SetCandidates("muline gun laser gps");
+  genCmd->SetCandidates("muline gun laser gps multivert");
 
   fileNameCmd = new G4UIcmdWithAString("/mygen/vecfile",this);
   fileNameCmd->SetGuidance("Select the file of vectors.");
@@ -42,6 +42,7 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
       myAction->SetGunEvtGenerator(false);
       myAction->SetLaserEvtGenerator(false);
       myAction->SetGPSEvtGenerator(false);
+      myAction->SetMultiVertEvtGenerator(false);
     }
     else if ( newValue == "gun")
     {
@@ -49,6 +50,7 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
       myAction->SetGunEvtGenerator(true);
       myAction->SetLaserEvtGenerator(false);
       myAction->SetGPSEvtGenerator(false);
+      myAction->SetMultiVertEvtGenerator(false);
     }
     else if ( newValue == "laser")   //T. Akiri: Addition of laser
     {
@@ -56,6 +58,7 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
       myAction->SetGunEvtGenerator(false);
       myAction->SetLaserEvtGenerator(true);
       myAction->SetGPSEvtGenerator(false);
+      myAction->SetMultiVertEvtGenerator(false);
     }
     else if ( newValue == "gps")
     {
@@ -63,7 +66,16 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
       myAction->SetGunEvtGenerator(false);
       myAction->SetLaserEvtGenerator(false);
       myAction->SetGPSEvtGenerator(true);
+      myAction->SetMultiVertEvtGenerator(false);
     }
+    else if ( newValue == "multivert")
+      {
+	myAction->SetMulineEvtGenerator(false);
+	myAction->SetGunEvtGenerator(false);
+	myAction->SetLaserEvtGenerator(false);
+	myAction->SetGPSEvtGenerator(false);
+	myAction->SetMultiVertEvtGenerator(true);
+      }
   }
 
   if( command == fileNameCmd )
@@ -88,6 +100,8 @@ G4String WCSimPrimaryGeneratorMessenger::GetCurrentValue(G4UIcommand* command)
       { cv = "laser"; }   //T. Akiri: Addition of laser
     else if(myAction->IsUsingGPSEvtGenerator())
       { cv = "gps"; }
+    else if(myAction->IsUsingMultiVertEvtGenerator())
+      { cv = "multivert"; }
   }
   
   return cv;


### PR DESCRIPTION
In order to simulate certain types of events, it is necessary to generate multiple particles from _different_ vertices. In particular, pileup events, SN bursts, calibration light sources, etc. I think this is not possible using the current generator action. So, I've added the functionality which creates a new vertex for every track in the nuance-formatted input file using the particle gun, allowing multiple vertices in each event.

First tests show this works as expected, but I'm not exactly sure how the change propagates errors to other parts of the simulation/analysis, if at all.

This should also work for single-vertex, multiple-track events, as muline appears to be designed for.