### PR TITLE
Fix of #244 to allow multiple instances of dark noise options to be s…

### DIFF
--- a/include/WCSimRootLinkDef.hh
+++ b/include/WCSimRootLinkDef.hh
@@ -21,4 +21,7 @@
 #pragma link C++ class WCSimEnumerations+;
 #pragma link C++ class WCSimRootOptions+;
 
+#pragma link C++ struct WCSimDarkNoiseOptions+;
+#pragma link C++ class std::map<std::string, WCSimDarkNoiseOptions>+;
+
 #endif

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -11,11 +11,29 @@
 #include "TObject.h"
 #include "TClonesArray.h"
 #include <string>
+#include <map>
+#include <iostream>
 
 #include "WCSimEnumerations.hh"
 
 class TDirectory;
 using std::string;
+using std::map;
+
+//////////////////////////////////////////////////////////////////////////
+
+struct WCSimDarkNoiseOptions {
+  double PMTDarkRate; // kHz
+  double ConvRate; // kHz
+  double DarkHigh; // ns
+  double DarkLow; // ns
+  double DarkWindow; // ns
+  int    DarkMode;  
+  WCSimDarkNoiseOptions() :
+    PMTDarkRate(-999), ConvRate(-999), DarkHigh(-999), DarkLow(-999),
+    DarkWindow(-999), DarkMode(-999)
+  {}
+};
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -38,19 +56,20 @@ public:
   int    GetPMTQEMethod() {return PMTQEMethod;}
   int    GetPMTCollEff() {return PMTCollEff;}
   //WCSimWCAddDarkNoise sets
-  void SetPMTDarkRate(double iPMTDarkRate) {PMTDarkRate = iPMTDarkRate;}
-  void SetConvRate(double iConvRate) {ConvRate = iConvRate;}
-  void SetDarkHigh(double iDarkHigh) {DarkHigh = iDarkHigh;}
-  void SetDarkLow(double iDarkLow) {DarkLow = iDarkLow;}
-  void SetDarkWindow(double iDarkWindow) {DarkWindow = iDarkWindow;}
-  void SetDarkMode(int iDarkMode) {DarkMode = iDarkMode;}
+  void SetPMTDarkRate(string tag, double iPMTDarkRate) {DarkOptMap[tag].PMTDarkRate = iPMTDarkRate;}
+  void SetConvRate(string tag, double iConvRate) {DarkOptMap[tag].ConvRate = iConvRate;}
+  void SetDarkHigh(string tag, double iDarkHigh) {DarkOptMap[tag].DarkHigh = iDarkHigh;}
+  void SetDarkLow(string tag, double iDarkLow) {DarkOptMap[tag].DarkLow = iDarkLow;}
+  void SetDarkWindow(string tag, double iDarkWindow) {DarkOptMap[tag].DarkWindow = iDarkWindow;}
+  void SetDarkMode(string tag, int iDarkMode) {DarkOptMap[tag].DarkMode = iDarkMode;}
   //WCSimWCAddDarkNoise gets
-  double GetPMTDarkRate() {return PMTDarkRate;}
-  double GetConvRate() {return ConvRate;}
-  double GetDarkHigh() {return DarkHigh;}
-  double GetDarkLow() {return DarkLow;}
-  double GetDarkWindow() {return DarkWindow;}
-  int    GetDarkMode() {return DarkMode;}
+  bool IsValidDarkTag(string tag) const;
+  double GetPMTDarkRate(string tag);
+  double GetConvRate(string tag);
+  double GetDarkHigh(string tag);
+  double GetDarkLow(string tag);
+  double GetDarkWindow(string tag);
+  int    GetDarkMode(string tag);
   //WCSimWCDigitizer* sets
   void SetDigitizerClassName(string iDigitizerClassName) {DigitizerClassName = iDigitizerClassName;}
   void SetDigitizerDeadTime(int iDigitizerDeadTime) {DigitizerDeadTime = iDigitizerDeadTime;}
@@ -132,12 +151,7 @@ private:
   int    PMTCollEff;
   
   //WCSimWCAddDarkNoise
