### PR TITLE
Minor changes

### DIFF
--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -71,7 +71,11 @@ libWCSim.a : $(ROOTOBJS)
 rootcint: ./src/WCSimRootDict.cc
 
 movedict: rootcint
-	$(shell cp ./src/WCSimRootDict_rdict.pcm .)
+ifneq (,$(wildcard /opt/HyperK/WCSim/src/WCSimRootDict_rdict.pcm))
+	cp -f ./src/WCSimRootDict_rdict.pcm .
+	cp -f ./src/WCSimRootDict_rdict.pcm ${G4WORKDIR}/tmp/${G4SYSTEM}/WCSim/
+endif
+
 
 doxy:
 	@if [ ${DOXYGEN_EXISTS} = 1 ]; \

--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -71,7 +71,7 @@ libWCSim.a : $(ROOTOBJS)
 rootcint: ./src/WCSimRootDict.cc
 
 movedict: rootcint
-ifneq (,$(wildcard /opt/HyperK/WCSim/src/WCSimRootDict_rdict.pcm))
+ifneq (,$$(wildcard ./src/WCSimRootDict_rdict.pcm))
 	cp -f ./src/WCSimRootDict_rdict.pcm .
 	cp -f ./src/WCSimRootDict_rdict.pcm ${G4WORKDIR}/tmp/${G4SYSTEM}/WCSim/
 endif
@@ -87,7 +87,7 @@ doxy:
 
 clean_wcsim:
 	echo  $(G4WORKDIR); 
-	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.h src/WCSimRootDict.cc WCSimRootDict_rdict.pcm; 
+	$(RM) -r $(G4WORKDIR); $(RM) *.o *.a *.so *~ */*~ src/WCSimRootDict.h src/WCSimRootDict.cc src/WCSimRootDict_rdict.pcm WCSimRootDict_rdict.pcm;
 	@if [ -d "doc/doxygen" ]; \
 		then \
 		rm -r doc/doxygen; \

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -53,7 +53,10 @@ libWCSimRoot.so : $(ROOTOBJS)
 rootcint: ./src/WCSimRootDict.cc
 
 movedict: rootcint
-	$(shell cp ./src/WCSimRootDict_rdict.pcm .)
+ifneq (,$$(wildcard ./src/WCSimRootDict_rdict.pcm))
+	cp -f ./src/WCSimRootDict_rdict.pcm .
+	cp -f ./src/WCSimRootDict_rdict.pcm ${G4TMPDIR}
+endif
 
 $(G4TMPDIR)/%.o: src/%.cc
 	@echo Compiling $*.cc ...
@@ -65,3 +68,4 @@ clean :
 	@rm -f $(G4TMPDIR)/*.o
 	@rm -f ./src/WCSimRootDict.cc
 	@rm -f ./WCSimRootDict_rdict.pcm
+	@rm -f ./src/WCSimRootDict_rdict.pcm

--- a/include/WCSimEnumerations.hh
+++ b/include/WCSimEnumerations.hh
@@ -7,6 +7,7 @@ typedef enum ETriggerType {
   kTriggerUndefined = -1,
   kTriggerNDigits,
   kTriggerNDigitsTest,
+  kTriggerTestVertices,
   kTriggerNoTrig,
   kTriggerFailure // this should always be the last entry (for looping)
 } TriggerType_t;

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -361,52 +361,33 @@ public:
   static void   Reset(Option_t *option ="");
   Int_t GetCurrentIndex() { return Current;}
 
-  //  WCSimRootTrigger* GetTrigger(int number) { return fEventList[number];}
-        WCSimRootTrigger * GetTrigger(int number)       { return (WCSimRootTrigger*) (*fEventList)[number];}
-  const WCSimRootTrigger * GetTrigger(int number) const { return (WCSimRootTrigger*) (*fEventList)[number];}
+        WCSimRootTrigger * GetTrigger(int number)       { return (WCSimRootTrigger*) fEventList->At(number);}
+  const WCSimRootTrigger * GetTrigger(int number) const { return (WCSimRootTrigger*) fEventList->At(number);}
 
-  Int_t GetNumberOfEvents() const { return fEventList->GetEntriesFast();}
-  Int_t GetNumberOfSubEvents() const { return (fEventList->GetEntriesFast()-1);}
-  bool HasSubEvents() { return  (fEventList->GetEntriesFast() > 1); } 
+  Int_t GetNumberOfEvents() const { return fEventList->GetEntries();}
+  Int_t GetNumberOfSubEvents() const { return (fEventList->GetEntries()-1);}
+  bool HasSubEvents() { return  (fEventList->GetEntries() > 1); }
 
-  //Int_t GetNumberOfEvents() const { return fEventList.size();}
-  //Int_t GetNumberOfSubEvents() const { return (fEventList.size()-1);}
-
-  //void AddSubEvent() { fEventList.push_back(new WCSimRootTrigger()); }
   void AddSubEvent() { 
     // be sure not to call the default constructor BUT the actual one
-    WCSimRootTrigger* tmp = dynamic_cast<WCSimRootTrigger*>( (*fEventList)[0] );
-    int num = tmp->GetHeader()->GetEvtNum();
-    ++Current; 
+    ++Current;
     if ( Current > 9 ) fEventList->Expand(150);
-    fEventList->AddAt(new WCSimRootTrigger(num,Current),Current);
+    int num = ((WCSimRootTrigger*)fEventList->At(0))->GetHeader()->GetEvtNum();
+    new((*fEventList)[Current]) WCSimRootTrigger(num,Current);
   }
   
-  /*  void ReInitialize() { // need to remove all subevents at the end, or they just get added anyway...
-    std::vector<WCSimRootTrigger*>::iterator  iter = fEventList.begin();
-    ++iter; // do not delete the first event --> regular beaviour for this program ?
-  */
   void Initialize();
 
