### PR TITLE
Fix missing events when using kin_converter.py & upgrade to support Python 3.x

### DIFF
--- a/sample-root-scripts/MakeKin.py
+++ b/sample-root-scripts/MakeKin.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
-# import the math module  
-import math  
-  
+from __future__ import print_function
+
 from optparse import OptionParser
 import random
 from math import pi,sin,cos,sqrt
@@ -21,7 +20,7 @@ detectors = {"SuperK":[3368.15/2., 3620.],
              "Cylinder_60x74_20inchBandL_14perCent":[7400./2., 6000.],
              "Cylinder_60x74_20inchBandL_40perCent":[7400./2., 6000.]}
 
-for pname, no in pid.items():
+for pname, no in list(pid.items()):
     if pname.endswith('+'):
         pid[pname.replace('+','-')] = -1*pid[pname]
 
@@ -45,7 +44,7 @@ parser.add_option("-V","--nVerticesPerEvent",dest="verticesPerEvent",
                   help=" Average number of vertices to simulate per event. Default: %s" \
                   % (verticesPerEventDefault),
                   metavar="#", default=verticesPerEventDefault)
-optchoices = pid.keys()
+optchoices = list(pid.keys())
 optdefault = "mu-"
 parser.add_option("-t", "--type", dest="type",
                   help="Particle type to be generated. Choices: %s. Default: %s" \
@@ -69,7 +68,7 @@ parser.add_option("-d", "--direction", dest="dirname",
                   help="Type of direction. Choices: %s. Default: %s" \
                       % (optchoices, optdefault),
                   choices=optchoices, default=optdefault)
-optchoices = detectors.keys()
+optchoices = list(detectors.keys())
 optdefault = "SuperK"
 parser.add_option("-w", "--detector", dest="detector",
                   help="Detector water volume to use (for vertex positioning). Choices: %s. Default: %s" \
@@ -103,7 +102,7 @@ if options.vertname == "center":
 elif options.vertname == "random":
     randvert = True
 elif options.vertname == "wall":
-    print >>sys.stderr, "Wall not implemented yet"
+    print("Wall not implemented yet", file=sys.stderr)
     sys.exit(3)
 elif options.vertname == "minusx":
     if options.detector == "SuperK":
@@ -126,7 +125,7 @@ elif options.vertname == "plusz":
     else:
         particle["vertex"] = (0, 0, +1000. * detectors[options.detector][1] / detectors["SuperK"][1])
 else:
-    print >>sys.stderr, "Don't understand vertex",opttions.vertname
+    print("Don't understand vertex", options.vertname, file=sys.stderr)
     sys.exit(2)
 
 if options.dirname == "towall":
@@ -138,10 +137,10 @@ elif options.dirname == "tocap":
 elif options.dirname == "4pi":
     randdir = True
 elif options.dirname == "wall":
-    print >>sys.stderr, "Wall not implemented yet"
+    print("Wall not implemented yet", file=sys.stderr)
     sys.exit(3)
 else:
-    print >>sys.stderr, "Don't understand direction",options.dirname
+    print("Don't understand direction", options.dirname, file=sys.stderr)
     sys.exit(2)
 
 
@@ -207,14 +206,14 @@ for fileno in range(nfiles):
     outfile = open(filename, 'w')
 
     if(verticesPerEvent == 1 ) :
-      print ("Writing %i particles to " % npart) + filename
+      print("Writing", npart, "particles to", filename)
 
       for i in range(npart):
         partPrint(particle, outfile, i)
     else :
-      print ("Writing %i particles to with an average of %i vertices per event to " % (npart,verticesPerEvent) ) + filename
+      print("Writing", npart, "particles with an average of", verticesPerEvent, "vertices per event to", filename)
       numberDone = 0
-      sigma=math.sqrt(verticesPerEvent)
+      sigma = sqrt(verticesPerEvent)
       while numberDone < npart:
         numberToProcess = int(round(random.gauss(verticesPerEvent,sigma)))
         eventPrint(numberToProcess,particle,outfile,numberDone)

--- a/sample-root-scripts/MakeKin.py
+++ b/sample-root-scripts/MakeKin.py
@@ -18,7 +18,8 @@ pid = {"pi0":111, "pi+":211, "k0l":130, "k0s":310, "k+":321,
 #holds detector [radius, height] in cm
 detectors = {"SuperK":[3368.15/2., 3620.],
              "Cylinder_60x74_20inchBandL_14perCent":[7400./2., 6000.],
-             "Cylinder_60x74_20inchBandL_40perCent":[7400./2., 6000.]}
+             "Cylinder_60x74_20inchBandL_40perCent":[7400./2., 6000.],
+             "HyperK":[7080./2., 5480.]}
 
 for pname, no in list(pid.items()):
     if pname.endswith('+'):
@@ -45,6 +46,11 @@ parser.add_option("-V","--nVerticesPerEvent",dest="verticesPerEvent",
                   % (verticesPerEventDefault),
                   metavar="#", default=verticesPerEventDefault)
 optchoices = list(pid.keys())
+optdefault = None
+parser.add_option("-s", "--seed", dest="seed",
+                  help="Random number seed to use. Default: None (use system time)",
+                  metavar="SEED", default=optdefault)
+optchoices = pid.keys()
 optdefault = "mu-"
 parser.add_option("-t", "--type", dest="type",
                   help="Particle type to be generated. Choices: %s. Default: %s" \

--- a/sample-root-scripts/MakeKin.py
+++ b/sample-root-scripts/MakeKin.py
@@ -45,12 +45,11 @@ parser.add_option("-V","--nVerticesPerEvent",dest="verticesPerEvent",
                   help=" Average number of vertices to simulate per event. Default: %s" \
                   % (verticesPerEventDefault),
                   metavar="#", default=verticesPerEventDefault)
-optchoices = list(pid.keys())
 optdefault = None
 parser.add_option("-s", "--seed", dest="seed",
-                  help="Random number seed to use. Default: None (use system time)",
+                  help="Random number seed to use. Default: None.",
                   metavar="SEED", default=optdefault)
-optchoices = pid.keys()
+optchoices = list(pid.keys())
 optdefault = "mu-"
 parser.add_option("-t", "--type", dest="type",
                   help="Particle type to be generated. Choices: %s. Default: %s" \
@@ -86,7 +85,7 @@ parser.add_option("-w", "--detector", dest="detector",
 options.vertname = options.vertname.lower()
 options.dirname = options.dirname.lower()
 
-
+random.seed(options.seed)
 
 nfiles = int(options.nfiles)
 npart = int(options.npart)

--- a/sample-root-scripts/kin_converter.py
+++ b/sample-root-scripts/kin_converter.py
@@ -1,5 +1,7 @@
 #!/bin/env python2
 
+from __future__ import print_function
+
 import argparse
 import sys
 from datetime import datetime
@@ -72,16 +74,16 @@ def IsTimeOrdered(filename):
                 last_time = float(GetTime(vertex))
             this_time = float(GetTime(vertex))
             if this_time < last_time:
-                print PrintNS(this_time), "comes before", PrintNS(last_time)
+                print(PrintNS(this_time), "comes before", PrintNS(last_time))
                 return False
-    print "Is time ordered"
+    print("Is time ordered")
     return True
 
 #Sort the initial file by time
 def SortByTime(filename):
     outfilename = args.input_filename + '.temp'
     with open(filename, 'r') as fin, open(outfilename, 'w') as fout:
-        print 'TODO SortByTime() not yet implemented'
+        print('TODO SortByTime() not yet implemented')
         sys.exit(-1)
 
 #Get the header
@@ -104,7 +106,7 @@ if not IsTimeOrdered(args.input_filename):
     SortByTime(args.input_filename)
 
 header = GetHeader(args.input_filename, args)
-print header
+print(header)
 
 
 #loop over kin file start/stop times
@@ -115,7 +117,7 @@ file_position = 0
 while event_start < last_event_end:
     event_end = event_start + args.fixed_duration
     next_event_start = event_start + args.fixed_duration - args.event_overlap
-    print "Event", ievent, "corresponds to range", PrintNS(event_start), PrintNS(event_end)
+    print("Event", ievent, "corresponds to range", PrintNS(event_start), PrintNS(event_end))
     with open(args.input_filename, 'r') as fin, open(args.input_filename + '.%09d' % ievent, 'w') as fout:
         #write the original header
         fout.write(header)
@@ -128,7 +130,7 @@ while event_start < last_event_end:
         nvertices = 0
         #skip forward in the file a bit
         if args.verbose:
-            print 'Skipping to position in file', file_position
+            print('Skipping to position in file', file_position)
         fin.seek(file_position)
         #loop over the input file
         for i, vertex in enumerate(GetVertex(fin, "$ begin", ["$ begin", "$ end"])):
@@ -138,10 +140,10 @@ while event_start < last_event_end:
             #get the event time
             time = GetTime(vertex)
             if args.verbose > 1:
-                print PrintNS(time)
+                print(PrintNS(time))
                 if args.verbose > 2:
-                    print ("Vertex #{}".format(i))
-                    print ("".join(vertex))
+                    print("Vertex #{}".format(i))
+                    print("".join(vertex))
             if time > event_end:
                 break
             if time >= event_start:
@@ -157,7 +159,7 @@ while event_start < last_event_end:
         #and close the event/file
         fout.write('$ end\n')
         fout.write('$ stop\n')
-        print 'contains', nvertices, 'vertices'
+        print('contains', nvertices, 'vertices')
     #increment for next event
     event_start = next_event_start
     ievent += 1

--- a/sample-root-scripts/kin_converter.py
+++ b/sample-root-scripts/kin_converter.py
@@ -44,6 +44,8 @@ $ track -11 0.511 0 0 0 0
 def GetVertex(seq, group_by, exclude=['']):
     data = []
     for line in seq:
+        if isinstance(line, bytes):
+            line = line.decode()
         if line.startswith(group_by):
             if data:
                 yield data
@@ -118,7 +120,7 @@ while event_start < last_event_end:
     event_end = event_start + args.fixed_duration
     next_event_start = event_start + args.fixed_duration - args.event_overlap
     print("Event", ievent, "corresponds to range", PrintNS(event_start), PrintNS(event_end))
-    with open(args.input_filename, 'r') as fin, open(args.input_filename + '.%09d' % ievent, 'w') as fout:
+    with open(args.input_filename, 'rb') as fin, open(args.input_filename + '.%09d' % ievent, 'w') as fout:
         #write the original header
         fout.write(header)
         #write the dark noise range


### PR DESCRIPTION
I encountered an issue where kin_converter.py appears to leave out some events (using the current develop branch of WCSim). See steps to reproduce at the end of this post.

I suspect this is due to the seek position in the file being off due to conflicts between manual use of the `seek` and `tell` functions and automatically iterating over lines in the file in the GetVertex function. ([some background](https://stackoverflow.com/a/29641787))

This problem appears to be specific to Python 2.x; in this PR, I’ve made some changes to allow the code to run under Python 3.x where it produces the expected results.

<s>Note: Currently, the code runs under both Python 2.x and Python 3.x, but gives different results. To avoid issues and confusion, we should probably add a check and quit early if it is run under Python 2.x—what do you think?</s> [Edit: see Tom’s comment below]

@eosullivan @tdealtry @sk1806 I think this will affect the supernova test production; so it would be good if you could take a look at this as soon as possible!


Full details of the issue, including sample output:
```
> sntools path/to/intp2001.data -f nakazato --start 100 --end 103 -v --out outfile.kin

[output omitted]

> tail outfile.kin 

$ begin
$ nuance -1001001
$ vertex -2673.54751 1805.73575 -1853.35047 102.97220016
$ track -12 44.34931 0.00000 0.00000 1.00000 -1
$ track 2212 938.27231 0.00000 0.00000 1.00000 -1
$ info 0 0 166
$ track -11 41.41111 -0.07745 0.98407 0.16005 0
$ track 2112 941.21051 0.05766 -0.73261 0.67820 0
$ end
$ stop
```

➔ So there are 167 events in total. (Note the "info" line!)

```
$ python2.7 kin_converter.py --input-filename outfile.kin --input-time-unit ms --dark-noise-start 100000000 --dark-noise-end 103000000 --event-overlap 0 --v 1 --fixed-duration 1000000

Is time ordered
# Generated on 2020-09-23 14:55:39.443669 with the options:
# Namespace(channel='all', detector='HyperK', distance=10.0, endtime=103.0, format='nakazato', hierarchy='noosc', input_file='../../../Astro/sntools/fluxes/intp2001.data', output='outfile.kin', randomseed=None, starttime=100.0, verbose=1)
# Split by kin_converter 2020-09-23 14:57:53.468352
# --fixed-duration 1000000
# --event-overlap 0

Event 0 corresponds to range 100.000000 ms 101.000000 ms
Skipping to position in file 0
contains 53 vertices
Event 1 corresponds to range 101.000000 ms 102.000000 ms
Skipping to position in file 18432
contains 44 vertices
Event 2 corresponds to range 102.000000 ms 103.000000 ms
Skipping to position in file 36864
contains 43 vertices
```
➔ Note that the total number of events is now 53 + 44 + 43 = 140, so 27 events have gone missing? And indeed:

```
> tail outfile.kin.000000000

$ track 2112 940.99432 -0.01142 -0.82586 0.56375 0
$ nuance -1001001
$ vertex 1809.43467 2232.02952 3283.42538 100.97875478
$ track -12 12.18543 0.00000 0.00000 1.00000 -1
$ track 2212 938.27231 0.00000 0.00000 1.00000 -1
$ info 0 0 52
$ track -11 10.82326 0.06939 -0.85369 0.51614 0
$ track 2112 939.63448 -0.06596 0.81142 0.58073 0
$ end
$ stop

> head -n 14 outfile.kin.000000001
# Generated on 2020-09-23 14:55:39.443669 with the options:
# Namespace(channel='all', detector='HyperK', distance=10.0, endtime=103.0, format='nakazato', hierarchy='noosc', input_file='../../../Astro/sntools/fluxes/intp2001.data', output='outfile.kin', randomseed=None, starttime=100.0, verbose=1)
# Split by kin_converter 2020-09-23 14:57:53.468352
# --fixed-duration 1000000
# --event-overlap 0
# Event 1
# /DarkRate/SetDarkLow  101000000
# /DarkRate/SetDarkHigh 102000000
$ begin
$ nuance -1001001
$ vertex -1020.49160 -1717.83248 -145.20323 101.10556478
$ track -12 28.98788 0.00000 0.00000 1.00000 -1
$ track 2212 938.27231 0.00000 0.00000 1.00000 -1
$ info 0 0 62
```
➔ So the events with numbers 53 to 61 appear to have gone missing?