-  double PMTDarkRate; // kHz
-  double ConvRate; // kHz
-  double DarkHigh; // ns
-  double DarkLow; // ns
-  double DarkWindow; // ns
-  int    DarkMode;
+  map<string, WCSimDarkNoiseOptions> DarkOptMap;
 
   //WCSimWCDigitizer*
   string DigitizerClassName;
@@ -181,8 +195,10 @@ private:
   int                    RandomSeed;
   WCSimRandomGenerator_t RandomGenerator;
   
-  ClassDef(WCSimRootOptions,2)  //WCSimRootEvent structure
+  ClassDef(WCSimRootOptions,3)  //WCSimRootEvent structure
 };
 
 
-#endif
+//////////////////////////////////////////////////////////////////////////
+
+#endif //WCSim_RootOptions

--- a/include/WCSimWCAddDarkNoise.hh
+++ b/include/WCSimWCAddDarkNoise.hh
@@ -35,7 +35,7 @@ public:
   void SetDarkLow(int idarklow){DarkLow = idarklow;}
   void SetDarkWindow(int idarkwindow){DarkWindow = idarkwindow;}
   int GetDarkWindow(){return (int)(DarkWindow);}
-  void SaveOptionsToOutput(WCSimRootOptions * wcopt);
+  void SaveOptionsToOutput(WCSimRootOptions * wcopt, string tag);
   
 private:
   void ReInitialize() { ranges.clear(); result.clear();}

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -678,7 +678,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
   if(!SavedOptions) {
     WCSimRootOptions * wcsimopt = runAction->GetRootOptions();
     //Dark noise
-    WCDNM->SaveOptionsToOutput(wcsimopt);
+    WCDNM->SaveOptionsToOutput(wcsimopt, "tank");
     //Digitizer
     WCDM->SaveOptionsToOutput(wcsimopt);
     //Trigger
@@ -686,6 +686,11 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     //Generator
     generatorAction->SaveOptionsToOutput(wcsimopt);
     
+    if(detectorConstructor->GetIsODConstructed()) {
+      //Dark noise
+      WCDNM_OD->SaveOptionsToOutput(wcsimopt, "OD");
+    }
+
     SavedOptions = true;
   }
 }

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -33,13 +33,18 @@ void WCSimRootOptions::Print(Option_t *) const
     << "\tSavePi0: " << SavePi0 << endl
     << "\tPMTQEMethod: " << PMTQEMethod << endl
     << "\tPMTCollEff: " << PMTCollEff << endl
-    << "Dark Noise options:" << endl
-    << "\tPMTDarkRate: " << PMTDarkRate << " kHz" << endl
-    << "\tConvRate: " << ConvRate << " kHz" << endl
-    << "\tDarkHigh: " << DarkHigh << " ns" << endl
-    << "\tDarkLow: " << DarkLow << " ns" << endl
-    << "\tDarkWindow: " << DarkWindow << " ns" << endl
-    << "\tDarkMode: " << DarkMode << endl
+    << "Dark Noise options:" << endl;
+  for(std::map<string, WCSimDarkNoiseOptions>::const_iterator it=DarkOptMap.begin(); it != DarkOptMap.end(); ++it) {
+    cout
+      << "\t" << it->first << endl
+      << "\t\tPMTDarkRate: " << it->second.PMTDarkRate << " kHz" << endl
+      << "\t\tConvRate: " << it->second.ConvRate << " kHz" << endl
+      << "\t\tDarkHigh: " << it->second.DarkHigh << " ns" << endl
+      << "\t\tDarkLow: " << it->second.DarkLow << " ns" << endl
+      << "\t\tDarkWindow: " << it->second.DarkWindow << " ns" << endl
+      << "\t\tDarkMode: " << it->second.DarkMode << endl;
+  }
+  cout
     << "Digitizer options:" << endl
     << "\tDigitizerClassName: " << DigitizerClassName << endl
     << "\tDigitizerDeadTime: " << DigitizerDeadTime << " ns" << endl