-  void ReInitialize() { // need to remove all subevents at the end, or they just get added anyway...
-    for ( int i = fEventList->GetLast() ; i>=1 ; i--) {
-      //      G4cout << "removing element # " << i << "...";
-      WCSimRootTrigger* tmp = 
-	dynamic_cast<WCSimRootTrigger*>(fEventList->RemoveAt(i));
-      delete tmp;
-      //G4cout <<"done !\n";
-    }
+  void ReInitialize() { 
     Current = 0;
-    WCSimRootTrigger* tmp = dynamic_cast<WCSimRootTrigger*>( (*fEventList)[0]);
-    tmp->Clear();
+    fEventList->Clear();
+    new((*fEventList)[Current]) WCSimRootTrigger(-99,Current);
   }
 
 private:
-  //std::vector<WCSimRootTrigger*> fEventList;
-  TObjArray* fEventList;
+  TClonesArray* fEventList;
   Int_t Current;                      //!               means transient, not writable to file
   ClassDef(WCSimRootEvent,1)
-
 };
 
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -387,7 +387,7 @@ public:
 private:
   TClonesArray* fEventList;
   Int_t Current;                      //!               means transient, not writable to file
-  ClassDef(WCSimRootEvent,2)
+  ClassDef(WCSimRootEvent,1)
 };
 
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -387,7 +387,7 @@ public:
 private:
   TClonesArray* fEventList;
   Int_t Current;                      //!               means transient, not writable to file
-  ClassDef(WCSimRootEvent,1)
+  ClassDef(WCSimRootEvent,2)
 };
 
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -359,6 +359,7 @@ public:
 
   void          Clear(Option_t *option ="");
   static void   Reset(Option_t *option ="");
+  Int_t GetCurrentIndex() { return Current;}
 
         WCSimRootTrigger * GetTrigger(int number)       { return (WCSimRootTrigger*) fEventList->At(number);}
   const WCSimRootTrigger * GetTrigger(int number) const { return (WCSimRootTrigger*) fEventList->At(number);}
