### PR TITLE
Add a WCSimRootTrigger::RemoveCherenkovDigiHit() method

### DIFF
--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -232,7 +232,7 @@ private:
 
   Int_t                fNumDigitizedTubes;  // Number of digitized tubes
   Int_t                fNcherenkovdigihits;  // Number of digihits in the array
-  Int_t                fNcherenkovdigihits_slots;  // Number of slots in the digihits array. This is more than fNcherenkovdigihits if any digihits have been removed
+  Int_t                fNcherenkovdigihits_slots;  // Number of slots in the digihits array. This is potentially more than fNcherenkovdigihits (i.e. if any digihits have been removed that aren't at the very start/end)
   Float_t              fSumQ;
   TClonesArray         *fCherenkovDigiHits;  //-> Array of WCSimRootCherenkovDigiHit's
 
@@ -291,7 +291,7 @@ public:
   Int_t               GetNcherenkovhits()     const {return fNcherenkovhits; }
   Int_t               GetNcherenkovhittimes() const {return fNcherenkovhittimes;}
   Int_t               GetNcherenkovdigihits() const {return fNcherenkovdigihits;}
-  Int_t               GetNcherenkovdigihits_slots() const {return fNcherenkovdigihits_slots;}
+  Int_t               GetNcherenkovdigihits_slots() const {return fCherenkovDigiHits->GetLast(); } //don't use fNcherenkovdigihits_slots directly as it doesn't take into account automatic TClonesArray shortening when digits at start/end are removed
   Float_t             GetSumQ()               const { return fSumQ;}
   TriggerType_t       GetTriggerType()        const { return fTriggerType;}
   std::vector<Float_t> GetTriggerInfo()        const { return fTriggerInfo;}

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -291,7 +291,7 @@ public:
   Int_t               GetNcherenkovhits()     const {return fNcherenkovhits; }
   Int_t               GetNcherenkovhittimes() const {return fNcherenkovhittimes;}
   Int_t               GetNcherenkovdigihits() const {return fNcherenkovdigihits;}
-  Int_t               GetNcherenkovdigihits_slots() const {return fCherenkovDigiHits->GetLast(); } //don't use fNcherenkovdigihits_slots directly as it doesn't take into account automatic TClonesArray shortening when digits at start/end are removed
+  Int_t               GetNcherenkovdigihits_slots() const {return fCherenkovDigiHits->GetLast() + 1; } //don't use fNcherenkovdigihits_slots directly as it doesn't take into account automatic TClonesArray shortening when digits at start/end are removed
   Float_t             GetSumQ()               const { return fSumQ;}
   TriggerType_t       GetTriggerType()        const { return fTriggerType;}
   std::vector<Float_t> GetTriggerInfo()        const { return fTriggerInfo;}

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -325,6 +325,7 @@ public:
 //						  Float_t t, 
 //						  Int_t tubeid,
  //                                                 Float_t sumq);
+  WCSimRootCherenkovDigiHit * RemoveCherenkovDigiHit(WCSimRootCherenkovDigiHit * digit);
 
   TClonesArray            *GetCherenkovDigiHits() const {return fCherenkovDigiHits;}
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -232,6 +232,7 @@ private:
 
   Int_t                fNumDigitizedTubes;  // Number of digitized tubes
   Int_t                fNcherenkovdigihits;  // Number of digihits in the array
+  Int_t                fNcherenkovdigihits_slots;  // Number of slots in the digihits array. This is more than fNcherenkovdigihits if any digihits have been removed
   Float_t              fSumQ;
   TClonesArray         *fCherenkovDigiHits;  //-> Array of WCSimRootCherenkovDigiHit's
 
@@ -290,6 +291,7 @@ public:
   Int_t               GetNcherenkovhits()     const {return fNcherenkovhits; }
   Int_t               GetNcherenkovhittimes() const {return fNcherenkovhittimes;}
   Int_t               GetNcherenkovdigihits() const {return fNcherenkovdigihits;}
+  Int_t               GetNcherenkovdigihits_slots() const {return fNcherenkovdigihits_slots;}
   Float_t             GetSumQ()               const { return fSumQ;}
   TriggerType_t       GetTriggerType()        const { return fTriggerType;}
   std::vector<Float_t> GetTriggerInfo()        const { return fTriggerInfo;}

--- a/sample-root-scripts/pmtremove.C
+++ b/sample-root-scripts/pmtremove.C
@@ -211,6 +211,7 @@ void pmtremove(TString infile, TString outfile, double removefrac)
     
 	  int ncherenkovhits     = oldtrigger->GetNcherenkovhits();
 	  int ncherenkovdigihits = oldtrigger->GetNcherenkovdigihits(); 
