### PR TITLE
Update dockerfiles for singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 ### Download base image from cern repo on docker hub
 FROM wcsim/wcsim:base
 
-USER nu
+### Run the following commands as super user (root):
+USER root
 
 ### Get and build WCSim
 WORKDIR $HYPERKDIR

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -22,6 +22,7 @@ RUN yum install -y \
     libXpm-devel \
     libXft-devel \
     libXext-devel \
+    libzstd-devel \
     git \
     mesa-libGL-devel \
     mesa-libGLU-devel \
@@ -40,7 +41,7 @@ RUN mkdir $HYPERKDIR
 WORKDIR $HYPERKDIR
 
 ### Downloading ROOT
-RUN wget https://root.cern.ch/download/root_v5.34.36.Linux-centos7-x86_64-gcc4.8.tar.gz -O root.tar.gz \
+RUN wget https://root.cern.ch/download/root_v6.20.04.Linux-centos7-x86_64-gcc4.8.tar.gz -O root.tar.gz \
     && tar -xvzf root.tar.gz \
     && rm -f root.tar.gz
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -35,9 +35,7 @@ RUN yum install -y \
     && rm -rf /var/cache/yum
 
 ### Setup environment
-RUN useradd -ms /bin/bash nu
-USER nu
-ENV HYPERKDIR /home/nu/HyperK
+ENV HYPERKDIR /opt/HyperK
 RUN mkdir $HYPERKDIR
 WORKDIR $HYPERKDIR
 
@@ -74,15 +72,15 @@ RUN make install
 ### ENV Geant4
 ENV WCSIMDIR $HYPERKDIR/WCSim
 ENV G4WORKDIR $WCSIMDIR/exe
-ENV G4INSTALL $HYPERKDIR/geant4.10.01.p03-install
+ENV G4INSTALLDIR $HYPERKDIR/geant4.10.01.p03-install
 ENV G4LIB $G4INSTALL/lib
 
 ### Make a setup script
 WORKDIR $HYPERKDIR
 RUN echo '#!/bin/bash -x' > env-WCSim.sh \
     && echo 'source $HYPERKDIR/root/bin/thisroot.sh' >> env-WCSim.sh \
-    && echo 'source $G4INSTALL/bin/geant4.sh' >> env-WCSim.sh \
-    && echo 'source $G4INSTALL/share/Geant4-10.1.3/geant4make/geant4make.sh' >> env-WCSim.sh
+    && echo 'source $G4INSTALLDIR/bin/geant4.sh' >> env-WCSim.sh \
+    && echo 'source $G4INSTALLDIR/share/Geant4-10.1.3/geant4make/geant4make.sh' >> env-WCSim.sh
 
 ### Open terminal
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Extra docker commands:
 3) See all containers `docker ps -a`
 4) Delete a container `docker rm ContainerID`
 
+#### Using WCSim without building using Singularity
+
+Singularity is a similar container tool with different philosphies. The most important being that you can't run as root. This means that it may be installed and available to use on your local cluster.
+
+You should be able to run the docker container with singularity without any problems. Just to note that $WCSIMDIR will be read-only, therefore you should run WCSim elsewhere (if you forget you'll see a nasty seg fault - this is just because of the read-only directory).
+
 ## Running WCSim
 
 To test that WCSim is working, try running the test macro `WCSim.mac`, which runs 10 electrons with 500 MeV of energy in the Super-Kamiokande detector. The command is one of the following, depending on how WCSim was built:


### PR DESCRIPTION
* Install software as root, in /opt/ (should now work in singularity)
* No longer create a new user (not required, was a misguided attempt for singularity compatability)
* Add singularity comment to README
* Use `G4INSTALLDIR` environment variable instead of `G4INSTALL` (the geant4 setup script sets `G4INSTALL` itself, to a different location to where the script is, hence the need for a new variable name)