@@ -368,21 +369,24 @@ public:
   bool HasSubEvents() { return  (fEventList->GetEntries() > 1); }
 
   void AddSubEvent() { 
-    int evt_num  = GetTrigger(0)->GetHeader()->GetEvtNum();
-    int trig_num = GetNumberOfEvents();
     // be sure not to call the default constructor BUT the actual one
-    new((*fEventList)[trig_num]) WCSimRootTrigger(evt_num, trig_num);
+    ++Current;
+    if ( Current > 9 ) fEventList->Expand(150);
+    int num = ((WCSimRootTrigger*)fEventList->At(0))->GetHeader()->GetEvtNum();
+    new((*fEventList)[Current]) WCSimRootTrigger(num,Current);
   }
   
   void Initialize();
 
   void ReInitialize() { 
+    Current = 0;
     fEventList->Clear();
-    new((*fEventList)[0]) WCSimRootTrigger(-99,0);
+    new((*fEventList)[Current]) WCSimRootTrigger(-99,Current);
   }
 
 private:
   TClonesArray* fEventList;
+  Int_t Current;                      //!               means transient, not writable to file
   ClassDef(WCSimRootEvent,2)
 };
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -359,7 +359,6 @@ public:
 
   void          Clear(Option_t *option ="");
   static void   Reset(Option_t *option ="");
-  Int_t GetCurrentIndex() { return Current;}
 
         WCSimRootTrigger * GetTrigger(int number)       { return (WCSimRootTrigger*) fEventList->At(number);}
   const WCSimRootTrigger * GetTrigger(int number) const { return (WCSimRootTrigger*) fEventList->At(number);}
@@ -369,24 +368,21 @@ public:
   bool HasSubEvents() { return  (fEventList->GetEntries() > 1); }
 
   void AddSubEvent() { 
+    int evt_num  = GetTrigger(0)->GetHeader()->GetEvtNum();
+    int trig_num = GetNumberOfEvents();
     // be sure not to call the default constructor BUT the actual one
-    ++Current;
-    if ( Current > 9 ) fEventList->Expand(150);
-    int num = ((WCSimRootTrigger*)fEventList->At(0))->GetHeader()->GetEvtNum();
-    new((*fEventList)[Current]) WCSimRootTrigger(num,Current);
+    new((*fEventList)[trig_num]) WCSimRootTrigger(evt_num, trig_num);
   }
   
   void Initialize();
 
   void ReInitialize() { 
-    Current = 0;
     fEventList->Clear();
-    new((*fEventList)[Current]) WCSimRootTrigger(-99,Current);
+    new((*fEventList)[0]) WCSimRootTrigger(-99,0);
   }
 
 private:
   TClonesArray* fEventList;
-  Int_t Current;                      //!               means transient, not writable to file
   ClassDef(WCSimRootEvent,2)
 };
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -144,6 +144,7 @@ public:
   bool CompareAllVariables(const WCSimRootCherenkovDigiHit * c) const;
 
   void SetT(float t) { fT = t; }
+  void SetPhotonIds(std::vector<int> photon_ids) { fPhotonIds = photon_ids; }
   Float_t     GetQ() const { return fQ;}
   Float_t     GetT() const { return fT;}
   Int_t       GetTubeId() const { return fTubeId;}

--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -343,6 +343,11 @@ private:
   ///Calls the workhorse of this class: AlgNoTrigger
   void DoTheWork(WCSimWCDigitsCollection* WCDCPMT);
   
