### PR TITLE
Updated vertex assignment for muline

### DIFF
--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -236,11 +236,14 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
 		    G4double ekin = energy - mass;
 
-		    particleGun->SetParticleEnergy(ekin);
+		    //particleGun->SetParticleEnergy(ekin);
 		    //G4cout << "Particle: " << pdgid << " KE: " << ekin << G4endl;
-		    particleGun->SetParticlePosition(vtxs[0]);
-		    particleGun->SetParticleMomentumDirection(dir);
-		    particleGun->GeneratePrimaryVertex(anEvent);
+		    //particleGun->SetParticlePosition(vtxs[0]);
+		    //particleGun->SetParticleMomentumDirection(dir);
+		    //particleGun->GeneratePrimaryVertex(anEvent);
+		    SetVtx(vtxs[0]);
+		    SetBeamEnergy(ekin);
+		    SetBeamDir(dir);
 		  }
 	      }
 	  }


### PR DESCRIPTION
WCSim files generated using muline option have the vertex incorrectly set to (0,0,0). This fixes it.