### PR TITLE
Increase buffer size for reading in lines of kin file

### DIFF
--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -40,6 +40,8 @@ inline vector<string> readInLine(fstream& inFile, int lineSize, char* inBuf)
 		}
 		else
 		{
+		  if(infile.fail())
+		    G4cerr << "Failed to read line. Is the buffer size large enough?" << G4endl;
 			vector<string> nullLine;                               
 			return nullLine; 
 		}
@@ -141,7 +143,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     //
     if (useNuanceTextFormat)
     {
-    	const int lineSize=100;
+    	const int lineSize=1000;
     	char      inBuf[lineSize];
     	vector<string> token(1);
 
@@ -163,7 +165,6 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         // but could be just  
         // nuance 
 		// if value is given set mode to equal it.
-
 			token = readInLine(inputFile, lineSize, inBuf);
 			int iVertex=0;
 			while(token[0]=="nuance" && iVertex < MAX_N_VERTICES)

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -165,6 +165,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         // but could be just  
         // nuance 
 		// if value is given set mode to equal it.
+
 			token = readInLine(inputFile, lineSize, inBuf);
 			int iVertex=0;
 			while(token[0]=="nuance" && iVertex < MAX_N_VERTICES)


### PR DESCRIPTION
Increase "const int lineSize=100" to 1000 to handle longer header lines in kin files, particularly for SN production. Add informative error so problem is more easily identified in future (if 1000 isn't large enough).