### PR TITLE
[FIX] ROOT/CERN Randomizer initialization

### DIFF
--- a/include/WCSimRandomParameters.hh
+++ b/include/WCSimRandomParameters.hh
@@ -6,6 +6,7 @@
 #include "CLHEP/Random/RanluxEngine.h"
 #include "CLHEP/Random/JamesRandom.h"
 #include "CLHEP/Random/RanecuEngine.h"
+#include "TRandom3.h"
 
 class WCSimRandomParameters
 {
@@ -57,6 +58,7 @@ public:
   void SetSeed(int iseed) 
     { 
       CLHEP::HepRandom::setTheSeed(iseed);
+      gRandom->SetSeed(iseed);
       printf("Setting the Random Seed to: %d\n",iseed); 
       seed = iseed;
     }


### PR DESCRIPTION
Hi,

This is a fix it seems I forget to commit before: the issue is that ROOT/CERN Randomizer (used in the Rn generator for example) is not initialized properly and always keep the same value. Here, I set it to be the same value as the Geant4 Randomizer seed, allowing to change it at the same time, and so to have correct randomization (while keeping the possibility to reproduce the previous results).