### PR TITLE
Build the WCSimWCPMT and WCSimWCAddDarkNoise instances for the OD no …

### DIFF
--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -82,16 +82,12 @@ WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
   ///// -- OD -- /////
   ////////////////////
   WCSimWCPMT* WCDMPMT_OD;
-  if(detectorConstructor->GetIsODConstructed()) {
-    WCDMPMT_OD = new WCSimWCPMT( "WCReadoutPMT_OD", myDetector, "OD");
-    DMman->AddNewModule(WCDMPMT_OD);
-  }
+  WCDMPMT_OD = new WCSimWCPMT( "WCReadoutPMT_OD", myDetector, "OD");
+  DMman->AddNewModule(WCDMPMT_OD);
 
   WCSimWCAddDarkNoise* WCDNM_OD;
-  if(detectorConstructor->GetIsODConstructed()) {
-    WCDNM_OD = new WCSimWCAddDarkNoise("WCDarkNoise_OD", detectorConstructor, "OD");
-    DMman->AddNewModule(WCDNM_OD);
-  }
+  WCDNM_OD = new WCSimWCAddDarkNoise("WCDarkNoise_OD", detectorConstructor, "OD");
+  DMman->AddNewModule(WCDNM_OD);
 }
 
 WCSimEventAction::~WCSimEventAction()


### PR DESCRIPTION
…matter what.

Where they are currently built in the constructor of WCSimEventAction, the WCSim.mac file hasn't been read, therefore even if you're planning to use a geometry with an OD, GetIsODConstructed() will always be false since the default geometry is SuperK (without an OD). 

Currently, WCSim.mac fails because `/DarkRate/SetDetectorElement OD` is not a valid. Fails also when using
```
/WCSim/WCgeom HyperKWithOD
/WCSim/Construct
```
A better fix is much more involved - I'll create an issue