### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ More detailed information about the simulation is available in
 ## Current notes and how to build
 
 You should have a recent and working version of ROOT and GEANT4.
-(Known to work with GEANT 4.10.1p03 and ROOT v5.28.00)  You also need all of the G4
+(Known to work with GEANT 4.10.03p03 and ROOT v5.28.00)  You also need all of the G4
 data files including hadron xsecs etc.  Those are the only
-requirements.  The code should work with gcc 4.4.7. For v1.6.0 and earlier, use GEANT 4.9.4.p01.
+requirements.  The code should work with gcc 4.4.7.
+* For v1.8.0 and earlier, use GEANT 4.10.1p03
+* For v1.6.0 and earlier, use GEANT 4.9.4.p01.
 
 ### Build Instructions using make:
 


### PR DESCRIPTION
PR #275 made some changes that causes builds with G4.10.1 to fail. Updating the README to suggest a more up-to-date G4 version (not sure what the minimum version is, just using the version suggested by #275)

e.g. of a change: https://github.com/WCSim/WCSim/pull/275/files#diff-0cfe8dcf71fdd92dedfef801c5fd0751R145