+	  int ncherenkovdigihits_slots = oldtrigger->GetNcherenkovdigihits_slots(); 
     
 	  // Grab the big arrays of times and parent IDs
 	  TClonesArray *timeArray = oldtrigger->GetCherenkovHitTimes();
@@ -250,10 +251,12 @@ void pmtremove(TString infile, TString outfile, double removefrac)
 
 	  float sumq = 0;
 
-	  for (int i=0;i<ncherenkovdigihits;i++)
+	  for (int i=0;i<ncherenkovdigihits_slots;i++)
 	    {
 	      // Loop through elements in the TClonesArray of WCSimRootCherenkovDigiHits
 	      TObject *element = (oldtrigger->GetCherenkovDigiHits())->At(i);
+	      if(!element)
+		continue;
 	      WCSimRootCherenkovDigiHit *wcsimrootcherenkovdigihit = 
 		dynamic_cast<WCSimRootCherenkovDigiHit*>(element);
 	      int tubeNumber = wcsimrootcherenkovdigihit->GetTubeId();

--- a/sample-root-scripts/read_OD.C
+++ b/sample-root-scripts/read_OD.C
@@ -122,8 +122,8 @@ void read_OD(char *filename=NULL) {
 	if(!cDigiHit)
 	  continue;
 	//WCSimRootChernkovDigiHit has methods GetTubeId(), GetT(), GetQ()
-	WCSimRootCherenkovHitTime *cHitTime =
-	  (WCSimRootCherenkovHitTime*)wcsimrootevent->GetCherenkovHitTimes()->At(i);
+	//WCSimRootCherenkovHitTime *cHitTime =
+	//(WCSimRootCherenkovHitTime*)wcsimrootevent->GetCherenkovHitTimes()->At(i); //this should be a loop over number of cherenkov hit times
 	//WCSimRootCherenkovHitTime has methods GetTubeId(), GetTruetime()
 
 	hPECollectedByEvtsByPMT->Fill(cDigiHit->GetQ());

--- a/sample-root-scripts/read_OD.C
+++ b/sample-root-scripts/read_OD.C
@@ -114,11 +114,13 @@ void read_OD(char *filename=NULL) {
       hPEByEvts->Fill(totRawPE);
 
       // DIGI HITS
-      int digiMax = wcsimrootevent->GetNcherenkovdigihits();
+      int digiMax = wcsimrootevent->GetNcherenkovdigihits_slots();
       int totDigiPE = 0;
       for (int i = 0; i < digiMax; i++){
 	WCSimRootCherenkovDigiHit *cDigiHit =
 	  (WCSimRootCherenkovDigiHit*)wcsimrootevent->GetCherenkovDigiHits()->At(i);
+	if(!cDigiHit)
+	  continue;
 	//WCSimRootChernkovDigiHit has methods GetTubeId(), GetT(), GetQ()
 	WCSimRootCherenkovHitTime *cHitTime =
 	  (WCSimRootCherenkovHitTime*)wcsimrootevent->GetCherenkovHitTimes()->At(i);

--- a/sample-root-scripts/read_PMT.C
+++ b/sample-root-scripts/read_PMT.C
@@ -79,7 +79,7 @@ void read_PMT(char *filename=NULL) {
   QvsT->SetXTitle("time");
   QvsT->SetYTitle("charge");
 
-  int max = wcsimrootevent->GetNcherenkovdigihits();
+  int max = wcsimrootevent->GetNcherenkovdigihits_slots();
   for (int i = 0; i<max; i++){
     WCSimRootCherenkovDigiHit *cDigiHit = wcsimrootevent->GetCherenkovDigiHits()->At(i);
     if(!cDigitHit)

--- a/sample-root-scripts/read_PMT.C
+++ b/sample-root-scripts/read_PMT.C
@@ -82,6 +82,8 @@ void read_PMT(char *filename=NULL) {
   int max = wcsimrootevent->GetNcherenkovdigihits();
   for (int i = 0; i<max; i++){
     WCSimRootCherenkovDigiHit *cDigiHit = wcsimrootevent->GetCherenkovDigiHits()->At(i);
+    if(!cDigitHit)
+      continue;
     //WCSimRootChernkovDigiHit has methods GetTubeId(), GetT(), GetQ()
     QvsT->Fill(cDigiHit->GetT(), cDigiHit->GetQ());
     WCSimRootCherenkovHitTime *cHitTime = wcsimrootevent->GetCherenkovHitTimes()->At(i);

--- a/sample-root-scripts/read_PMT.C
+++ b/sample-root-scripts/read_PMT.C
@@ -86,7 +86,7 @@ void read_PMT(char *filename=NULL) {
       continue;
     //WCSimRootChernkovDigiHit has methods GetTubeId(), GetT(), GetQ()
     QvsT->Fill(cDigiHit->GetT(), cDigiHit->GetQ());
-    WCSimRootCherenkovHitTime *cHitTime = wcsimrootevent->GetCherenkovHitTimes()->At(i);
+    //WCSimRootCherenkovHitTime *cHitTime = wcsimrootevent->GetCherenkovHitTimes()->At(i); // this should loop over wcsimrootevent->GetCherenkovHitTimes()!
     //WCSimRootCherenkovHitTime has methods GetTubeId(), GetTruetime()
   }
 

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -240,16 +240,20 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
       
       int ncherenkovdigihits = wcsimrootevent->GetNcherenkovdigihits();
       if(verbose) printf("Ncherenkovdigihits %d\n", ncherenkovdigihits);
-     
+      int ncherenkovdigihits_slots = wcsimrootevent->GetNcherenkovdigihits_slots();
+
       if(ncherenkovdigihits>0)
 	num_trig++;
       //for (i=0;i<(ncherenkovdigihits>4 ? 4 : ncherenkovdigihits);i++){
-      for (i=0;i<ncherenkovdigihits;i++)
+      int idigi = 0;
+      for (i=0;i<ncherenkovdigihits_slots;i++)
       {
     	// Loop through elements in the TClonesArray of WCSimRootCherenkovDigHits
 	
     	TObject *element = (wcsimrootevent->GetCherenkovDigiHits())->At(i);
-	
+	if(!element) continue;
+	idigi++;
+
     	WCSimRootCherenkovDigiHit *wcsimrootcherenkovdigihit = 
     	  dynamic_cast<WCSimRootCherenkovDigiHit*>(element);
 	
@@ -259,6 +263,8 @@ void sample_readfile(char *filename=NULL, bool verbose=false)
 		   wcsimrootcherenkovdigihit->GetT(),wcsimrootcherenkovdigihit->GetTubeId());
 	}
       } // End of loop over Cherenkov digihits
+      if(verbose)
+	cout << idigi << " digits found; expected " << ncherenkovdigihits << endl;
     } // End of loop over trigger
     
     // reinitialize super event between loops.

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -100,6 +100,7 @@ void WCSimRootTrigger::Initialize() //actually allocate memory for things in her
 				       10000);
   fCherenkovDigiHits->BypassStreamer(kFALSE); // use the member Streamer
   fNcherenkovdigihits = 0;
+  fNcherenkovdigihits_slots = 0;
   fSumQ = 0;
 
   fTriggerType = kTriggerUndefined;
@@ -161,6 +162,7 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
 
   // TClonesArray of WCSimRootCherenkovDigiHits
   fNcherenkovdigihits = 0;
+  fNcherenkovdigihits_slots = 0;
   fSumQ = 0;
 
   // remove whatever's in the arrays
@@ -378,16 +380,17 @@ WCSimRootCherenkovDigiHit *WCSimRootTrigger::AddCherenkovDigiHit(Float_t q,
   // Add a new digitized hit to the list of digitized hits
   TClonesArray &cherenkovdigihits = *fCherenkovDigiHits;
   WCSimRootCherenkovDigiHit *cherenkovdigihit = 
-    new(cherenkovdigihits[fNcherenkovdigihits++]) WCSimRootCherenkovDigiHit(q, 
-									    t, 
+    new(cherenkovdigihits[fNcherenkovdigihits_slots++]) WCSimRootCherenkovDigiHit(q,
+									    t,
 									    tubeid,
 									    photon_ids);
+  fNcherenkovdigihits++;
  
   return cherenkovdigihit;
 }
 //_____________________________________________________________________________
 
-WCSimRootCherenkovDigiHit::WCSimRootCherenkovDigiHit(Float_t q, 
+WCSimRootCherenkovDigiHit::WCSimRootCherenkovDigiHit(Float_t q,
 						     Float_t t, 
 						     Int_t tubeid,
 						     std::vector<int> photon_ids)
@@ -404,7 +407,10 @@ WCSimRootCherenkovDigiHit::WCSimRootCherenkovDigiHit(Float_t q,
 
 WCSimRootCherenkovDigiHit * WCSimRootTrigger::RemoveCherenkovDigiHit(WCSimRootCherenkovDigiHit * digit)
 {
-  return (WCSimRootCherenkovDigiHit *)fCherenkovDigiHits->Remove(digit);
+  WCSimRootCherenkovDigiHit * tmp = (WCSimRootCherenkovDigiHit *)fCherenkovDigiHits->Remove(digit);
+  if(tmp)
+    fNcherenkovdigihits--;
+  return tmp;
 }
 
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -82,6 +82,7 @@ void WCSimRootTrigger::Initialize() //actually allocate memory for things in her
 
   // TClonesArray of WCSimRootTracks
   fTracks = new TClonesArray("WCSimRootTrack", 10000);
+  fTracks->BypassStreamer(kFALSE); // use the member Streamer
   fNtrack = 0;
 
   // TClonesArray of WCSimRootCherenkovHits
@@ -89,12 +90,15 @@ void WCSimRootTrigger::Initialize() //actually allocate memory for things in her
 				    10000);
   fCherenkovHitTimes = new TClonesArray("WCSimRootCherenkovHitTime", 
 					10000);
+  fCherenkovHits->BypassStreamer(kFALSE); // use the member Streamer
+  fCherenkovHitTimes->BypassStreamer(kFALSE); // use the member Streamer
   fNcherenkovhits = 0;
   fNcherenkovhittimes = 0;
 
   // TClonesArray of WCSimRootCherenkovDigiHits
   fCherenkovDigiHits = new TClonesArray("WCSimRootCherenkovDigiHit", 
 				       10000);
+  fCherenkovDigiHits->BypassStreamer(kFALSE); // use the member Streamer
   fNcherenkovdigihits = 0;
   fSumQ = 0;
 
@@ -162,9 +166,9 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   // remove whatever's in the arrays
   // but don't deallocate the arrays themselves
 
-  fTracks->Delete();            
-  fCherenkovHits->Delete();      
-  fCherenkovHitTimes->Delete();   
+  fTracks->Delete();
+  fCherenkovHits->Delete();
+  fCherenkovHitTimes->Delete();
   fCherenkovDigiHits->Delete();
 
   fTriggerType = kTriggerUndefined;
@@ -395,6 +399,16 @@ WCSimRootCherenkovDigiHit::WCSimRootCherenkovDigiHit(Float_t q,
   fTubeId = tubeid;
   fPhotonIds = photon_ids;
 }
+
+//_____________________________________________________________________________
+
+WCSimRootCherenkovDigiHit * WCSimRootTrigger::RemoveCherenkovDigiHit(WCSimRootCherenkovDigiHit * digit)
+{
+  return (WCSimRootCherenkovDigiHit *)fCherenkovDigiHits->Remove(digit);
+}
+
+
+//_____________________________________________________________________________
 
 // M Fechner, august 2006
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -54,6 +54,7 @@ WCSimRootTrigger::WCSimRootTrigger()
   // TClonesArray of WCSimRootCherenkovDigiHits
   fCherenkovDigiHits = 0;
   fNcherenkovdigihits = 0;
+  fNcherenkovdigihits_slots = 0;
   fSumQ = 0;
 
   fTriggerType = kTriggerUndefined;

--- a/verification-test-scripts/verification_HitsChargeTime.C
+++ b/verification-test-scripts/verification_HitsChargeTime.C
@@ -140,13 +140,14 @@ void verification_HitsChargeTime(char *filename="wcsimtest.root", char *filename
     for (int index = 0 ; index < wcsimrootsuperevent->GetNumberOfEvents(); index++){ 
 	wcsimrootevent = wcsimrootsuperevent->GetTrigger(index);
 	int ncherenkovdigihits = wcsimrootevent->GetNcherenkovdigihits();
+	int ncherenkovdigihits_slots = wcsimrootevent->GetNcherenkovdigihits_slots();
 	hits->Fill(ncherenkovdigihits);
 	
 	
 	float totalq = 0.;
 	float totalt = 0.;
 	// Loop through elements in the TClonesArray of WCSimRootCherenkovHits
-	for (int i=0; i< ncherenkovdigihits; i++){
+	for (int i=0; i< ncherenkovdigihits_slots; i++){
 	    TObject *Digi = (wcsimrootevent->GetCherenkovDigiHits())->At(i);
 	    WCSimRootCherenkovDigiHit *wcsimrootcherenkovdigihit = 
 	      dynamic_cast<WCSimRootCherenkovDigiHit*>(Digi);

--- a/verification-test-scripts/verification_HitsChargeTime.C
+++ b/verification-test-scripts/verification_HitsChargeTime.C
@@ -149,6 +149,8 @@ void verification_HitsChargeTime(char *filename="wcsimtest.root", char *filename
 	// Loop through elements in the TClonesArray of WCSimRootCherenkovHits
 	for (int i=0; i< ncherenkovdigihits_slots; i++){
 	    TObject *Digi = (wcsimrootevent->GetCherenkovDigiHits())->At(i);
+	    if(!Digi)
+	      continue;
 	    WCSimRootCherenkovDigiHit *wcsimrootcherenkovdigihit = 
 	      dynamic_cast<WCSimRootCherenkovDigiHit*>(Digi);
 	    


### PR DESCRIPTION
Requires changes to the WCSimRootTrigger streamer settings, otherwise segfaults occur when trying to write WCSimRootEvent classes to the output tree.
Also modified the macros that loop over digits to account for the cases when they're reading files that have had digits removed (essentially just looping over a different number, and checking for null pointers)