### PR TITLE
Add how to run WCSim to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ Extra docker commands:
 
 ## Running WCSim
 
-To test that WCSim is working, try running the test macro `WCSim.mac`, which runs 10 electrons with 500 MeV of energy in the Super-Kamiokande detector:
+To test that WCSim is working, try running the test macro `WCSim.mac`, which runs 10 electrons with 500 MeV of energy in the Super-Kamiokande detector. The command is one of the following, depending on how WCSim was built:
 
 `./bin/Linux-g++/WCSim WCSim.mac`
+
+`./exe/bin/Linux-g++/WCSim WCSim.mac`
 
 `WCSim.mac` is well commented. Take a look inside (and also at other `.mac` files in `/macros/`) for the various options you can use to run WCSim
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Useful cmake commands:
 
 Docker allows you to use WCSim without compiling in an OS independant way. The Docker images are hosted on DockerHub and can be used by following the steps below.
 
-1) Install Doocker cross platform instructions can be found at https://www.docker.com/
-2) Pull the WCSim image from docker hub by using `docker pull wcsim/wcsim:tag` where tag is the tagged version or use the tag `latest` to get the current develop branch 
+1) Install Docker cross platform instructions can be found at https://www.docker.com/
+2) Pull the WCSim image from docker hub by using `docker pull wcsim/wcsim:tag` where `tag` is the tagged version or use the tag `latest` to get the current develop branch 
 3) Run the docker image and create a container `docker run --name=WCSim -i -t wcsim/wcsim:tag` this will give you a shell in the container's OS with WCSim already built. 
 To save data from inside your docker image mount a local folder in the docker image at runtime and then anything placed in that directory will be available in that folder after exit. To do that run the following `docker run -v local_folder_path:docker_mount_path -i -t wcsim/wcsim:tag`
 4) Once you have run the docker image navigate to `cd /root/HyperK/WCSim` and source the enviroment variables using `source /root/HyperK/env-WCSim.sh` and then run WCSim as normal form this directory

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## Welcome to WCSim
+# Welcome to WCSim
 
 WCSim is a very flexible GEANT4 based program for developing and
 simulating large water Cherenkov detectors.
 
 As of August 2014 WCSim has been moved to GitHub.  It can be found at:
 
-https://github.com/WCSim
+https://github.com/WCSim/WCSim
 
 Tutorials and information about the branches and WCSim development model can be
 found on the wiki:
@@ -21,33 +21,38 @@ https://lists.phy.duke.edu/mailman/listinfo/wcsim-git
 
 You can follow issues/requests etc by watching the GitHub respository.
 
-# Validation Webpage
+## Validation Webpage
+
+WCSim uses Travis CI to perform build and physics tests for each pull request and commit.
+The scripts it runs can be found at https://github.com/WCSim/Validation
+The output can be found at
 
 https://wcsim.github.io/Validation/
 
+## Documentation
+
+More detailed information about the simulation is available in
+doc/DetectorDocumentation.pdf
 
 ## Current notes and how to build
-
-Build Instructions:
 
 You should have a recent and working version of ROOT and GEANT4.
 (Known to work with GEANT 4.10.1p03 and ROOT v5.28.00)  You also need all of the G4
 data files including hadron xsecs etc.  Those are the only
 requirements.  The code should work with gcc 4.4.7. For v1.6.0 and earlier, use GEANT 4.9.4.p01.
 
+### Build Instructions using make:
+
 To compile: 
-* make clean 
-* make rootcint
-* make
+* `make clean`
+* `make rootcint`
+* `make`
 
 If you want to use these libraries with an external program then also do:
-* make shared      [ For root programs]
-* make libWCSim.a  [ Also necessary for the event display?]
+* `make shared`      [ For root programs]
+* `make libWCSim.a`  [ Also necessary for the event display?]
 
-More detailed information about the simulation is available in
-doc/DetectorDocumentation.pdf.
-
-Build Instructions using CMake:
+### Build Instructions using CMake:
 
 CMake is cross-platform software for managing the build process in 
 a compiler-independent way (cmake.org). 
@@ -59,53 +64,59 @@ it easier to build many versions of the same software.
 
 A recommended way to set up the directory structure in your own
 preferred WCSIM_HOME:
-- ${WCSIM_HOME}/WCSim : contains the src dir, typically the cloned or 
+- `${WCSIM_HOME}/WCSim` : contains the src dir, typically the cloned or 
   unzipped code from GitHub
-- ${WCSIM_HOME}/WCSim_build : contains directories for each build, eg.
+- `${WCSIM_HOME}/WCSim_build` : contains directories for each build, eg.
   for each branch you want to test or for different releases, comparing
   debugged versions, etc.
   This directory will contain the executable, the example macros and
   library for ROOT.
 
-To compile you need to have CMakeLists.txt in the WCSim source dir.
-* mkdir ${WCSIM_HOME}/WCSim_build/mydir ; cd ${WCSIM_HOME}/WCSim_build/mydir
-* Set up the Geant4_Dir: export Geant4_DIR=${HOME}/Geant4/install/geant4.9.6.p04 
+To compile you need to have `CMakeLists.txt` in the WCSim source dir.
+* `mkdir ${WCSIM_HOME}/WCSim_build/mydir ; cd ${WCSIM_HOME}/WCSim_build/mydir`
+* Set up the Geant4_Dir: `export Geant4_DIR=${HOME}/Geant4/install/geant4.9.6.p04`
   (from the make install phase of Geant4)