+  bool GetDefaultMultiDigitsPerTrigger()    { return true;  } ///< We want to save everything
+  int  GetDefaultNDigitsWindow()            { return 0;     } ///< This is not an NDigits trigger
+  int  GetDefaultNDigitsThreshold()         { return 0;     } ///< This is not an NDigits trigger
+  int  GetDefaultNDigitsPreTriggerWindow()  { return 0;     } ///< This is not an NDigits trigger
+  int  GetDefaultNDigitsPostTriggerWindow() { return 0;     } ///< This is not an NDigits trigger
 };
 
 /**

--- a/sample-root-scripts/kin_converter.py
+++ b/sample-root-scripts/kin_converter.py
@@ -1,0 +1,28 @@
+#!/bin/env python2
+
+import argparse
+
+parser = argparse.ArgumentParser(description='KinConverter: convert kin files that have multiple events into a single event')
+parser.add_argument('--infilename','-i',required=True,type=str,help='Input .kin filename. Output filename will be the same as the input filename & path, with a .single suffix added')
+args = parser.parse_args()
+
+outfilename = args.infilename + '.single'
+foundbegin = False
+with open(args.infilename, 'r') as fin, open(outfilename, 'w') as fout:
+    for line in fin:
+        split = line.split()
+        #we only need the first begin
+        if 'begin' in split:
+            if not foundbegin:
+                foundbegin = True
+            else:
+                continue
+        #we only need the last begin...
+        elif 'end' in split:
+            continue
+        #... which occurs just before the stop
+        elif 'stop' in split:
+            fout.write('$ end\n')
+        #write the line
+        fout.write(line)
+

--- a/src/WCSimEnumerations.cc
+++ b/src/WCSimEnumerations.cc
@@ -25,6 +25,9 @@ std::string WCSimEnumerations::EnumAsString(TriggerType_t t)
   case (kTriggerNDigitsTest) :
     return "NDigits_TEST";
     break;
+  case (kTriggerTestVertices) :
+    return "TestVertices";
+    break;
   case (kTriggerFailure) :
     return "No_trigger_passed";
     break;

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -43,19 +43,20 @@
 
 #ifndef _SAVE_RAW_HITS
 #define _SAVE_RAW_HITS
-#ifndef _SAVE_RAW_HITS_VERBOSE
+//Use this and one/two of below to debug hit information
 //#define _SAVE_RAW_HITS_VERBOSE
 #endif
-#endif
-#ifndef SAVE_DIGITS_VERBOSE
+
+//Use this and one/two of below to debug digit information
 //#define SAVE_DIGITS_VERBOSE
-#endif
+
+//Print out hits with PMT IDs up to N
+#define NPMTS_VERBOSE -1
+//And/Or a specific PMT ID
+#define VERBOSE_PMT -1
+
 #ifndef TIME_DAQ_STEPS
 //#define TIME_DAQ_STEPS
-#endif
-
-#ifndef NPMTS_VERBOSE
-#define NPMTS_VERBOSE 10
 #endif
 
 WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
@@ -1088,14 +1089,14 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 #endif
       }//id
 #ifdef _SAVE_RAW_HITS_VERBOSE
-      if(digi_tubeid < NPMTS_VERBOSE) {
+      if(digi_tubeid < NPMTS_VERBOSE || digi_tubeid == VERBOSE_PMT) {
 	G4cout << "Adding " << truetime.size()
 	       << " Cherenkov hits in tube " << digi_tubeid
 	       << " with truetime:smeartime:primaryparentID";
 	for(G4int id = 0; id < truetime.size(); id++) {
 	  G4cout << " " << truetime[id]
-		 << ":" << smeartime[id]
-		 << ":" << primaryParentID[id];
+		 << "\t" << smeartime[id]
+		 << "\t" << primaryParentID[id] << G4endl;
 	}//id
 	G4cout << G4endl;
       }
@@ -1137,7 +1138,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 	      assert(vec_pe.size() == vec_digicomp.size());
 	      for(unsigned int iv = 0; iv < vec_pe.size(); iv++) {
 #ifdef SAVE_DIGITS_VERBOSE
-		if(tubeID < NPMTS_VERBOSE) {
+		if(tubeID < NPMTS_VERBOSE || digi_tubeid == VERBOSE_PMT) {
 		  G4cout << "Adding digit " << iv 
 			 << " for PMT " << tubeID
 			 << " pe "   << vec_pe[iv]

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -541,13 +541,11 @@ WCSimRootEvent::WCSimRootEvent()
   // this is standard root practise for streaming ROOT objtecs : if memory is alloc'ed here,
   // it will be lost
   fEventList = 0;
-  Current = 0;
 }
 
 WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 {
   //this->Clear();
-  Current = in.Current;
   fEventList = (TClonesArray*)in.fEventList->Clone();
   return *this;
 }
@@ -555,8 +553,7 @@ WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 void WCSimRootEvent::Initialize()
 {
   fEventList = new TClonesArray("WCSimRootTrigger",10); // very rarely more than 10 subevents...
-  Current = 0;
-  new((*fEventList)[Current]) WCSimRootTrigger(0,Current);
+  ReInitialize();
 }
 
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -194,8 +194,6 @@ WCSimRootTrigger & WCSimRootTrigger::operator=(const WCSimRootTrigger & in)
   fTriggerType = in.fTriggerType;
   fTriggerInfo = in.fTriggerInfo;
   IsZombie = in.IsZombie;
-
-  return *this;
 }
 
 //_____________________________________________________________________________
@@ -220,10 +218,10 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   // remove whatever's in the arrays
   // but don't deallocate the arrays themselves
 
-  fTracks->Clear();
-  fCherenkovHits->Clear();
-  fCherenkovHitTimes->Clear();
-  fCherenkovDigiHits->Clear();
+  fTracks->Delete();
+  fCherenkovHits->Delete();
+  fCherenkovHitTimes->Delete();
+  fCherenkovDigiHits->Delete();
 
   fTriggerType = kTriggerUndefined;
   fTriggerInfo.clear();
@@ -546,24 +544,25 @@ WCSimRootEvent::WCSimRootEvent()
 
 WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 {
-  //this->Clear();
+  this->Clear();
   Current = in.Current;
   fEventList = (TClonesArray*)in.fEventList->Clone();
-  return *this;
 }
 
 void WCSimRootEvent::Initialize()
 {
-  fEventList = new TClonesArray("WCSimRootTrigger",10); // very rarely more than 10 subevents...
+  fEventList = new TObjArray(10,0); // very rarely more than 10 subevents...
+  fEventList->AddAt(new WCSimRootTrigger(0,0),0);
   Current = 0;
-  new((*fEventList)[Current]) WCSimRootTrigger(0,Current);
 }
 
 
 WCSimRootEvent::~WCSimRootEvent()
 {
   if (fEventList != 0) {
-    fEventList->Delete();
+    for (int i = 0 ; i < fEventList->GetEntriesFast() ; i++) {
+      delete (*fEventList)[i];
+    }
     delete fEventList;
   }
   //  std::vector<WCSimRootTrigger*>::iterator  iter = fEventList.begin();
@@ -573,7 +572,7 @@ WCSimRootEvent::~WCSimRootEvent()
 
 void WCSimRootEvent::Clear(Option_t* /*o*/)
 {
-  fEventList->Clear();
+  //nothing for now
 }
 
 void WCSimRootEvent::Reset(Option_t* /*o*/)

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -194,6 +194,8 @@ WCSimRootTrigger & WCSimRootTrigger::operator=(const WCSimRootTrigger & in)
   fTriggerType = in.fTriggerType;
   fTriggerInfo = in.fTriggerInfo;
   IsZombie = in.IsZombie;
