### PR TITLE
Printf to g4cout

### DIFF
--- a/include/WCSimRandomParameters.hh
+++ b/include/WCSimRandomParameters.hh
@@ -27,14 +27,14 @@ public:
       {
         case RANDOM_E_RANLUX:
 	  {
-	    printf("Setting the random number generator to RANLUX\n");
+	    G4cout << "Setting the random number generator to RANLUX" << G4endl;
 	    CLHEP::RanluxEngine *newluxengine = new CLHEP::RanluxEngine(31415,4);  // highest luxury level
 	    CLHEP::HepRandom::setTheEngine(newluxengine);
 	  }
 	  break;
       case RANDOM_E_RANECU:
 	  {
-	    printf("Setting the random number generator to RANECU\n");
+	    G4cout << "Setting the random number generator to RANECU" << G4endl;
 	    CLHEP::RanecuEngine *newecuengine = new CLHEP::RanecuEngine();
 	    CLHEP::HepRandom::setTheEngine(newecuengine);
 	  }
@@ -42,14 +42,14 @@ public:
 	  
         case RANDOM_E_HEPJAMES:
 	  {
-	    printf("Setting the random number generator to HEPJAMES\n");
+	    G4cout << "Setting the random number generator to HEPJAMES" << G4endl;
 	    CLHEP::HepJamesRandom *newjamesengine = new CLHEP::HepJamesRandom();
 	    CLHEP::HepRandom::setTheEngine(newjamesengine);
 	  }  
 	  break;
       default:
 	{
-	  printf("Random number generator type not understood: %d\n",rng);
+	  G4cout << "Random number generator type not understood: " << rng << G4endl;
 	  exit(0);
 	}
       }
@@ -59,7 +59,7 @@ public:
     { 
       CLHEP::HepRandom::setTheSeed(iseed);
       gRandom->SetSeed(iseed);
-      printf("Setting the Random Seed to: %d\n",iseed); 
+      G4cout << "Setting the Random Seed to: " << iseed << G4endl;
       seed = iseed;
     }
 

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -445,7 +445,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
    // Get from the tuning parameters
    RAYFF = WCSimTuningParams->GetRayff();
