### PR TITLE
Make compatible with G4.10.1 again

### DIFF
--- a/src/WCSimVisManager.cc
+++ b/src/WCSimVisManager.cc
@@ -141,8 +141,8 @@ void WCSimVisManager::RegisterGraphicsSystems () {
     G4cout <<
       "\nYou have successfully chosen to use the following graphics systems."
 	 << G4endl;
-//    PrintAvailableGraphicsSystems ();
-    PrintAvailableGraphicsSystems (GetVerbosityValue(fVerbose));
+    PrintAvailableGraphicsSystems (); //use this version for Geant4.10.1
+    //PrintAvailableGraphicsSystems (GetVerbosityValue(fVerbose)); //use this version for Geant4.10.2+
   }
   RegisterModel(mymodel);
 


### PR DESCRIPTION
Since the recommended Geant version is going to remain G4.10.1 (see discussion in #276), lets make sure people checking out the code can actually build with G4.10.1