+
+  return *this;
 }
 
 //_____________________________________________________________________________
@@ -218,10 +220,10 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   // remove whatever's in the arrays
   // but don't deallocate the arrays themselves
 
-  fTracks->Delete();
-  fCherenkovHits->Delete();
-  fCherenkovHitTimes->Delete();
-  fCherenkovDigiHits->Delete();
+  fTracks->Clear();
+  fCherenkovHits->Clear();
+  fCherenkovHitTimes->Clear();
+  fCherenkovDigiHits->Clear();
 
   fTriggerType = kTriggerUndefined;
   fTriggerInfo.clear();
@@ -544,25 +546,24 @@ WCSimRootEvent::WCSimRootEvent()
 
 WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 {
-  this->Clear();
+  //this->Clear();
   Current = in.Current;
   fEventList = (TClonesArray*)in.fEventList->Clone();
+  return *this;
 }
 
 void WCSimRootEvent::Initialize()
 {
-  fEventList = new TObjArray(10,0); // very rarely more than 10 subevents...
-  fEventList->AddAt(new WCSimRootTrigger(0,0),0);
+  fEventList = new TClonesArray("WCSimRootTrigger",10); // very rarely more than 10 subevents...
   Current = 0;
+  new((*fEventList)[Current]) WCSimRootTrigger(0,Current);
 }
 
 
 WCSimRootEvent::~WCSimRootEvent()
 {
   if (fEventList != 0) {
-    for (int i = 0 ; i < fEventList->GetEntriesFast() ; i++) {
-      delete (*fEventList)[i];
-    }
+    fEventList->Delete();
     delete fEventList;
   }
   //  std::vector<WCSimRootTrigger*>::iterator  iter = fEventList.begin();
@@ -572,7 +573,7 @@ WCSimRootEvent::~WCSimRootEvent()
 
 void WCSimRootEvent::Clear(Option_t* /*o*/)
 {
-  //nothing for now
+  fEventList->Clear();
 }
 
 void WCSimRootEvent::Reset(Option_t* /*o*/)

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -541,11 +541,13 @@ WCSimRootEvent::WCSimRootEvent()
   // this is standard root practise for streaming ROOT objtecs : if memory is alloc'ed here,
   // it will be lost
   fEventList = 0;
+  Current = 0;
 }
 
 WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 {
   //this->Clear();
+  Current = in.Current;
   fEventList = (TClonesArray*)in.fEventList->Clone();
   return *this;
 }
