### PR TITLE
Fix typos in `movedict` part of Makefiles

### DIFF
--- a/GNUmakefile_full
+++ b/GNUmakefile_full
@@ -71,7 +71,7 @@ libWCSim.a : $(ROOTOBJS)
 rootcint: ./src/WCSimRootDict.cc
 
 movedict: rootcint
-ifneq (,$$(wildcard ./src/WCSimRootDict_rdict.pcm))
+ifneq (,$(wildcard ./src/WCSimRootDict_rdict.pcm))
 	cp -f ./src/WCSimRootDict_rdict.pcm .
 	cp -f ./src/WCSimRootDict_rdict.pcm ${G4WORKDIR}/tmp/${G4SYSTEM}/WCSim/
 endif

--- a/GNUmakefile_root
+++ b/GNUmakefile_root
@@ -53,7 +53,7 @@ libWCSimRoot.so : $(ROOTOBJS)
 rootcint: ./src/WCSimRootDict.cc
 
 movedict: rootcint
-ifneq (,$$(wildcard ./src/WCSimRootDict_rdict.pcm))
+ifneq (,$(wildcard ./src/WCSimRootDict_rdict.pcm))
 	cp -f ./src/WCSimRootDict_rdict.pcm .
 	cp -f ./src/WCSimRootDict_rdict.pcm ${G4TMPDIR}
 endif


### PR DESCRIPTION
Sorry about this @eosullivan, but #286 has some typos in the Makefiles, causing `make` to report an error at the `movedict` stage (even though everything is successfully built). I've made sure to test now
- With ROOT5, build doesn't error
- With ROOT6, the `.pcm` file is still correctly copied