@@ -78,3 +83,60 @@ void WCSimRootOptions::Print(Option_t *) const
     << "\tRandomGenerator: " << WCSimEnumerations::EnumAsString(RandomGenerator) << endl
     << endl;
 }
+//______________________________________________________________________________
+bool WCSimRootOptions::IsValidDarkTag(string tag) const
+{
+  if(DarkOptMap.find(tag) != DarkOptMap.end())
+      return true;
+  return false; 
+}
+//______________________________________________________________________________
+double WCSimRootOptions::GetPMTDarkRate(string tag)
+{
+  if(IsValidDarkTag(tag))
+    return DarkOptMap[tag].PMTDarkRate;
+  std::cerr << "WCSimDarkNoiseOptions with tag: " << tag << " does not exist in WCSimRootOptions. Returning -999" << std::endl;
+  return -999;
+}
+//______________________________________________________________________________
+double WCSimRootOptions::GetConvRate(string tag)
+{
+  if(IsValidDarkTag(tag))
+    return DarkOptMap[tag].ConvRate;
+  std::cerr << "WCSimDarkNoiseOptions with tag: " << tag << " does not exist in WCSimRootOptions. Returning -999" << std::endl;
+  return -999;
+}
+//______________________________________________________________________________
+double WCSimRootOptions::GetDarkHigh(string tag)
+{
+  if(IsValidDarkTag(tag))
+    return DarkOptMap[tag].DarkHigh;
+  std::cerr << "WCSimDarkNoiseOptions with tag: " << tag << " does not exist in WCSimRootOptions. Returning -999" << std::endl;
+  return -999;
+}
+//______________________________________________________________________________
+double WCSimRootOptions::GetDarkLow(string tag)
+{
+  if(IsValidDarkTag(tag))
+    return DarkOptMap[tag].DarkLow;
+  std::cerr << "WCSimDarkNoiseOptions with tag: " << tag << " does not exist in WCSimRootOptions. Returning -999" << std::endl;
+  return -999;
+}
+//______________________________________________________________________________
+double WCSimRootOptions::GetDarkWindow(string tag)
+{
+  if(IsValidDarkTag(tag))
+    return DarkOptMap[tag].DarkWindow;
+  std::cerr << "WCSimDarkNoiseOptions with tag: " << tag << " does not exist in WCSimRootOptions. Returning -999" << std::endl;
+  return -999;
+}
+//______________________________________________________________________________
+int    WCSimRootOptions::GetDarkMode(string tag)
+{
+  if(IsValidDarkTag(tag))
+    return DarkOptMap[tag].DarkMode;
+  std::cerr << "WCSimDarkNoiseOptions with tag: " << tag << " does not exist in WCSimRootOptions. Returning -999" << std::endl;
+  return -999;
+}
+//______________________________________________________________________________
+

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -391,12 +391,12 @@ void WCSimWCAddDarkNoise::FindDarkNoiseRanges(WCSimWCDigitsCollection* WCHCPMT, 
   //dark noise routine
 }
 
-void WCSimWCAddDarkNoise::SaveOptionsToOutput(WCSimRootOptions * wcopt)
+void WCSimWCAddDarkNoise::SaveOptionsToOutput(WCSimRootOptions * wcopt, string tag)
 {
-  wcopt->SetPMTDarkRate(PMTDarkRate);
-  wcopt->SetConvRate(ConvRate);
-  wcopt->SetDarkHigh(DarkHigh);
-  wcopt->SetDarkLow(DarkLow);
-  wcopt->SetDarkWindow(DarkWindow);
-  wcopt->SetDarkMode(DarkMode);
+  wcopt->SetPMTDarkRate(tag, PMTDarkRate);
+  wcopt->SetConvRate(tag, ConvRate);
+  wcopt->SetDarkHigh(tag, DarkHigh);
+  wcopt->SetDarkLow(tag, DarkLow);
+  wcopt->SetDarkWindow(tag, DarkWindow);
+  wcopt->SetDarkMode(tag, DarkMode);
 }


### PR DESCRIPTION
…aved in WCSimRootOptions (i.e. tank and OD options are now both stored)

Trigger/digitizer can be expanded in similar way if this PR is accepted and if required