@@ -553,7 +555,8 @@ WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 void WCSimRootEvent::Initialize()
 {
   fEventList = new TClonesArray("WCSimRootTrigger",10); // very rarely more than 10 subevents...
-  ReInitialize();
+  Current = 0;
+  new((*fEventList)[Current]) WCSimRootTrigger(0,Current);
 }
 
 

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -4,9 +4,12 @@
 
 // for memset
 
-#ifndef NPMTS_VERBOSE
-#define NPMTS_VERBOSE 10
-#endif
+//Use this and one/two of below to debug hit information
+//#define WCSIMWCDIGITIZER_VERBOSE
+//Print out hits with PMT IDs up to N
+#define NPMTS_VERBOSE -1
+//And/Or a specific PMT ID
+#define VERBOSE_PMT -1
 
 #ifndef HYPER_VERBOSITY
 // #define HYPER_VERBOSITY
@@ -15,10 +18,6 @@
 // *******************************************
 // BASE CLASS
 // *******************************************
-
-#ifndef WCSIMWCDIGITIZER_VERBOSE
-//#define WCSIMWCDIGITIZER_VERBOSE
-#endif
 
 WCSimWCDigitizerBase::WCSimWCDigitizerBase(G4String name,
 										   WCSimDetectorConstruction* inDetector,
@@ -124,7 +123,7 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, float digihittime, fl
   //gate is not a trigger, but just the position of the digit in the array
   //inside the WCSimWCDigi object
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-  if(tube < NPMTS_VERBOSE) {
+  if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT) {
     G4cout<<"Adding hit "<<gate<<" in tube "<<tube
 	  << " with time " << digihittime_d << " charge " << peSmeared_d
 	  << " (truncated from t: " << digihittime << " q: " << peSmeared << ")"
@@ -146,7 +145,7 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, float digihittime, fl
 	Digi->AddDigiCompositionInfo(digi_comp);
 	DigiStoreHitMap[tube] = DigiStore->insert(Digi);
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-	if(tube < NPMTS_VERBOSE)
+	if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	  G4cout << " NEW HIT" << G4endl;
 #endif
       }
@@ -156,7 +155,7 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, float digihittime, fl
 	(*DigiStore)[DigiStoreHitMap[tube]-1]->AddPe(digihittime_d);
 	(*DigiStore)[DigiStoreHitMap[tube]-1]->AddDigiCompositionInfo(digi_comp);
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-	if(tube < NPMTS_VERBOSE)
+	if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	  G4cout << " DEJA VU" << G4endl;
 #endif
       }
