### PR TITLE
Last changes for TriggerApplication

### DIFF
--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -143,6 +143,7 @@ public:
   virtual ~WCSimRootCherenkovDigiHit() { }
   bool CompareAllVariables(const WCSimRootCherenkovDigiHit * c) const;
 
+  void SetT(float t) { fT = t; }
   Float_t     GetQ() const { return fQ;}
   Float_t     GetT() const { return fT;}
   Int_t       GetTubeId() const { return fTubeId;}

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -491,7 +491,7 @@ WCSimRootCherenkovDigiHit *WCSimRootTrigger::AddCherenkovDigiHit(WCSimRootCheren
   // Add a new digitized hit to the list of digitized hits
   TClonesArray &cherenkovdigihits = *fCherenkovDigiHits;
   WCSimRootCherenkovDigiHit *cherenkovdigihit =
-    new(cherenkovdigihits[fNcherenkovdigihits++]) WCSimRootCherenkovDigiHit(
+    new(cherenkovdigihits[fNcherenkovdigihits_slots++]) WCSimRootCherenkovDigiHit(
 										  digit->GetQ(),
 										  digit->GetT(),
 										  digit->GetTubeId(),
@@ -768,24 +768,33 @@ bool WCSimRootTrigger::CompareAllVariables(const WCSimRootTrigger * c) const
   }//i (WCSimRootCherenkovHit)
 
   //check digitised hits
-  for(int i = 0; i < TMath::Min(this->GetCherenkovDigiHits()->GetEntries(), c->GetCherenkovDigiHits()->GetEntries()); i++) {
-    WCSimRootCherenkovDigiHit * tmp_digit_1 = (WCSimRootCherenkovDigiHit *)this->GetCherenkovDigiHits()->At(i);
-    if(! tmp_digit_1) {
-#ifdef VERBOSE_COMPARISON
-      cerr << "Digit " << i << " does not exist in this" << endl;
-#endif
-      continue;
+  // this is more complicated because there can be some empty slots for at least one of the TClonesArray
+  ithis = -1, ithat = -1;
+  WCSimRootCherenkovDigiHit * tmp_digit_1, * tmp_digit_2;
+  int ncomp_digi = 0;
+  while(true) {
+    tmp_digit_1 = 0;
+    while(!tmp_digit_1 && ithis < this->GetNcherenkovdigihits_slots() - 1) {
+      ithis++;
+      tmp_digit_1 = (WCSimRootCherenkovDigiHit *)this->GetCherenkovDigiHits()->At(ithis);
     }
-    WCSimRootCherenkovDigiHit * tmp_digit_2 = (WCSimRootCherenkovDigiHit *)c->GetCherenkovDigiHits()->At(i);
-    if(! tmp_digit_2) {
-#ifdef VERBOSE_COMPARISON
-      cerr << "Digit " << i << " does not exist in that" << endl;
-#endif
-      continue;
+    tmp_digit_2 = 0;
+    while(!tmp_digit_2 && ithat < c->GetNcherenkovdigihits_slots() - 1) {
+      ithat++;
+      tmp_digit_2 = (WCSimRootCherenkovDigiHit *)c->GetCherenkovDigiHits()->At(ithat);
     }
+    if(!tmp_digit_1 || !tmp_digit_2)
+      break;
+#ifdef VERBOSE_COMPARISON
+    cout << "Comparing digit " << ithis " in this with digit"
+	 << ithat " in that" << endl;
+#endif
     failed = !(tmp_digit_1->CompareAllVariables(tmp_digit_2)) || failed;
-  }//i
-
+    ncomp_digi++;
+  }//ithis ithat
+  if(ncomp_digi != fNcherenkovdigihits && ncomp_digi != c->GetNcherenkovdigihits()) {
+    cerr << "Only compared " << ncomp_digi << " digits. There should be " << TMath::Min(fNcherenkovdigihits, c->GetNcherenkovdigihits()) << " comparisons" << endl;
+  }
 
   failed = (!ComparisonPassed(fMode, c->GetMode(), typeid(*this).name(), __func__, "Mode")) || failed;
   failed = (!ComparisonPassed(fNvtxs, c->GetNvtxs(), typeid(*this).name(), __func__, "Nvtxs")) || failed;
@@ -802,10 +811,13 @@ bool WCSimRootTrigger::CompareAllVariables(const WCSimRootTrigger * c) const
   failed = (!ComparisonPassed(fNumTubesHit, c->GetNumTubesHit(), typeid(*this).name(), __func__, "NumTubesHit")) || failed;
   failed = (!ComparisonPassed(fNumDigitizedTubes, c->GetNumDigiTubesHit(), typeid(*this).name(), __func__, "NumDigitizedTubes")) || failed;
   failed = (!ComparisonPassed(fNtrack, c->GetNtrack(), typeid(*this).name(), __func__, "Ntrack")) || failed;
+  //don't expect this to pass in general, so don't affect failed
   ComparisonPassed(fNtrack_slots, c->GetNtrack_slots(), typeid(*this).name(), __func__, "Ntrack_slots (shouldn't necessarily be equal)");
   failed = (!ComparisonPassed(fNcherenkovhits, c->GetNcherenkovhits(), typeid(*this).name(), __func__, "Ncherenkovhits")) || failed;
   failed = (!ComparisonPassed(fNcherenkovhittimes, c->GetNcherenkovhittimes(), typeid(*this).name(), __func__, "Ncherenkovhittimes")) || failed;
   failed = (!ComparisonPassed(fNcherenkovdigihits, c->GetNcherenkovdigihits(), typeid(*this).name(), __func__, "Ncherenkovdigihits")) || failed;
+  //don't expect this to pass in general, so don't affect failed
+  ComparisonPassed(fNcherenkovdigihits_slots, c->GetNcherenkovdigihits_slots(), typeid(*this).name(), __func__, "Ncherenkovdigihits_slots (shouldn't necessarily be equal)");
   failed = (!ComparisonPassed(fSumQ, c->GetSumQ(), typeid(*this).name(), __func__, "SumQ")) || failed;
   failed = (!ComparisonPassed(fTriggerType, c->GetTriggerType(), typeid(*this).name(), __func__, "TriggerType")) || failed;
   failed = (!ComparisonPassedVec(fTriggerInfo, c->GetTriggerInfo(), typeid(*this).name(), __func__, "TriggerInfo")) || failed;


### PR DESCRIPTION
These are the last (hopefully!) changes required for TriggerApplication
* Add a `SetT()` to `WCSimRootCherenkovDigiHit` - essential for setting the time of digits correctly (digit time depends on the trigger time, therefore isn't known when writing the output in WCSim)
* Do a proper comparison of digits using `fNcherenkovdigihits_slots` in `WCSimRootTrigger::CompareAllVariables()`
* Fix to use `fNcherenkovdigihits_slots` in `AddCherenkovDigiHit()`