### PR TITLE
Fix memory over-usage ("leak") in WCSim

### DIFF
--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -663,11 +663,14 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
   //TBranch* tankeventbranch = tree->GetBranch("wcsimrootevent");
   //tree->SetEntries(tankeventbranch->GetEntries());
   tree->SetEntries(GetRunAction()->GetNumberOfEventsGenerated());
+  /*
+  	-> G. Pronost (2019/12/17) Moved to RunAction (EndOfRun) in order to fasten the simulation
   TFile* hfile = tree->GetCurrentFile();
   // MF : overwrite the trees -- otherwise we have as many copies of the tree
   // as we have events. All the intermediate copies are incomplete, only the
   // last one is useful --> huge waste of disk space.
   hfile->Write("",TObject::kOverwrite);
+  */
 
   //save DAQ options here. This ensures that when the user selects a default option
   // (e.g. with -99), the saved option value in the output reflects what was run

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -127,6 +127,8 @@ void WCSimRunAction::EndOfRunAction(const G4Run*)
   // Close the Root file at the end of the run
 
   TFile* hfile = WCSimTree->GetCurrentFile();
+  // Moved from EventAction by G. Pronost on 2019/12/17
+  hfile->Write("",TObject::kOverwrite); // Need to overwrite to avoid multiple instance of wcsimT
   hfile->Close();
 
   // Clean up stuff on the heap; I think deletion of hfile and trees


### PR DESCRIPTION
I found a memory over-usage in WCSim (kind of a memory leak). This issue cause the simulation duration to increase much faster than the number of events: the duration of the simulation for one event is increasing event after event.

Here is an example with the default WCSim 1.8.0 (compiled with geant4.10.03p3 and root 5.34.38 on sukap)
   Event 1000: 8.9771 sec for the last 1000 events
   Event 2000: 10.692 sec for the last 1000 events
   Event 3000: 12.3112 sec for the last 1000 events
   Event 4000: 14.5926 sec for the last 1000 events
   Event 5000: 15.1249 sec for the last 1000 events
   Event 6000: 16.3592 sec for the last 1000 events
   Event 7000: 18.2621 sec for the last 1000 events

I managed to pinpoint the issue as coming from the EventAction EndOfEvent function. The issue is due to the way the tree is filled: the root file is overwritten every event. The duration of the root file writing is then obviously increasing event after event.

If I moved the root file writing from the EventAction to the RunAction, the root file is still properly written but the simulation is much faster: 
   Event 1000: 3.7401 sec for the last 1000 events
   Event 2000: 3.8835 sec for the last 1000 events
   Event 3000: 3.74723 sec for the last 1000 events
   Event 4000: 3.75198 sec for the last 1000 events
   Event 5000: 3.86014 sec for the last 1000 events
   Event 6000: 3.84479 sec for the last 1000 events
   Event 7000: 3.72253 sec for the last 1000 events

I tested with 1 million events (the simulation took about 1h) and there is no obvious issue.