@@ -164,7 +163,7 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, float digihittime, fl
   }//peSmeared > 0
   else {
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-    if(tube < NPMTS_VERBOSE)
+    if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
       G4cout << "DIGIT REJECTED with charge " << peSmeared_d
 	     << " time " << digihittime_d << G4endl;
 #endif
@@ -223,7 +222,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
       (*WCHCPMT)[i]->SortArrayByHitTime();
       int tube = (*WCHCPMT)[i]->GetTubeID();
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-      if(tube < NPMTS_VERBOSE) {
+      if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT) {
 	G4cout << "tube " << tube
 	       << " totalpe = " << (*WCHCPMT)[i]->GetTotalPe()
 	       << " times";
@@ -269,7 +268,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	  }
 	  
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-	  if(tube < NPMTS_VERBOSE)
+	  if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	    G4cout << "ip "    << ip
 		   << " pe "   << pe
 		   << " time " << time
@@ -285,7 +284,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	    digi_comp.push_back(photon_unique_id);
       
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-	    if(tube < NPMTS_VERBOSE)
+	    if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	      G4cout<<"INFO: time "<<time<<" digi_id "<<digi_unique_id<<" p_id "<<photon_unique_id<<G4endl;
 #endif
 	    //if this is the last digit, make sure to make the digit
@@ -325,7 +324,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	    else {
 	      //reject hit
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-	      if(tube < NPMTS_VERBOSE)
+	      if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 		G4cout << "DIGIT REJECTED with time " << intgr_start << G4endl;
 #endif
 	      digi_comp.clear();
@@ -340,7 +339,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	  }
 	  else if(time > upperlimit + DigitizerDeadTime){
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-	    if(tube < NPMTS_VERBOSE)
+	    if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	      G4cout<<"*** PREPARING FOR >1 DIGI ***"<<G4endl;
 #endif
 	    //we now need to start integrating from the hit
@@ -375,7 +374,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	      else {
 		//reject hit
 #ifdef WCSIMWCDIGITIZER_VERBOSE
-		if(tube < NPMTS_VERBOSE)
+		if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 		  G4cout << "DIGIT REJECTED with time " << intgr_start << G4endl;
 #endif
 		digi_comp.clear();

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -596,6 +596,7 @@ WCSimWCTriggerNoTrigger::WCSimWCTriggerNoTrigger(G4String name,
   :WCSimWCTriggerBase(name, myDetector, myMessenger, detectorElement)
 {
   triggerClassName = "NoTrigger";
+  GetVariables();
 }
 
 WCSimWCTriggerNoTrigger::~WCSimWCTriggerNoTrigger()


### PR DESCRIPTION
There's a massive memory leak when reading a WCSim root file, just doing a simple`GetEntry()` when the `WCSimRootEvent` branch is active. This was noticed when running on large (>1000) event files.
This fixes that by using a `TClonesArray` instead of `TObjArray`, and by using `Delete()`/`Clear()` appropriately
When viewing the running with htop, the memory use now stays constant at 0.1% precision over 10000 events, instead of adding about 5% memory use with every ~1000 events.

The output is identical (tested by grepping the output of `sample_readfile.C` from a 20 MeV electron file with 10 events and NoTrigger trigger - unfortunately `complete_comparison.C` won't work due to the `WCSimRootEvent` redefinition)

I also noticed that WCSimRootOptions is filled with junk for the NoTrigger trigger - I've set these to sensible values now