-   //    printf("RAYFF: %f\n",RAYFF);
+   //    G4cout << "RAYFF: " << RAYFF << G4endl;
 
    //T. Akiri: Values from Skdetsim 
    G4double RAYLEIGH_water[NUMENTRIES_water] = {
@@ -490,7 +490,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
    // Get from the tuning parameters
    G4double MIEFF = WCSimTuningParams->GetMieff();
    //G4double MIEFF = 0.0;
-   //    printf("MIEFF: %f\n",MIEFF);
+   //    G4cout << "MIEFF: " << MIEFF << G4endl;
 
    //Values extracted from Skdetsim
    G4double MIE_water[NUMENTRIES_water] = {

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -70,51 +70,51 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 
   if(command == Rayff) {
 	  // Set the Rayleigh scattering parameter
-	  //	  printf("Input parameter %f\n",Rayff->GetNewDoubleValue(newValue));
+	  //	  G4cout << "Input parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
 
   WCSimTuningParams->SetRayff(Rayff->GetNewDoubleValue(newValue));
 
-  printf("Setting Rayleigh scattering parameter %f\n",Rayff->GetNewDoubleValue(newValue));
+  G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
 
   }
 
  if(command == Bsrff) {
 	  // Set the blacksheet reflection parameter
-	  //	  printf("Input parameter %f\n",Bsrff->GetNewDoubleValue(newValue));
+	  //	  G4cout << "Input parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
 
   WCSimTuningParams->SetBsrff(Bsrff->GetNewDoubleValue(newValue));
 
-  printf("Setting blacksheet reflection parameter %f\n",Bsrff->GetNewDoubleValue(newValue));
+  G4cout << "Setting blacksheet reflection parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
 
   }
 
  if(command == Abwff) {
 	  // Set the water attenuation  parameter
-	  //	  printf("Input parameter %f\n",Abwff->GetNewDoubleValue(newValue));
+	  //	  G4cout << "Input parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
 
   WCSimTuningParams->SetAbwff(Abwff->GetNewDoubleValue(newValue));
 
-  printf("Setting water attenuation parameter %f\n",Abwff->GetNewDoubleValue(newValue));
+  G4cout << "Setting water attenuation parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
 
   }
 
  if(command == Rgcff) {
 	  // Set the cathode reflectivity parameter
-	  //	  printf("Input parameter %f\n",Rgcff->GetNewDoubleValue(newValue));
+	  //	  G4cout << "Input parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
 
   WCSimTuningParams->SetRgcff(Rgcff->GetNewDoubleValue(newValue));
 
-  printf("Setting cathode reflectivity parameter %f\n",Rgcff->GetNewDoubleValue(newValue));
+  G4cout << "Setting cathode reflectivity parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
 
   }
 
  if(command == Mieff) {
 	  // Set the Mie scattering parameter
-	  //	  printf("Input parameter %f\n",Mieff->GetNewDoubleValue(newValue));
+	  //	  G4cout << "Input parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
 
   WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
 
-  printf("Setting Mie scattering parameter %f\n",Mieff->GetNewDoubleValue(newValue));
+  G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
 
   }
 
@@ -123,16 +123,16 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   else if(command == TVSpacing) {
     // Set the Top Veto PMT Spacing
     WCSimTuningParams->SetTVSpacing(TVSpacing->GetNewDoubleValue(newValue));
-    printf("Setting Top Veto PMT Spacing %f\n",TVSpacing->GetNewDoubleValue(newValue));
+    G4cout << "Setting Top Veto PMT Spacing " << TVSpacing->GetNewDoubleValue(newValue) << G4endl;
   }
 
   else if(command == TopVeto) {
     // Set the Top Veto on/off
     WCSimTuningParams->SetTopVeto(TopVeto->GetNewBoolValue(newValue));
     if(TopVeto->GetNewBoolValue(newValue))
-      printf("Setting Top Veto On\n");
+      G4cout << "Setting Top Veto On" << G4endl;
     else
-      printf("Setting Top Veto Off\n");
+      G4cout << "Setting Top Veto Off" << G4endl;
   }
 
 

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -5,7 +5,7 @@
 #include "G4UIcommand.hh"
 #include "G4UIparameter.hh"
 #include "G4UIcmdWithADouble.hh"
-#include "G4UIcmdWithABool.hh" //jl145
+#include "G4UIcmdWithABool.hh"
 
 
 WCSimTuningMessenger::WCSimTuningMessenger(WCSimTuningParameters* WCTuningPars):WCSimTuningParams(WCTuningPars) { 
@@ -37,7 +37,6 @@ WCSimTuningMessenger::WCSimTuningMessenger(WCSimTuningParameters* WCTuningPars):
   Mieff->SetParameterName("Mieff",true);
   Mieff->SetDefaultValue(0.0);
 
-  //jl145 - for Top Veto
   TVSpacing = new G4UIcmdWithADouble("/WCSim/tuning/tvspacing",this);
   TVSpacing->SetGuidance("Set the Top Veto PMT Spacing, in cm.");
   TVSpacing->SetParameterName("TVSpacing",true);
@@ -58,7 +57,6 @@ WCSimTuningMessenger::~WCSimTuningMessenger()
   delete Rgcff;
   delete Mieff;
 
-  //jl145 - for Top Veto
   delete TVSpacing;
   delete TopVeto;
 
@@ -97,8 +95,6 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
   G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
   }
-
-  //jl145 - For Top Veto
 
   else if(command == TVSpacing) {
     // Set the Top Veto PMT Spacing

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -74,25 +74,25 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
   }
 
- if(command == Bsrff) {
+  else if(command == Bsrff) {
 	  // Set the blacksheet reflection parameter
   WCSimTuningParams->SetBsrff(Bsrff->GetNewDoubleValue(newValue));
   G4cout << "Setting blacksheet reflection parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
   }
 
- if(command == Abwff) {
+  else if(command == Abwff) {
 	  // Set the water attenuation  parameter
   WCSimTuningParams->SetAbwff(Abwff->GetNewDoubleValue(newValue));
   G4cout << "Setting water attenuation parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
   }
 
- if(command == Rgcff) {
+  else if(command == Rgcff) {
 	  // Set the cathode reflectivity parameter
   WCSimTuningParams->SetRgcff(Rgcff->GetNewDoubleValue(newValue));
   G4cout << "Setting cathode reflectivity parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
   }
 
- if(command == Mieff) {
+  else if(command == Mieff) {
 	  // Set the Mie scattering parameter
   WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
   G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -70,52 +70,32 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 
   if(command == Rayff) {
 	  // Set the Rayleigh scattering parameter
-	  //	  G4cout << "Input parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
-
   WCSimTuningParams->SetRayff(Rayff->GetNewDoubleValue(newValue));
-
   G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
-
   }
 
  if(command == Bsrff) {
 	  // Set the blacksheet reflection parameter
-	  //	  G4cout << "Input parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
-
   WCSimTuningParams->SetBsrff(Bsrff->GetNewDoubleValue(newValue));
-
   G4cout << "Setting blacksheet reflection parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
-
   }
 
  if(command == Abwff) {
 	  // Set the water attenuation  parameter
-	  //	  G4cout << "Input parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
-
   WCSimTuningParams->SetAbwff(Abwff->GetNewDoubleValue(newValue));
-
   G4cout << "Setting water attenuation parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
-
   }
 
  if(command == Rgcff) {
 	  // Set the cathode reflectivity parameter
-	  //	  G4cout << "Input parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
-
   WCSimTuningParams->SetRgcff(Rgcff->GetNewDoubleValue(newValue));
-
   G4cout << "Setting cathode reflectivity parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
-
   }
 
  if(command == Mieff) {
 	  // Set the Mie scattering parameter
-	  //	  G4cout << "Input parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
-
   WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
-
   G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
-
   }
 
   //jl145 - For Top Veto
@@ -134,6 +114,5 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
     else
       G4cout << "Setting Top Veto Off" << G4endl;
   }
-
 
 }

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -67,33 +67,33 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 {    
 
   if(command == Rayff) {
-	  // Set the Rayleigh scattering parameter
-  WCSimTuningParams->SetRayff(Rayff->GetNewDoubleValue(newValue));
-  G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
+    // Set the Rayleigh scattering parameter
+    WCSimTuningParams->SetRayff(Rayff->GetNewDoubleValue(newValue));
+    G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewDoubleValue(newValue) << G4endl;
   }
 
   else if(command == Bsrff) {
-	  // Set the blacksheet reflection parameter
-  WCSimTuningParams->SetBsrff(Bsrff->GetNewDoubleValue(newValue));
-  G4cout << "Setting blacksheet reflection parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
+    // Set the blacksheet reflection parameter
+    WCSimTuningParams->SetBsrff(Bsrff->GetNewDoubleValue(newValue));
+    G4cout << "Setting blacksheet reflection parameter " << Bsrff->GetNewDoubleValue(newValue) << G4endl;
   }
 
   else if(command == Abwff) {
-	  // Set the water attenuation  parameter
-  WCSimTuningParams->SetAbwff(Abwff->GetNewDoubleValue(newValue));
-  G4cout << "Setting water attenuation parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
+    // Set the water attenuation  parameter
+    WCSimTuningParams->SetAbwff(Abwff->GetNewDoubleValue(newValue));
+    G4cout << "Setting water attenuation parameter " << Abwff->GetNewDoubleValue(newValue) << G4endl;
   }
 
   else if(command == Rgcff) {
-	  // Set the cathode reflectivity parameter
-  WCSimTuningParams->SetRgcff(Rgcff->GetNewDoubleValue(newValue));
-  G4cout << "Setting cathode reflectivity parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
+    // Set the cathode reflectivity parameter
+    WCSimTuningParams->SetRgcff(Rgcff->GetNewDoubleValue(newValue));
+    G4cout << "Setting cathode reflectivity parameter " << Rgcff->GetNewDoubleValue(newValue) << G4endl;
   }
 
   else if(command == Mieff) {
-	  // Set the Mie scattering parameter
-  WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
-  G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
+    // Set the Mie scattering parameter
+    WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
+    G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
   }
 
   else if(command == TVSpacing) {


### PR DESCRIPTION
When looking at #312 I realised that there are still some places where `printf` is used. This PR swaps these to use `G4cout`

I also got a bit carried away... and had a more detailed look at WCSimTuningMessenger.cc. In particular a couple of questions to ask @eosullivan 
- I removed references to the username of the person who added bits in (jl145 / top veto). It's my personal opinion that this kind of code comment isn't required, or particularlly useful - we can use `git blame` to get this information
- I sorted out the whitespace, as it was very odd inside `WCSimTuningMessenger::SetNewValue()`. Again, this is my personal opinion that it makes code a lot easier to read/write when it's consistently aligned (which it is on the whole, but certaintly not in every file).
  - I seem to remember you being a bit worried about this wrecking the `git blame` output. Thankfully there's a way to mitigate this `git blame -w` (there's also `git diff -w`) See examples below

Let me know if you're happy/unhappy about these changes. If you're happy with them, I'll open issues to sort all the other files out. If not, I can revert individual commits



`git blame`
```
f0564405 (Chris Walter   2010-06-11 17:20:19 +0000  69)   if(command == Rayff) {
9cbc3fb2 (Tom Dealtry    2021-04-30 11:40:38 +0100  70)     // Set the Rayleigh scattering parameter
9cbc3fb2 (Tom Dealtry    2021-04-30 11:40:38 +0100  71)     WCSimTuningParams->SetRayff(Rayff->GetNewDoubleValue(newValue));
9cbc3fb2 (Tom Dealtry    2021-04-30 11:40:38 +0100  72)     G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewD
f0564405 (Chris Walter   2010-06-11 17:20:19 +0000  73)   }
```
`git blame -w`
```
f0564405 (Chris Walter   2010-06-11 17:20:19 +0000  69)   if(command == Rayff) {
f0564405 (Chris Walter   2010-06-11 17:20:19 +0000  70)     // Set the Rayleigh scattering parameter
f0564405 (Chris Walter   2010-06-11 17:20:19 +0000  71)     WCSimTuningParams->SetRayff(Rayff->GetNewDoubleValue(newValue));
3b16ec49 (Tom Dealtry    2021-04-30 11:33:04 +0100  72)     G4cout << "Setting Rayleigh scattering parameter " << Rayff->GetNewD
f0564405 (Chris Walter   2010-06-11 17:20:19 +0000  73)   }
```