### PR TITLE
bug fix:  Make daq.mac PreTriggerWindows take effect

### DIFF
--- a/include/WCSimWCDAQMessenger.hh
+++ b/include/WCSimWCDAQMessenger.hh
@@ -72,7 +72,7 @@ private:
   G4bool                StoreNDigitsAdjustForNoise;
   G4UIcmdWithAnInteger* NDigitsPreTriggerWindow;
   G4int                 StoreNDigitsPreWindow;
-  G4bool                NDigitsPreWindowSetByUser; //because this is typically negative, a foolproof workaround
+  G4bool                NDigitsPreWindowSetByUser; //because this is typically negative, a foolproof(?) workaround
   G4UIcmdWithAnInteger* NDigitsPostTriggerWindow;
   G4int                 StoreNDigitsPostWindow;
 

--- a/include/WCSimWCDAQMessenger.hh
+++ b/include/WCSimWCDAQMessenger.hh
@@ -72,6 +72,7 @@ private:
   G4bool                StoreNDigitsAdjustForNoise;
   G4UIcmdWithAnInteger* NDigitsPreTriggerWindow;
   G4int                 StoreNDigitsPreWindow;
+  G4bool                NDigitsPreWindowSetByUser; //because this is typically negative, a foolproof workaround
   G4UIcmdWithAnInteger* NDigitsPostTriggerWindow;
   G4int                 StoreNDigitsPostWindow;
 

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -12,7 +12,7 @@
 #include <string>
 
 WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
-  WCSimEvent(eventaction)
+  WCSimEvent(eventaction), StoreSaveFailuresPreWindow(-1E6), StoreNDigitsPreWindow(-1E6)
 {
   initialiseString = " (this is a default set; it may be overwritten by user commands)";
   initialised = false;
@@ -333,7 +333,7 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
   G4cout << "\t" << failuremode << G4endl;
   WCSimTrigger->SetSaveFailuresTime(StoreSaveFailuresTime);
   G4cout << "\tTrigger time for events which fail all triggers will be set to " << StoreSaveFailuresTime << " ns" << G4endl;
-  if(StoreSaveFailuresPreWindow >= -1E6) {
+  if(StoreSaveFailuresPreWindow > -1E6) {
     WCSimTrigger->SetSaveFailuresPreTriggerWindow(StoreSaveFailuresPreWindow);
     G4cout << "\tSaveFailures pretrigger window set to " << StoreSaveFailuresPreWindow << " ns" << G4endl;
   }
@@ -353,7 +353,7 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
     WCSimTrigger->SetNDigitsWindow(StoreNDigitsWindow);
     G4cout << "\tNDigits trigger window set to " << StoreNDigitsWindow << " ns" << G4endl;
   }
-  if(StoreNDigitsPreWindow >= 0) {
+  if(StoreNDigitsPreWindow > -1E6) {
     WCSimTrigger->SetNDigitsPreTriggerWindow(StoreNDigitsPreWindow);
     G4cout << "\tNDigits pretrigger window set to " << StoreNDigitsPreWindow << " ns" << G4endl;
   }

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -12,7 +12,7 @@
 #include <string>
 
 WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
-  WCSimEvent(eventaction), StoreSaveFailuresPreWindow(-1E6), StoreNDigitsPreWindow(-1E6)
+  WCSimEvent(eventaction), NDigitsPreWindowSetByUser(false)
 {
   initialiseString = " (this is a default set; it may be overwritten by user commands)";
   initialised = false;
@@ -303,6 +303,7 @@ void WCSimWCDAQMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   else if (command == NDigitsPreTriggerWindow) {
     G4cout << "NDigits pretrigger window set to " << newValue << " ns" << initialiseString.c_str() << G4endl;
     StoreNDigitsPreWindow = NDigitsPreTriggerWindow->GetNewIntValue(newValue);
+    NDigitsPreWindowSetByUser = true;
   }
   else if (command == NDigitsPostTriggerWindow) {
     G4cout << "NDigits posttrigger window set to " << newValue << " ns" << initialiseString.c_str() << G4endl;
@@ -333,14 +334,10 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
   G4cout << "\t" << failuremode << G4endl;
   WCSimTrigger->SetSaveFailuresTime(StoreSaveFailuresTime);
   G4cout << "\tTrigger time for events which fail all triggers will be set to " << StoreSaveFailuresTime << " ns" << G4endl;
-  if(StoreSaveFailuresPreWindow > -1E6) {
-    WCSimTrigger->SetSaveFailuresPreTriggerWindow(StoreSaveFailuresPreWindow);
-    G4cout << "\tSaveFailures pretrigger window set to " << StoreSaveFailuresPreWindow << " ns" << G4endl;
-  }
-  if(StoreSaveFailuresPostWindow >= 0) {
-    WCSimTrigger->SetSaveFailuresPostTriggerWindow(StoreSaveFailuresPostWindow);
-    G4cout << "\tSaveFailures posttrigger window set to " << StoreSaveFailuresPostWindow << " ns" << G4endl;
-  }
+  WCSimTrigger->SetSaveFailuresPreTriggerWindow(StoreSaveFailuresPreWindow);
+  G4cout << "\tSaveFailures pretrigger window set to " << StoreSaveFailuresPreWindow << " ns" << G4endl;
+  WCSimTrigger->SetSaveFailuresPostTriggerWindow(StoreSaveFailuresPostWindow);
+  G4cout << "\tSaveFailures posttrigger window set to " << StoreSaveFailuresPostWindow << " ns" << G4endl;
 
   if(StoreNDigitsThreshold >= 0) {
    WCSimTrigger->SetNDigitsThreshold(StoreNDigitsThreshold);
@@ -353,7 +350,7 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
     WCSimTrigger->SetNDigitsWindow(StoreNDigitsWindow);
     G4cout << "\tNDigits trigger window set to " << StoreNDigitsWindow << " ns" << G4endl;
   }
-  if(StoreNDigitsPreWindow > -1E6) {
+  if(NDigitsPreWindowSetByUser) {
     WCSimTrigger->SetNDigitsPreTriggerWindow(StoreNDigitsPreWindow);
     G4cout << "\tNDigits pretrigger window set to " << StoreNDigitsPreWindow << " ns" << G4endl;
   }


### PR DESCRIPTION
Currently the `/DAQ/*Trigger/PreTriggerWindow` options have no effect, because in the `WCSimWCDAQMessenger.cc` file the setting is only transferred from the messenger internal variable to the Trigger class if the `PreTriggerWindow >= 0` is satisfied. But the PreTriggerWindow is defined as being negative, so this condition is never met.
This PR initializes the messenger internal variables with -1E6 and then changes the condition for transferring this to the Trigger class to be `PreTriggerWindow > -1E6`