-* cmake ../../WCSim : this executes the commands in CMakeLists.txt and generates
+* `cmake ../../WCSim` : this executes the commands in `CMakeLists.txt` and generates
   the Makefiles for both the ROOT library as the main executable.
-* make clean : if necessary
-* make : will first compile the libWCSimRoot.so which you need for using
+* `make clean` : if necessary
+* `make` : will first compile the libWCSimRoot.so which you need for using
   the ROOT Dict from WCSim and then compile WCSim.
 
 To recompile:
-* Typically just "make" will be enough and also redo the cmake phase if
+* Typically just `make` will be enough and also redo the cmake phase if
   something changed.
-* Sometimes you need to "make clean" first.
-* When there are problems, try removing CMakeCache.txt, and redo the cmake.
+* Sometimes you need to `make clean` first.
+* When there are problems, try removing `CMakeCache.txt`, and redo the cmake.
 
 Useful cmake commands:
-* make edit_cache : customize the build.
-* make rebuild_cache : redo the cmake phase.
+* `make edit_cache` : customize the build.
+* `make rebuild_cache` : redo the cmake phase.
 
 
-Using WCSim without building using Docker:
+### Using WCSim without building using Docker:
 
 Docker allows you to use WCSim without compiling in an OS independant way. The Docker images are hosted on DockerHub and can be used by following the steps below.
 
 1) Install Doocker cross platform instructions can be found at https://www.docker.com/
-2) Pull the WCSim image from docker hub by using "docker pull wcsim/wcsim:tag" where tag is the tagged version or use the tag "latest" to get the current develop branch 
-3) Run the docker image and create a container "docker run --name=WCSim -i -t wcsim/wcsim:tag" this will give you a shell in the container's OS with WCSim already built. 
-To save data from inside your docker image mount a local folder in the docker image at runtime and then anything placed in that directory will be available in that folder after exit. To do that run the following "docker run -v local_folder_path:docker_mount_path -i -t wcsim/wcsim:tag"
-4) Once you have run the docker image navigate to "cd /root/HyperK/WCSim" and source the enviroment variables using "source /root/HyperK/env-WCSim.sh" and then run WCSim as normal form this directory
-5) To exit the docker image "exit"
+2) Pull the WCSim image from docker hub by using `docker pull wcsim/wcsim:tag` where tag is the tagged version or use the tag `latest` to get the current develop branch 
+3) Run the docker image and create a container `docker run --name=WCSim -i -t wcsim/wcsim:tag` this will give you a shell in the container's OS with WCSim already built. 
+To save data from inside your docker image mount a local folder in the docker image at runtime and then anything placed in that directory will be available in that folder after exit. To do that run the following `docker run -v local_folder_path:docker_mount_path -i -t wcsim/wcsim:tag`
+4) Once you have run the docker image navigate to `cd /root/HyperK/WCSim` and source the enviroment variables using `source /root/HyperK/env-WCSim.sh` and then run WCSim as normal form this directory
+5) To exit the docker image `exit`
 
-(Note: You only need to use the "docker run" command once to create the container. Once created you changes are saved in that container instance and you can start and stop the contianer at any time with  "docker start WCSim" and "docker stop WCSim");
+(Note: You only need to use the `docker run` command once to create the container. Once created you changes are saved in that container instance and you can start and stop the contianer at any time with  `docker start WCSim` and `docker stop WCSim`);
 
 Extra docker commands:
-1) See all images "docker images"
-2) Delete an image "docker rmi imageID"
-3) See all containers "docker ps -a"
-4) Delete a container "docker rm ContainerID"
+1) See all images `docker images`
+2) Delete an image `docker rmi imageID`
+3) See all containers `docker ps -a`
+4) Delete a container `docker rm ContainerID`
+
+## Running WCSim
+
+To test that WCSim is working, try running the test macro `WCSim.mac`, which runs 10 electrons with 500 MeV of energy in the Super-Kamiokande detector:
+
+`./bin/Linux-g++/WCSim WCSim.mac`
 
 
 ## Color Convention for visualization used in WCSimVismanager.cc
@@ -118,7 +129,6 @@ Extra docker commands:
 * muon+ = silver
 * proton = magenta
 * neutron = cyan
-
 
 ```
 WCSim development is supported by the United States National Science Foundation.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ To test that WCSim is working, try running the test macro `WCSim.mac`, which run
 
 `./bin/Linux-g++/WCSim WCSim.mac`
 
+`WCSim.mac` is well commented. Take a look inside (and also at other `.mac` files in `/macros/`) for the various options you can use to run WCSim
 
 ## Color Convention for visualization used in WCSimVismanager.cc
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ You can follow issues/requests etc by watching the GitHub respository.
 
 WCSim uses Travis CI to perform build and physics tests for each pull request and commit.
 The scripts it runs can be found at https://github.com/WCSim/Validation
-The output can be found at
 
-https://wcsim.github.io/Validation/
+The output can be found at: https://wcsim.github.io/Validation/
 
 ## Documentation
 
 More detailed information about the simulation is available in
-doc/DetectorDocumentation.pdf
+`doc/DetectorDocumentation.pdf`
 
 ## Current notes and how to build
 


### PR DESCRIPTION
I've just realised that the only place that how to run WCSim is at https://github.com/WCSim/WCSim/wiki/Tutorial:-How-to-set-up-GitHub-(in-the-context-of-WCSim) This is quite an unexpected place for new people to find the information! So I've added a little section to the README.md

Additionally I've cleaned up the formatting a bit