### PR TITLE
Fix trivial compiler warnings

### DIFF
--- a/include/WCSimPMTObject.hh
+++ b/include/WCSimPMTObject.hh
@@ -299,27 +299,27 @@ class WCSimBasicPMTObject
   ~WCSimBasicPMTObject();
 
  private:
-  std::vector<G4double> QE;
-  std::vector<G4double> wavelength;
-  std::map<G4double,G4double> mapQE;
-  G4double  maxQE;
-  TGraph   *gQE = nullptr;
+  std::vector<G4double> fQE;
+  std::vector<G4double> fWavelength;
+  std::map<G4double,G4double> fMapQE;
+  G4double  fMaxQE;
+  TGraph   *fGQE = nullptr;
 
  public:
-  std::vector<G4double> GetQE(){ return QE;};
-  void SetQE(std::vector<G4double> qe){ QE=qe;};
+  std::vector<G4double> GetQE(){ return fQE;};
+  void SetQE(std::vector<G4double> qe){ fQE=qe;};
 
-  std::vector<G4double> GetWavelength(){ return wavelength;};
-  void SetWavelength(std::vector<G4double> qe){ wavelength=qe;};
+  std::vector<G4double> GetWavelength(){ return fWavelength;};
+  void SetWavelength(std::vector<G4double> qe){ fWavelength=qe;};
 
-  std::map<G4double,G4double> GetMapQE(){ return mapQE;};
-  void SetMapQE(std::map<G4double,G4double> qe){ mapQE=qe;};
+  std::map<G4double,G4double> GetMapQE(){ return fMapQE;};
+  void SetMapQE(std::map<G4double,G4double> qe){ fMapQE=qe;};
 
-  G4double GetmaxQE(){ return maxQE;};
-  void SetmaxQE(G4double qe){ maxQE=qe;};
+  G4double GetmaxQE(){ return fMaxQE;};
+  void SetmaxQE(G4double qe){ fMaxQE=qe;};
 
-  TGraph* GetgQE(){ return gQE;};
-  void SetgQE(TGraph *g){ gQE=g;};
+  TGraph* GetgQE(){ return fGQE;};
+  void SetgQE(TGraph *g){ fGQE=g;};
 
   void DefineQEHist(std::map<G4double,G4double>);
 };

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -33,7 +33,10 @@ public:
   TBranch* GetBranch(G4String detectorElement = "tank"){
     if(detectorElement=="tank") return wcsimrooteventbranch;
     else if(detectorElement=="OD")  return wcsimrooteventbranch_OD;
-    else G4cout << "Unkown detector element" << G4endl;
+    else {
+      G4cout << "Unkown detector element" << G4endl;
+      return nullptr;
+    }
   }
   TTree* GetGeoTree(){return geoTree;}
   TTree* GetOptionsTree(){return optionsTree;}
@@ -41,7 +44,11 @@ public:
   // WCSimRootEvent* GetRootEvent(){return wcsimrootsuperevent;}
   WCSimRootEvent* GetRootEvent(G4String detectorElement = "tank"){
     if(detectorElement=="tank") return wcsimrootsuperevent;
-    if(detectorElement=="OD") return wcsimrootsuperevent_OD;
+    else if(detectorElement=="OD") return wcsimrootsuperevent_OD;
+    else {
+      G4cout << "Unkown detector element" << G4endl;
+      return nullptr;
+    }
   }
   WCSimRootOptions* GetRootOptions(){return wcsimrootoptions;}
 

--- a/include/WCSimWCAddDarkNoise.hh
+++ b/include/WCSimWCAddDarkNoise.hh
@@ -27,34 +27,34 @@ public:
   void FindDarkNoiseRanges(WCSimWCDigitsCollection* WCHCPMT, double width);
   //As it inherits from G4VDigitizerModule it needs a digitize class.  Not used
   void Digitize() { }
-  void SetDarkRate(double idarkrate){ PMTDarkRate = idarkrate; }
-  double GetDarkRate() { return PMTDarkRate; }
-  void SetConversion(double iconvrate){ ConvRate = iconvrate; }
-  void SetDarkMode(int imode){DarkMode = imode;}
-  void SetDarkHigh(double idarkhigh){DarkHigh = idarkhigh;}
-  void SetDarkLow(double idarklow){DarkLow = idarklow;}
-  void SetDarkWindow(int idarkwindow){DarkWindow = idarkwindow;}
-  int GetDarkWindow(){return (int)(DarkWindow);}
+  void SetDarkRate(double idarkrate){ fPMTDarkRate = idarkrate; }
+  double GetDarkRate() { return fPMTDarkRate; }
+  void SetConversion(double iconvrate){ fConvRate = iconvrate; }
+  void SetDarkMode(int imode){fDarkMode = imode;}
+  void SetDarkHigh(double idarkhigh){fDarkHigh = idarkhigh;}
+  void SetDarkLow(double idarklow){fDarkLow = idarklow;}
+  void SetDarkWindow(int idarkwindow){fDarkWindow = idarkwindow;}
+  int GetDarkWindow(){return (int)(fDarkWindow);}
   void SaveOptionsToOutput(WCSimRootOptions * wcopt, string tag);
   
 private:
-  void ReInitialize() { ranges.clear(); result.clear();}
+  void ReInitialize() { franges.clear(); fresult.clear();}
   void SetPMTDarkDefaults();
 
-  WCSimDarkRateMessenger *DarkRateMessenger;
-  double PMTDarkRate; // kHz
-  double ConvRate; // kHz
-  double DarkHigh; //ns
-  double DarkLow; //ns
-  double DarkWindow; //ns
-  int DarkMode;
+  WCSimDarkRateMessenger *fDarkRateMessenger;
+  double fPMTDarkRate; // kHz
+  double fConvRate; // kHz
+  double fDarkHigh; //ns
+  double fDarkLow; //ns
+  double fDarkWindow; //ns
+  int fDarkMode;
   bool fCalledAddDarkNoise;
 
-  WCSimDetectorConstruction* myDetector;
-  G4String detectorElement;
+  WCSimDetectorConstruction* fDetector;
+  G4String fDetectorElement;
 
-  std::vector<std::pair<double, double> > ranges;
-  std::vector<std::pair<double, double> > result;
+  std::vector<std::pair<double, double> > franges;
+  std::vector<std::pair<double, double> > fresult;
   
 };
 

--- a/include/WCSimWCDigitizer.hh
+++ b/include/WCSimWCDigitizer.hh
@@ -33,10 +33,10 @@ public:
   void Digitize();
 
   //.mac file option setting methods
-  void SetDigitizerDeadTime         (int deadtime) { DigitizerDeadTime = deadtime;         }; ///< Override the default digitizer deadtime (ns)
-  void SetDigitizerIntegrationWindow(int inttime ) { DigitizerIntegrationWindow = inttime; }; ///< Override the default digitizer integration window (ns)
-  void SetDigitizerTimingPrecision  (double precision) { DigitizerTimingPrecision = precision; }; ///< Override the default digitizer timing resolution (ns)
-  void SetDigitizerPEPrecision      (double precision) { DigitizerPEPrecision     = precision; }; ///< Override the default digitizer charge resolution (p.e.)
+  void SetDigitizerDeadTime         (int deadtime) { fDigitizerDeadTime = deadtime;         }; ///< Override the default digitizer deadtime (ns)
+  void SetDigitizerIntegrationWindow(int inttime ) { fDigitizerIntegrationWindow = inttime; }; ///< Override the default digitizer integration window (ns)
+  void SetDigitizerTimingPrecision  (double precision) { fDigitizerTimingPrecision = precision; }; ///< Override the default digitizer timing resolution (ns)
+  void SetDigitizerPEPrecision      (double precision) { fDigitizerPEPrecision     = precision; }; ///< Override the default digitizer charge resolution (p.e.)
 
   double Truncate(double value, double precision) {
     if(precision < 1E-10) return value;
@@ -50,24 +50,24 @@ public:
   void SaveOptionsToOutput(WCSimRootOptions * wcopt);
   
 protected:
-  void ReInitialize() { DigiStoreHitMap.clear(); }
+  void ReInitialize() { fDigiStoreHitMap.clear(); }
 
-  G4double peSmeared;
+  G4double fPESmeared;
 
-  WCSimDetectorConstruction* myDetector; ///< Get the geometry information
-  WCSimWCDAQMessenger* DAQMessenger;     ///< Get the /DAQ/ .mac options
+  WCSimDetectorConstruction* fMyDetector; ///< Get the geometry information
+  WCSimWCDAQMessenger* fDAQMessenger;     ///< Get the /DAQ/ .mac options
 
-  WCSimWCDigitsCollection*  DigiStore;
-  std::map<int,int> DigiStoreHitMap;   ///< Used to check if a digit has already been created on a PMT
+  WCSimWCDigitsCollection*  fDigiStore;
+  std::map<int,int> fDigiStoreHitMap;   ///< Used to check if a digit has already been created on a PMT
 
   //generic digitizer properties. Defaults set with the GetDefault*() methods. Overidden by .mac options
-  G4String DigitizerClassName;    ///< Name of the digitizer class being run
-  int DigitizerDeadTime;          ///< Digitizer deadtime (ns)
-  int DigitizerIntegrationWindow; ///< Digitizer integration window (ns)
-  double DigitizerTimingPrecision; ///< Digitizer time precision (ns)
-  double DigitizerPEPrecision;     ///< Digitizer charge precision (p.e.)
+  G4String fDigitizerClassName;    ///< Name of the digitizer class being run
+  int fDigitizerDeadTime;          ///< Digitizer deadtime (ns)
+  int fDigitizerIntegrationWindow; ///< Digitizer integration window (ns)
+  double fDigitizerTimingPrecision; ///< Digitizer time precision (ns)
+  double fDigitizerPEPrecision;     ///< Digitizer charge precision (p.e.)
 
-  DigitizerType_t DigitizerType; ///< Enumeration to say which digitizer we've constructed
+  DigitizerType_t fDigitizerType; ///< Enumeration to say which digitizer we've constructed
 
   virtual int GetDefaultDeadTime() = 0;          ///< Set the default digitizer-specific deadtime (in ns) (overridden by .mac)
   virtual int GetDefaultIntegrationWindow() = 0; ///< Set the default digitizer-specific integration window (in ns) (overridden by .mac)
@@ -76,7 +76,7 @@ protected:
 
   void GetVariables(); ///< Get the default deadtime, etc. from the derived class, and override with read from the .mac file
 
-  G4String detectorElement;
+  G4String fDetectorElement;
 };
 
 

--- a/include/WCSimWCPMT.hh
+++ b/include/WCSimWCPMT.hh
@@ -34,7 +34,6 @@ public:
   //  static G4double GetLongTime() { return LongTime;}
   
   G4double rn1pe();
-  G4double peSmeared;
   // double ConvRate; // kHz
   std::vector<G4double> TriggerTimes;
   std::map<int,int> DigiHitMapPMT; // need to check if a hit already exists..

--- a/include/WCSimWCSD.hh
+++ b/include/WCSimWCSD.hh
@@ -21,13 +21,13 @@ class WCSimWCSD : public G4VSensitiveDetector
   
  private:
 
-  G4int HCID;
+  G4int fHCID;
   WCSimDetectorConstruction* fdet;
-  WCSimWCHitsCollection* hitsCollection;
-  std::map<int,int> PMTHitMap;   // Whether a PMT was hit already
+  WCSimWCHitsCollection* fHitsCollection;
+  std::map<int,int> fPMTHitMap;   // Whether a PMT was hit already
 
 
-  G4String detectorElement;
+  G4String fDetectorElement;
 };
 
 #endif

--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -44,48 +44,48 @@ public:
   void Digitize();
 
   ///Returns the number of trigger gates in the event (i.e. the number of triggers passed)
-  int NumberOfGatesInThisEvent() { return TriggerTimes.size(); }
+  int NumberOfGatesInThisEvent() { return fTriggerTimes.size(); }
   ///Get the time of the ith trigger
-  Double_t             GetTriggerTime(int i) { return TriggerTimes[i];}
+  Double_t             GetTriggerTime(int i) { return fTriggerTimes[i];}
   ///Get the trigger type of the ith trigger
-  TriggerType_t        GetTriggerType(int i) { return TriggerTypes[i];}
+  TriggerType_t        GetTriggerType(int i) { return fTriggerTypes[i];}
   ///Get the additional trigger information associated with the ith trigger
-  std::vector<Float_t> GetTriggerInfo(int i) { return TriggerInfos[i];}
+  std::vector<Float_t> GetTriggerInfo(int i) { return fTriggerInfos[i];}
   ///Get the trigger class name
-  G4String GetTriggerClassName(){ return triggerClassName; }
+  G4String GetTriggerClassName(){ return fTriggerClassName; }
 
   //
   // Trigger algorithm option set methods
   //
 
   ///Set whether to allow the number of digits per PMT per trigger to go > 1
-  void SetMultiDigitsPerTrigger(G4bool allow_multi) { multiDigitsPerTrigger = allow_multi; }
-  G4bool GetMultiDigitsPerTrigger() { return multiDigitsPerTrigger; }
+  void SetMultiDigitsPerTrigger(G4bool allow_multi) { fMultiDigitsPerTrigger = allow_multi; }
+  G4bool GetMultiDigitsPerTrigger() { return fMultiDigitsPerTrigger; }
 
   // NDigits options
   ///Set the threshold for the NDigits trigger
-  void SetNDigitsThreshold(G4int threshold) { ndigitsThreshold = threshold; }
+  void SetNDigitsThreshold(G4int threshold) { fNDigitsThreshold = threshold; }
   ///Set the time window for the NDigits trigger
-  void SetNDigitsWindow(G4int window) { ndigitsWindow = window; }
+  void SetNDigitsWindow(G4int window) { fNDigitsWindow = window; }
   ///Automatically adjust the NDigits threshold based on the average noise occupancy?
-  void SetNDigitsAdjustForNoise    (G4bool adjust)      { ndigitsAdjustForNoise = adjust; }
+  void SetNDigitsAdjustForNoise    (G4bool adjust)      { fNDigitsAdjustForNoise = adjust; }
   ///Set the pretrigger window for the NDigits trigger (value will be forced negative)
-  void SetNDigitsPreTriggerWindow(G4int window)  { ndigitsPreTriggerWindow  = - abs(window); }
+  void SetNDigitsPreTriggerWindow(G4int window)  { fNDigitsPreTriggerWindow  = - abs(window); }
   ///Set the posttrigger window for the NDigits trigger (value will be forced positive)
-  void SetNDigitsPostTriggerWindow(G4int window) { ndigitsPostTriggerWindow = + abs(window); }
+  void SetNDigitsPostTriggerWindow(G4int window) { fNDigitsPostTriggerWindow = + abs(window); }
 
   // Save trigger failures options
   ///Set the mode for saving failed triggers (0:save only triggered events, 1:save both triggered events & failed events, 2:save only failed events)
-  void SetSaveFailuresMode       (G4int mode )        { saveFailuresMode = mode; }
+  void SetSaveFailuresMode       (G4int mode )        { fSaveFailuresMode = mode; }
   ///Set the dummy trigger time for the failed triggers
-  void SetSaveFailuresTime       (G4double time )     { saveFailuresTime = time; }
+  void SetSaveFailuresTime       (G4double time )     { fSaveFailuresTime = time; }
   ///Set the pretrigger window for the SaveFailures trigger (value will be forced negative)
-  void SetSaveFailuresPreTriggerWindow(G4int window)  { saveFailuresPreTriggerWindow  = - abs(window); }
+  void SetSaveFailuresPreTriggerWindow(G4int window)  { fSaveFailuresPreTriggerWindow  = - abs(window); }
   ///Set the posttrigger window for the SaveFailures trigger (value will be forced positive)
-  void SetSaveFailuresPostTriggerWindow(G4int window) { saveFailuresPostTriggerWindow = + abs(window); }
+  void SetSaveFailuresPostTriggerWindow(G4int window) { fSaveFailuresPostTriggerWindow = + abs(window); }
   
   ///Knowledge of the dark rate (use for automatically adjusting for noise)
-  void SetDarkRate(double idarkrate){ PMTDarkRate = idarkrate; }
+  void SetDarkRate(double idarkrate){ fPMTDarkRate = idarkrate; }
 
   ///Save current values of options
   void SaveOptionsToOutput(WCSimRootOptions * wcopt);
@@ -135,42 +135,42 @@ protected:
   void AlgNoTrigger(WCSimWCDigitsCollection* WCDCPMT, bool remove_hits, bool test=false);
 
 
-  WCSimWCTriggeredDigitsCollection*   DigitsCollection; ///< The main output of the class - collection of digits in the trigger window
-  std::map<int,int>          DigiHitMap; ///< Keeps track of the PMTs that have been added to the output WCSimWCTriggeredDigitsCollection
+  WCSimWCTriggeredDigitsCollection*   fDigitsCollection; ///< The main output of the class - collection of digits in the trigger window
+  std::map<int,int>          fDigiHitMap; ///< Keeps track of the PMTs that have been added to the output WCSimWCTriggeredDigitsCollection
 
-  std::vector<Double_t>               TriggerTimes; ///< The times of the triggers
-  std::vector<TriggerType_t>          TriggerTypes; ///< The type of the triggers
-  std::vector< std::vector<Float_t> > TriggerInfos; ///< Additional information associated with each trigger
+  std::vector<Double_t>               fTriggerTimes; ///< The times of the triggers
+  std::vector<TriggerType_t>          fTriggerTypes; ///< The type of the triggers
+  std::vector< std::vector<Float_t> > fTriggerInfos; ///< Additional information associated with each trigger
 
-  WCSimWCDAQMessenger*       DAQMessenger; ///< Get the options from the .mac file
-  WCSimDetectorConstruction* myDetector;   ///< Know about the detector, so can add appropriate PMT time smearing
-  G4String detectorElement;
+  WCSimWCDAQMessenger*       fDAQMessenger; ///< Get the options from the .mac file
+  WCSimDetectorConstruction* fDetector;   ///< Know about the detector, so can add appropriate PMT time smearing
+  G4String fDetectorElement;
 
-  /// Clear the Trigger* vectors and DigiHitMap
+  /// Clear the Trigger* vectors and fDigiHitMap
   void ReInitialize() {
-    TriggerTimes.clear(); 
-    TriggerTypes.clear(); 
-    TriggerInfos.clear(); 
-    DigiHitMap.clear();
+    fTriggerTimes.clear(); 
+    fTriggerTypes.clear(); 
+    fTriggerInfos.clear(); 
+    fDigiHitMap.clear();
   }
 
-  double PMTDarkRate;    ///< Dark noise rate of the PMTs
+  double fPMTDarkRate;    ///< Dark noise rate of the PMTs
 
   // Trigger algorithm options
-  G4bool multiDigitsPerTrigger;    ///< Allow the number of digits per PMT saved in each trigger window to go > 1?
+  G4bool fMultiDigitsPerTrigger;    ///< Allow the number of digits per PMT saved in each trigger window to go > 1?
   //NDigits
-  G4int  ndigitsThreshold;         ///< The threshold for the NDigits trigger
-  G4int  ndigitsWindow;            ///< The time window for the NDigits trigger
-  G4bool ndigitsAdjustForNoise;    ///< Automatically adjust the NDigits trigger threshold based on the average dark noise rate?
-  G4int  ndigitsPreTriggerWindow;  ///< The pretrigger window to save before an NDigits trigger
-  G4int  ndigitsPostTriggerWindow; ///< The posttrigger window to save after an NDigits trigger
+  G4int  fNDigitsThreshold;         ///< The threshold for the NDigits trigger
+  G4int  fNDigitsWindow;            ///< The time window for the NDigits trigger
+  G4bool fNDigitsAdjustForNoise;    ///< Automatically adjust the NDigits trigger threshold based on the average dark noise rate?
+  G4int  fNDigitsPreTriggerWindow;  ///< The pretrigger window to save before an NDigits trigger
+  G4int  fNDigitsPostTriggerWindow; ///< The posttrigger window to save after an NDigits trigger
   //Save failures
-  G4int    saveFailuresMode;              ///< The mode for saving events which don't pass triggers
-  G4double saveFailuresTime;              ///< The dummy trigger time for failed events
-  G4int    saveFailuresPreTriggerWindow;  ///< The pretrigger window to save before an SaveFailures trigger
-  G4int    saveFailuresPostTriggerWindow; ///< The posttrigger window to save after an SaveFailures trigger
+  G4int    fSaveFailuresMode;              ///< The mode for saving events which don't pass triggers
+  G4double fSaveFailuresTime;              ///< The dummy trigger time for failed events
+  G4int    fSaveFailuresPreTriggerWindow;  ///< The pretrigger window to save before an SaveFailures trigger
+  G4int    fSaveFailuresPostTriggerWindow; ///< The posttrigger window to save after an SaveFailures trigger
 
-  G4String triggerClassName; ///< Save the name of the trigger class
+  G4String fTriggerClassName; ///< Save the name of the trigger class
 
 private:
   ///modify the NDigits threshold based on the average dark noise rate
@@ -185,25 +185,25 @@ private:
     TriggerType_t index_type;
     double index_time;
     std::vector<float> index_info;
-    for (i = 1; i < (int) TriggerTimes.size(); ++i) {
-      index_time = TriggerTimes[i];
-      index_type = TriggerTypes[i];
-      index_info = TriggerInfos[i];
-      for (j = i; j > 0 && TriggerTimes[j-1] > index_time; j--) {
-	TriggerTimes[j] = TriggerTimes[j-1];
-	TriggerTypes[j] = TriggerTypes[j-1];
-	TriggerInfos[j] = TriggerInfos[j-1];
+    for (i = 1; i < (int) fTriggerTimes.size(); ++i) {
+      index_time = fTriggerTimes[i];
+      index_type = fTriggerTypes[i];
+      index_info = fTriggerInfos[i];
+      for (j = i; j > 0 && fTriggerTimes[j-1] > index_time; j--) {
+	fTriggerTimes[j] = fTriggerTimes[j-1];
+	fTriggerTypes[j] = fTriggerTypes[j-1];
+	fTriggerInfos[j] = fTriggerInfos[j-1];
       }//j
-      TriggerTimes[j] = index_time;
-      TriggerTypes[j] = index_type;
-      TriggerInfos[j] = index_info;
+      fTriggerTimes[j] = index_time;
+      fTriggerTypes[j] = index_type;
+      fTriggerInfos[j] = index_info;
     }//i
   }
   
-  static const double offset;        ///< Hit time offset (ns)
-  static const double LongTime;      ///< An arbitrary long time to use in loops (ns)
+  static const double fOffset;        ///< Hit time offset (ns)
+  static const double fLongTime;      ///< An arbitrary long time to use in loops (ns)
 
-  bool   digitizeCalled; ///< Has Digitize() been called yet?
+  bool   fDigitizeCalled; ///< Has Digitize() been called yet?
 };
 
 // *******************************************
@@ -226,11 +226,11 @@ public:
   void Draw() {}
   void Print();
 
-  inline void SetTubeID(G4int tube) { tubeID = tube; }
-  inline void AddGate  (G4int gate) { Gates.insert(gate); }
-  inline void AddPe    ()           { totalPe++; }
-  inline void SetPe    (G4int gate, G4double Q) {   pe.insert(std::pair<int,double>(gate,Q)); }
-  inline void SetTime  (G4int gate, G4double T) { time.insert(std::pair<int,double>(gate,T)); }
+  inline void SetTubeID(G4int tube) { fTubeID = tube; }
+  inline void AddGate  (G4int gate) { fGates.insert(gate); }
+  inline void AddPe    ()           { fTotalPe++; }
+  inline void SetPe    (G4int gate, G4double Q) {   fPe.insert(std::pair<int,double>(gate,Q)); }
+  inline void SetTime  (G4int gate, G4double T) { fTime.insert(std::pair<int,double>(gate,T)); }
 
   /// Add a whole vector for one digit to fDigiComp. Clear input vector once added.
   void AddDigiCompositionInfo(G4int gate, std::vector<int> &digi_comp){
@@ -238,9 +238,9 @@ public:
     digi_comp.clear();
   }
 
-  inline G4int   GetTubeID() {return tubeID;}
-  inline std::vector<G4double> GetPe      (int gate) { return FindInMultimap(gate, pe); }
-  inline std::vector<G4double> GetTime    (int gate) { return FindInMultimap(gate, time); }
+  inline G4int   GetTubeID() {return fTubeID;}
+  inline std::vector<G4double> GetPe      (int gate) { return FindInMultimap(gate, fPe); }
+  inline std::vector<G4double> GetTime    (int gate) { return FindInMultimap(gate, fTime); }
   std::vector<std::vector<int> > GetDigiCompositionInfo(int gate)
   {
     std::vector<std::vector<int> > v;
@@ -252,22 +252,22 @@ public:
     return v;
   }
 
-  inline int NumberOfGates()     { return Gates.size();      }
-  inline int NumberOfSubEvents() { return Gates.size() - 1;  }
-  inline bool HasHitsInGate(int gate) { return Gates.count(gate) > 0; }
+  inline int NumberOfGates()     { return fGates.size();      }
+  inline int NumberOfSubEvents() { return fGates.size() - 1;  }
+  inline bool HasHitsInGate(int gate) { return fGates.count(gate) > 0; }
 
 private:
-  G4int tubeID; ///< PMT id of the digit
+  G4int fTubeID; ///< PMT id of the digit
 
-  std::set<int> Gates;  ///< 'Gates' specifies subevent
+  std::set<int> fGates;  ///< 'Gates' specifies subevent
 
   //lists (meaning multimap) of information for each digit created on the PMT
-  std::multimap<int,double> pe;   ///< Digit charge
-  std::multimap<int,double> time; ///< Digit time
+  std::multimap<int,double> fPe;   ///< Digit charge
+  std::multimap<int,double> fTime; ///< Digit time
   std::multimap<int, std::vector<int> > fDigiComp;   ///< Stores the unique IDs of each photon making up a digit
 
   //integrated hit/digit parameters
-  G4int                 totalPe; ///< Total charge on digit
+  G4int                 fTotalPe; ///< Total charge on digit
 
   template <typename T> std::vector<T> FindInMultimap(const int compare, typename std::multimap<int,T> &map)
   {
@@ -315,7 +315,7 @@ class WCSimWCTriggerNDigits : public WCSimWCTriggerBase
 public:
 
   ///Create WCSimWCTriggerNDigits instance with knowledge of the detector and DAQ options
-  WCSimWCTriggerNDigits(G4String name, WCSimDetectorConstruction*, WCSimWCDAQMessenger*, G4String detectorElement);
+  WCSimWCTriggerNDigits(G4String name, WCSimDetectorConstruction*, WCSimWCDAQMessenger*, G4String fDetectorElement);
 
   ~WCSimWCTriggerNDigits();
   
@@ -335,7 +335,7 @@ class WCSimWCTriggerNoTrigger : public WCSimWCTriggerBase
 public:
   
   ///Create WCSimWCTriggerNoTrigger instance with knowledge of the detector and DAQ options
-  WCSimWCTriggerNoTrigger(G4String name, WCSimDetectorConstruction*, WCSimWCDAQMessenger*,  G4String detectorElement);
+  WCSimWCTriggerNoTrigger(G4String name, WCSimDetectorConstruction*, WCSimWCDAQMessenger*,  G4String fDetectorElement);
   
   ~WCSimWCTriggerNoTrigger();
   
@@ -362,7 +362,7 @@ class WCSimWCTriggerNDigits2 : public WCSimWCTriggerBase
 public:
 
   //not recommended to override these methods
-  WCSimWCTriggerNDigits2(G4String name, WCSimDetectorConstruction*, WCSimWCDAQMessenger*, G4String detectorElement);
+  WCSimWCTriggerNDigits2(G4String name, WCSimDetectorConstruction*, WCSimWCDAQMessenger*, G4String fDetectorElement);
   ~WCSimWCTriggerNDigits2();
   
 private:

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -161,7 +161,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 			"WCBarrel",
 			0,0,0);
 
-    G4VPhysicalVolume* physiWCBarrel = 
+    //G4VPhysicalVolume* physiWCBarrel = 
     new G4PVPlacement(0,
 		      G4ThreeVector(0.,0.,0.),
 		      logicWCBarrel,
@@ -188,7 +188,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
                             "CaveTyvek",
                             0, 0, 0);
 
-    G4VPhysicalVolume *physiCaveTyvek =
+    //G4VPhysicalVolume *physiCaveTyvek =
         new G4PVPlacement(0,
                           G4ThreeVector(0., 0., 0.),
                           logicCaveTyvek,
@@ -197,7 +197,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 						  false,
                           0);
 
-    G4LogicalSkinSurface *TyvekCaveBarrelSurface = new G4LogicalSkinSurface("TyvekCaveBarrelSurface", logicCaveTyvek, OpWaterTySurface);
+    //G4LogicalSkinSurface *TyvekCaveBarrelSurface =
+        new G4LogicalSkinSurface("TyvekCaveBarrelSurface", logicCaveTyvek, OpWaterTySurface);
 
     G4VisAttributes *showTyvekCave = new G4VisAttributes(green);
     showTyvekCave->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
@@ -221,7 +222,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 								"CaveCapTyvek",
 								0, 0, 0);
 
-    G4LogicalSkinSurface *TyvekCaveTopSurface = new G4LogicalSkinSurface("TyvekCaveTopSurface", logicCaveCapsTyvek, OpWaterTySurface);
+    //G4LogicalSkinSurface *TyvekCaveTopSurface =
+        new G4LogicalSkinSurface("TyvekCaveTopSurface", logicCaveCapsTyvek, OpWaterTySurface);
 
     G4VisAttributes *CapsCaveTyvekVisAtt = new G4VisAttributes(yellow);
     CapsCaveTyvekVisAtt->SetForceWireframe(true);
@@ -230,7 +232,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 
     G4ThreeVector CaveTyvekPosition(0., 0., WCLength / 2);
 
-    G4VPhysicalVolume *physiTopCaveTyvek =
+    //G4VPhysicalVolume *physiTopCaveTyvek =
         new G4PVPlacement(0,
                           CaveTyvekPosition,
 						  logicCaveCapsTyvek,
@@ -242,7 +244,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 
     CaveTyvekPosition.setZ(-CaveTyvekPosition.getZ());
 
-    G4VPhysicalVolume *physiBottomCaveTyvek =
+    //G4VPhysicalVolume *physiBottomCaveTyvek =
         new G4PVPlacement(0,
                           CaveTyvekPosition,
 						  logicCaveCapsTyvek,
@@ -289,7 +291,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 			"WCBarrelAnnulus",
 			0,0,0);
   // G4cout << *solidWCBarrelAnnulus << G4endl; 
-  G4VPhysicalVolume* physiWCBarrelAnnulus = 
+  //G4VPhysicalVolume* physiWCBarrelAnnulus = 
     new G4PVPlacement(0,
 		      G4ThreeVector(0.,0.,0.),
 		      logicWCBarrelAnnulus,
@@ -320,7 +322,7 @@ if(!debugMode)
 			"WCBarrelRing",
 			0,0,0);
 
-  G4VPhysicalVolume* physiWCBarrelRing = 
+  //G4VPhysicalVolume* physiWCBarrelRing = 
     new G4PVReplica("WCBarrelRing",
 		    logicWCBarrelRing,
 		    logicWCBarrelAnnulus,
@@ -420,8 +422,8 @@ else {
                       false,
                       0,true);
 
-  G4LogicalBorderSurface * WaterBSBarrelCellSurface 
-    = new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
+  //G4LogicalBorderSurface * WaterBSBarrelCellSurface =
+      new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
                                  physiWCBarrelCell,
                                  physiWCBarrelCellBlackSheet, 
                                  OpWaterBSSurface);
@@ -456,7 +458,6 @@ else {
   // we have to declare the logical Volumes 
   // outside of the if block to access it later on 
   G4LogicalVolume* logicWCExtraTowerCell;
-  G4LogicalVolume* logicWCExtraBorderCell;
   if(!(WCBarrelRingNPhi*WCPMTperCellHorizontal == WCBarrelNumPMTHorizontal)){
 
     // as the angles between the corners of the main annulus 
@@ -489,7 +490,7 @@ else {
 			  G4Material::GetMaterial(water),
 			  "WCExtraTower",
 			  0,0,0);
-    G4VPhysicalVolume* physiWCExtraTower = 
+    //G4VPhysicalVolume* physiWCExtraTower = 
       new G4PVPlacement(0,
 			G4ThreeVector(0.,0.,0.),
 			logicWCExtraTower,
@@ -561,8 +562,8 @@ else {
 			false,
 			0,true);
 
-    G4LogicalBorderSurface * WaterBSTowerCellSurface 
-      = new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
+    //G4LogicalBorderSurface * WaterBSTowerCellSurface =
+        new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
 				   physiWCTowerCell,
 				   physiWCTowerBlackSheet, 
 				   OpWaterBSSurface);
@@ -631,7 +632,7 @@ else {
 								"WCTopVeto",
 								0,0,0);
 
-	  G4VPhysicalVolume* physiWCTopVeto =
+	  //G4VPhysicalVolume* physiWCTopVeto =
 			new G4PVPlacement(	0,
 								G4ThreeVector(0.,0.,WCIDHeight/2
 													+1.0*m),
@@ -660,7 +661,7 @@ else {
 								0,0,0);
 
 	  //Bottom
-	  G4VPhysicalVolume* physiWCTVTyvekBot =
+	  //G4VPhysicalVolume* physiWCTVTyvekBot =
 			new G4PVPlacement(	0,
 		                  		G4ThreeVector(0.,0.,-0.5*m
 													-WCTyvekThickness/2),
@@ -669,9 +670,10 @@ else {
 		          				logicWCTopVeto,
 				 				false,0,true);
 
-          G4LogicalSkinSurface *WaterTyTVSurfaceBot = new G4LogicalSkinSurface("WaterTyTVSurfaceBot", logicWCTVTyvek, OpWaterTySurface);
+          //G4LogicalSkinSurface *WaterTyTVSurfaceBot =
+                new G4LogicalSkinSurface("WaterTyTVSurfaceBot", logicWCTVTyvek, OpWaterTySurface);
 	  //Top
-	  G4VPhysicalVolume* physiWCTVTyvekTop =
+	  //G4VPhysicalVolume* physiWCTVTyvekTop =
 			new G4PVPlacement(	0,
 		                  		G4ThreeVector(0.,0.,0.5*m
 													+WCTyvekThickness/2),
@@ -698,7 +700,7 @@ else {
 								"WCTVTyvekSide",
 								0,0,0);
 
-	  G4VPhysicalVolume* physiWCTVTyvekSide =
+	  //G4VPhysicalVolume* physiWCTVTyvekSide =
 			new G4PVPlacement(	0,
 		                  		G4ThreeVector(0.,0.,0.),
 								logicWCTVTyvekSide,
@@ -706,7 +708,8 @@ else {
 		          				logicWCTopVeto,
 				 				false,0,true);
 
-          G4LogicalSkinSurface *WaterTyTVSurfaceSurface = new G4LogicalSkinSurface("WaterTyTVSurfaceSide", logicWCTVTyvekSide, OpWaterTySurface);
+          //G4LogicalSkinSurface *WaterTyTVSurfaceSurface =
+                new G4LogicalSkinSurface("WaterTyTVSurfaceSide", logicWCTVTyvekSide, OpWaterTySurface);
   }
 
   //
@@ -763,7 +766,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 
 		  if ((sqrt(xoffset*xoffset + yoffset*yoffset) + WCPMTRadius) < WCTVEdgeLimit) {
 
-		    G4VPhysicalVolume* physiCapPMT =
+		    //G4VPhysicalVolume* physiCapPMT =
 		    		new G4PVPlacement(	0,						// no rotation
 		    							cellpos,				// its position
 		    							logicWCPMT,				// its logical volume
@@ -803,7 +806,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 						 -barrelCellHeight/2.+(j+0.5)*verticalSpacing);
 
 #ifdef ACTIVATE_IDPMTS
-      G4VPhysicalVolume* physiWCBarrelPMT =
+      //G4VPhysicalVolume* physiWCBarrelPMT =
 	new G4PVPlacement(WCPMTRotation,              // its rotation
 			  PMTPosition, 
 			  logicWCPMT,                // its logical volume
@@ -826,26 +829,26 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 
   if(!(WCBarrelRingNPhi*WCPMTperCellHorizontal == WCBarrelNumPMTHorizontal)){
 
-    G4RotationMatrix* WCPMTRotation = new G4RotationMatrix;
-    WCPMTRotation->rotateY(90.*deg);
-    WCPMTRotation->rotateX((2*pi-totalAngle)/2.);//align the PMT with the Cell
+    G4RotationMatrix* WCExtraTowerPMTRotation = new G4RotationMatrix;
+    WCExtraTowerPMTRotation->rotateY(90.*deg);
+    WCExtraTowerPMTRotation->rotateX((2*pi-totalAngle)/2.);//align the PMT with the Cell
                                                  
     G4double towerWidth = WCIDRadius*tan(2*pi-totalAngle);
 
-    G4double horizontalSpacing   = towerWidth/(WCBarrelNumPMTHorizontal-WCBarrelRingNPhi*WCPMTperCellHorizontal);
-    G4double verticalSpacing     = barrelCellHeight/WCPMTperCellVertical;
+    G4double extraTowerHorizontalSpacing   = towerWidth/(WCBarrelNumPMTHorizontal-WCBarrelRingNPhi*WCPMTperCellHorizontal);
+    G4double extraTowerVerticalSpacing     = barrelCellHeight/WCPMTperCellVertical;
 
     for(G4double i = 0; i < (WCBarrelNumPMTHorizontal-WCBarrelRingNPhi*WCPMTperCellHorizontal); i++){
       for(G4double j = 0; j < WCPMTperCellVertical; j++){
 	G4ThreeVector PMTPosition =  G4ThreeVector(WCIDRadius/cos(dPhi/2.)*cos((2.*pi-totalAngle)/2.),
-				towerWidth/2.-(i+0.5)*horizontalSpacing,
-			       -barrelCellHeight/2.+(j+0.5)*verticalSpacing);
+				towerWidth/2.-(i+0.5)*extraTowerHorizontalSpacing,
+			       -barrelCellHeight/2.+(j+0.5)*extraTowerVerticalSpacing);
 	PMTPosition.rotateZ(-(2*pi-totalAngle)/2.); // align with the symmetry 
 	                                            //axes of the cell 
 
 #ifdef ACTIVATE_IDPMTS
-	G4VPhysicalVolume* physiWCBarrelPMT =
-	  new G4PVPlacement(WCPMTRotation,             // its rotation
+	//G4VPhysicalVolume* physiWCBarrelPMT =
+	  new G4PVPlacement(WCExtraTowerPMTRotation,    // its rotation
 			    PMTPosition, 
 			    logicWCPMT,                // its logical volume
 			    "WCPMT",             // its name
@@ -910,7 +913,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 
     G4ThreeVector CapTyvekPosition(0.,0.,(WCIDHeight + 2*WCODDeadSpace)/2);
 
-    G4VPhysicalVolume* physiWCODTopCapsTyvek =
+    //G4VPhysicalVolume* physiWCODTopCapsTyvek =
         new G4PVPlacement(0,
                           CapTyvekPosition,
                           logicWCODCapTyvek,
@@ -919,12 +922,12 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
                           false,
                           0);
 
-    G4LogicalSkinSurface *WaterTySurfaceTop =
+    //G4LogicalSkinSurface *WaterTySurfaceTop =
         new G4LogicalSkinSurface("WaterTySurfaceTop", logicWCODCapTyvek, OpWaterTySurface);
 
     CapTyvekPosition.setZ(-CapTyvekPosition.getZ());
 
-    G4VPhysicalVolume* physiWCODBottomCapsTyvek =
+    //G4VPhysicalVolume* physiWCODBottomCapsTyvek =
         new G4PVPlacement(0,
                           CapTyvekPosition,
                           logicWCODCapTyvek,
@@ -969,7 +972,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
     logicWCBarrelCellODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
 
-    G4VPhysicalVolume* physiWCBarrelCellODTyvek =
+    //G4VPhysicalVolume* physiWCBarrelCellODTyvek =
         new G4PVPlacement(0,
                           G4ThreeVector(0.,0.,0.),
                           logicWCBarrelCellODTyvek,
@@ -977,7 +980,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
                           logicWCBarrelCell,
                           false,
                           0,true);
-    G4LogicalSkinSurface *WaterTySurfaceSide =
+    //G4LogicalSkinSurface *WaterTySurfaceSide =
         new G4LogicalSkinSurface("WaterTySurfaceSide", logicWCBarrelCellODTyvek, OpWaterTySurface);
 
     //-------------------------------------------------------------
@@ -1039,7 +1042,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 		//		std::cout << " qqqqqqqqqqqqqqqqqqqqqqqq barrel i " << i << " of " << WCPMTODperCellHorizontal << " j " << j << " of " << WCPMTODperCellVertical << " Container (" << Container.x() << ", " << Container.y()
 		//				  << ", " << Container.z() << ") " << std::endl;
 
-        G4VPhysicalVolume* physiWCBarrelWLSPlate =
+        //G4VPhysicalVolume* physiWCBarrelWLSPlate =
             new G4PVPlacement(WCPMTODRotation,           // its rotation
                               Container,
                               logicWCODWLSAndPMT,         // its logical volume
@@ -1084,7 +1087,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
                               "WCExtraTowerODTyvek",
                               0,0,0);
 
-      G4LogicalSkinSurface *WaterExtraTySurfaceSide =
+      //G4LogicalSkinSurface *WaterExtraTySurfaceSide =
           new G4LogicalSkinSurface("WaterExtraTySurfaceSide", logicWCTowerODTyvek, OpWaterTySurface);
 
 
@@ -1093,7 +1096,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
       logicWCTowerODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
 
-      G4VPhysicalVolume* physiWCTowerODTyvek =
+      //G4VPhysicalVolume* physiWCTowerODTyvek =
           new G4PVPlacement(0,
                             G4ThreeVector(0.,0.,0.),
                             logicWCTowerODTyvek,
@@ -1104,27 +1107,27 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 
       // PMTs
 
-      G4RotationMatrix* WCPMTRotation = new G4RotationMatrix;
-      WCPMTRotation->rotateY(270.*deg);
-      WCPMTRotation->rotateX(2*pi - (2*pi-totalAngle)/2.);//align the PMT with the Cell
+      G4RotationMatrix* WCODExtraTowerPMTRotation = new G4RotationMatrix;
+      WCODExtraTowerPMTRotation->rotateY(270.*deg);
+      WCODExtraTowerPMTRotation->rotateX(2*pi - (2*pi-totalAngle)/2.);//align the PMT with the Cell
 
       G4double towerWidthOD = WCODRadius*tan(2*pi-totalAngle);
       // We don't want the same number of OD PMTs squished horizontally so we scale down the horizontal PMTs by the width of the extra tower
       G4double ratioOfWidths = (double)(WCPMTODperCellHorizontal)*(towerWidthOD/barrelODCellWidth);
       G4int WCPMTODperCellHorizontalExtra = (int)(ratioOfWidths+0.5);
-      G4double horizontalODSpacing   = towerWidthOD/(double)WCPMTODperCellHorizontalExtra;
-      G4double verticalODSpacing   = barrelODCellHeight/WCPMTODperCellVertical;
+      G4double horizontalODExtraTowerSpacing   = towerWidthOD/(double)WCPMTODperCellHorizontalExtra;
+      G4double verticalODExtraTowerSpacing   = barrelODCellHeight/WCPMTODperCellVertical;
 
       for(G4double i = 0; i < (WCPMTODperCellHorizontalExtra); i++){
         for(G4double j = 0; j < WCPMTODperCellVertical; j++){
 			G4ThreeVector Container =  G4ThreeVector((WCODRadius)/cos(dPhi/2.)*cos((2.*pi-totalAngle)/2.),
-													 -towerWidthOD/2.+(i+0.5)*horizontalODSpacing,
-													 -(barrelCellHeight * (WCODRadius/WCIDRadius))/2.+(j+0.5)*verticalODSpacing);
+													 -towerWidthOD/2.+(i+0.5)*horizontalODExtraTowerSpacing,
+													 -(barrelCellHeight * (WCODRadius/WCIDRadius))/2.+(j+0.5)*verticalODExtraTowerSpacing);
 
 			Container.rotateZ(-(2*pi-totalAngle)/2.); // align with the symmetry
 
-			G4VPhysicalVolume* physiWCExtraBarrelWLSPlate =
-					new G4PVPlacement(WCPMTRotation,              // its rotation
+			//G4VPhysicalVolume* physiWCExtraBarrelWLSPlate =
+					new G4PVPlacement(WCODExtraTowerPMTRotation,              // its rotation
 									  Container,
 									  logicWCODWLSAndPMT,                // its logical volume
 									  "WCExtraBarrelCellODContainer",             // its name
@@ -1173,7 +1176,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 		  //		  std::cout << " qqqqqqqqqqqqqqqqqqqqqqqq cap i " << i << " of " << CapNCell << " j " << j << " of " << CapNCell << " Container (" << topWLSpos.x() << ", " << topWLSpos.y()
 		  //				  << ", " << topWLSpos.z() << ") " << std::endl;
 
-			G4VPhysicalVolume* physiTopCapWLSPlate =
+			//G4VPhysicalVolume* physiTopCapWLSPlate =
 					new G4PVPlacement(0,                   // its rotation
 									  topWLSpos,
 									  logicWCODWLSAndPMT,   // its logical volume
@@ -1183,7 +1186,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
 									  icopy);
 
 
-			G4VPhysicalVolume* physiBottomCapWLSPlate =
+			//G4VPhysicalVolume* physiBottomCapWLSPlate =
 					new G4PVPlacement(WCCapPMTRotation,                             // its rotation
 									  bottomWLSpos,
 									  logicWCODWLSAndPMT,   // its logical volume
@@ -1214,7 +1217,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
     logicBottomCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
     logicTopCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);}
 
-  G4VPhysicalVolume* physiTopCapAssembly =
+  //G4VPhysicalVolume* physiTopCapAssembly =
       new G4PVPlacement(0,
                         G4ThreeVector(0.,0.,(mainAnnulusHeight/2.+ capAssemblyHeight/2.)),
                         logicTopCapAssembly,
@@ -1222,7 +1225,7 @@ If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the 
                         logicWCBarrel,
                         false, 0,true);
 
-  G4VPhysicalVolume* physiBottomCapAssembly =
+  //G4VPhysicalVolume* physiBottomCapAssembly =
       new G4PVPlacement(0,
                         G4ThreeVector(0.,0.,(-mainAnnulusHeight/2.- capAssemblyHeight/2.)),
                         logicBottomCapAssembly,
@@ -1280,7 +1283,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
                         0,0,0);
   //G4cout << *solidWCBarrelBorderRing << G4endl;
 
-  G4VPhysicalVolume* physiWCBarrelBorderRing =
+  //G4VPhysicalVolume* physiWCBarrelBorderRing =
     new G4PVPlacement(0,
                   G4ThreeVector(0.,0.,(capAssemblyHeight/2.- barrelCellHeight/2.)*zflip),
                   logicWCBarrelBorderRing,
@@ -1325,14 +1328,14 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
  if (Vis_Choice == "RayTracer"){
 
   if(!debugMode){
-        G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
-        tmpVisAtt->SetForceSolid(true);
-        logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt);
+        G4VisAttributes* tmpVisAtt1 = new G4VisAttributes(G4Colour(1.,0.5,0.5));
+        tmpVisAtt1->SetForceSolid(true);
+        logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt1);
 		logicWCBarrelBorderCell->SetVisAttributes(G4VisAttributes::Invisible);}
   else {
-        G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
-        tmpVisAtt->SetForceWireframe(true);
-        logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt);
+        G4VisAttributes* tmpVisAtt1 = new G4VisAttributes(G4Colour(1.,0.5,0.5));
+        tmpVisAtt1->SetForceWireframe(true);
+        logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt1);
 		logicWCBarrelBorderCell->SetVisAttributes(G4VisAttributes::Invisible);}}
 
 // used for OGLSX
@@ -1341,9 +1344,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
   if(!debugMode)
         {logicWCBarrelBorderCell->SetVisAttributes(G4VisAttributes::Invisible);}
   else {
-        G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
-        tmpVisAtt->SetForceWireframe(true);
-        logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt);}}
+        G4VisAttributes* tmpVisAtt1 = new G4VisAttributes(G4Colour(1.,0.5,0.5));
+        tmpVisAtt1->SetForceWireframe(true);
+        logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt1);}}
 
 
   //------------------------------------------------------------
@@ -1362,15 +1365,14 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
                       false,
                       0,true);
 
-  G4LogicalBorderSurface * WaterBSBarrelBorderCellSurface
-    = new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
+  //G4LogicalBorderSurface * WaterBSBarrelBorderCellSurface =
+      new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
                                  physiWCBarrelBorderCell,
                                  physiWCBarrelBorderCellBlackSheet,
                                  OpWaterBSSurface);
 
   // we have to declare the logical Volumes 
   // outside of the if block to access it later on 
-  G4LogicalVolume* logicWCExtraTowerCell;
   G4LogicalVolume* logicWCExtraBorderCell;
   G4VPhysicalVolume* physiWCExtraBorderCell;
   if(!(WCBarrelRingNPhi*WCPMTperCellHorizontal == WCBarrelNumPMTHorizontal)){
@@ -1421,8 +1423,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
 			false,
 			0,true);
 
-    G4LogicalBorderSurface * WaterBSExtraBorderCellSurface 
-      = new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
+    //G4LogicalBorderSurface * WaterBSExtraBorderCellSurface =
+        new G4LogicalBorderSurface("WaterBSBarrelCellSurface",
 				   physiWCExtraBorderCell,
 				   physiWCExtraBorderBlackSheet, 
 				   OpWaterBSSurface);
@@ -1595,14 +1597,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
                       logicWCCap,
                       false,
                       0,true);
-   G4LogicalBorderSurface * WaterBSBottomCapSurface 
-      = new G4LogicalBorderSurface("WaterBSCapPolySurface",
+   //G4LogicalBorderSurface * WaterBSBottomCapSurface =
+        new G4LogicalBorderSurface("WaterBSCapPolySurface",
                                    physiWCCap,physiWCCapBlackSheet,
                                    OpWaterBSSurface);
 
-   G4VisAttributes* WCCapBlackSheetVisAtt 
-      = new G4VisAttributes(G4Colour(0.9,0.2,0.2));
-    
 // used for OGLSX
  if (Vis_Choice == "OGLSX"){
 
@@ -1661,7 +1660,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
       //      if ( (comp > WCPMTRadius*WCPMTRadius) && ((sqrt(xoffset*xoffset + yoffset*yoffset) + WCPMTRadius) < WCCapEdgeLimit) ) {
             if (((sqrt(xoffset*xoffset + yoffset*yoffset) + WCPMTRadius) < WCCapEdgeLimit) ) {
 #ifdef ACTIVATE_IDPMTS
-	G4VPhysicalVolume* physiCapPMT =
+	//G4VPhysicalVolume* physiCapPMT =
 	  new G4PVPlacement(WCCapPMTRotation,
 			    cellpos,                   // its position
 			    logicWCPMT,                // its logical volume
@@ -1696,7 +1695,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
 						 -barrelCellWidth/2.+(i+0.5)*horizontalSpacing,
 						 (-(barrelCellHeight-WCBorderPMTOffset)/2.+(j+0.5)*verticalSpacing)*zflip);
 #ifdef ACTIVATE_IDPMTS
-     G4VPhysicalVolume* physiWCBarrelBorderPMT =
+     //G4VPhysicalVolume* physiWCBarrelBorderPMT =
 	new G4PVPlacement(WCPMTRotation,                      // its rotation
 			  PMTPosition,
 			  logicWCPMT,                // its logical volume
@@ -1719,25 +1718,25 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
 
   if(!(WCBarrelRingNPhi*WCPMTperCellHorizontal == WCBarrelNumPMTHorizontal)){
 
-    G4RotationMatrix* WCPMTRotation = new G4RotationMatrix;
-    WCPMTRotation->rotateY(90.*deg);
-    WCPMTRotation->rotateX((2*pi-totalAngle)/2.);//align the PMT with the Cell
+    G4RotationMatrix* WCExtraTowerPMTRotation = new G4RotationMatrix;
+    WCExtraTowerPMTRotation->rotateY(90.*deg);
+    WCExtraTowerPMTRotation->rotateX((2*pi-totalAngle)/2.);//align the PMT with the Cell
                                                  
     G4double towerWidth = WCIDRadius*tan(2*pi-totalAngle);
 
-    G4double horizontalSpacing   = towerWidth/(WCBarrelNumPMTHorizontal-WCBarrelRingNPhi*WCPMTperCellHorizontal);
-    G4double verticalSpacing     = (barrelCellHeight-WCBorderPMTOffset)/WCPMTperCellVertical;
+    G4double extraTowerHorizontalSpacing   = towerWidth/(WCBarrelNumPMTHorizontal-WCBarrelRingNPhi*WCPMTperCellHorizontal);
+    G4double extraTowerVerticalSpacing     = (barrelCellHeight-WCBorderPMTOffset)/WCPMTperCellVertical;
 
     for(G4double i = 0; i < (WCBarrelNumPMTHorizontal-WCBarrelRingNPhi*WCPMTperCellHorizontal); i++){
       for(G4double j = 0; j < WCPMTperCellVertical; j++){
 	G4ThreeVector PMTPosition =  G4ThreeVector(WCIDRadius/cos(dPhi/2.)*cos((2.*pi-totalAngle)/2.),
-				towerWidth/2.-(i+0.5)*horizontalSpacing,
-			       (-(barrelCellHeight-WCBorderPMTOffset)/2.+(j+0.5)*verticalSpacing)*zflip);
+				towerWidth/2.-(i+0.5)*extraTowerHorizontalSpacing,
+			       (-(barrelCellHeight-WCBorderPMTOffset)/2.+(j+0.5)*extraTowerVerticalSpacing)*zflip);
 	PMTPosition.rotateZ(-(2*pi-totalAngle)/2.); // align with the symmetry 
 	                                            //axes of the cell 
 #ifdef ACTIVATE_IDPMTS
-	G4VPhysicalVolume* physiWCBarrelBorderPMT =
-	  new G4PVPlacement(WCPMTRotation,                          // its rotation
+	//G4VPhysicalVolume* physiWCBarrelBorderPMT =
+	  new G4PVPlacement(WCExtraTowerPMTRotation,                          // its rotation
 			    PMTPosition,
 			    logicWCPMT,                // its logical volume
 			    "WCPMT",             // its name
@@ -1772,7 +1771,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
     // barrel cells.
     // ---------------------------------------------------------
 
-    G4VPhysicalVolume* physiWCBarrelBorderCellODTyvek =
+    //G4VPhysicalVolume* physiWCBarrelBorderCellODTyvek =
         new G4PVPlacement(0,
                           G4ThreeVector(0.,0.,0.),
                           logicWCBarrelCellODTyvek,
@@ -1802,7 +1801,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
                                                  -(barrelCellHeight * (barrelODCellWidth/barrelCellWidth))/2.+(j+0.5)*verticalODSpacing);
 
 
-        G4VPhysicalVolume* physiWCBarrelWLSPlate =
+        //G4VPhysicalVolume* physiWCBarrelWLSPlate =
             new G4PVPlacement(WCPMTODRotation,           // its rotation
                               Container,
                               logicWCODWLSAndPMT,         // its logical volume
@@ -1819,7 +1818,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
 
     if(!(WCBarrelRingNPhi*WCPMTperCellHorizontal == WCBarrelNumPMTHorizontal)){
 
-      G4VPhysicalVolume* physiWCExtraBorderODTyvek =
+      //G4VPhysicalVolume* physiWCExtraBorderODTyvek =
           new G4PVPlacement(0,
                             G4ThreeVector(0.,0.,0.),
                             logicWCTowerODTyvek,
@@ -1828,30 +1827,30 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4int zflip)
                             false,
                             0,true);
 
-      G4double barrelODCellWidth   = 2.*WCODRadius*tan(dPhi/2.);
-      G4double barrelODCellHeight  = barrelCellHeight * (barrelODCellWidth/barrelCellWidth);
+      G4double barrelODExtraTowerCellWidth   = 2.*WCODRadius*tan(dPhi/2.);
+      G4double barrelODExtraTowerCellHeight  = barrelCellHeight * (barrelODExtraTowerCellWidth/barrelCellWidth);
       
-      G4RotationMatrix* WCPMTRotation = new G4RotationMatrix;
-      WCPMTRotation->rotateY(270.*deg);
-      WCPMTRotation->rotateX(2*pi - (2*pi-totalAngle)/2.);//align the PMT with the Cell
+      G4RotationMatrix* WCODExtraTowerPMTRotation = new G4RotationMatrix;
+      WCODExtraTowerPMTRotation->rotateY(270.*deg);
+      WCODExtraTowerPMTRotation->rotateX(2*pi - (2*pi-totalAngle)/2.);//align the PMT with the Cell
 
       G4double towerWidthOD = WCODRadius*tan(2*pi-totalAngle);
       // We don't want the same number of OD PMTs squished horizontally so we scale down the horizontal PMTs by the width of the extra tower
-      G4double ratioOfWidths = (double)(WCPMTODperCellHorizontal)*(towerWidthOD/barrelODCellWidth);
+      G4double ratioOfWidths = (double)(WCPMTODperCellHorizontal)*(towerWidthOD/barrelODExtraTowerCellWidth);
       G4int WCPMTODperCellHorizontalExtra = (int)(ratioOfWidths+0.5);
-      G4double horizontalODSpacing   = towerWidthOD/(double)WCPMTODperCellHorizontalExtra;
-      G4double verticalODSpacing   = barrelODCellHeight/WCPMTODperCellVertical;
+      G4double horizontalODExtraTowerSpacing   = towerWidthOD/(double)WCPMTODperCellHorizontalExtra;
+      G4double verticalODExtraTowerSpacing   = barrelODExtraTowerCellHeight/WCPMTODperCellVertical;
       
 
       for(G4double i = 0; i < (WCPMTODperCellHorizontalExtra); i++){
         for(G4double j = 0; j < WCPMTODperCellVertical; j++){
           G4ThreeVector Container =  G4ThreeVector((WCODRadius)/cos(dPhi/2.)*cos((2.*pi-totalAngle)/2.),
-													 -towerWidthOD/2.+(i+0.5)*horizontalODSpacing,
-													 -(barrelCellHeight * (WCODRadius/WCIDRadius))/2.+(j+0.5)*verticalODSpacing);
+													 -towerWidthOD/2.+(i+0.5)*horizontalODExtraTowerSpacing,
+													 -(barrelCellHeight * (WCODRadius/WCIDRadius))/2.+(j+0.5)*verticalODExtraTowerSpacing);
           Container.rotateZ(-(2*pi-totalAngle)/2.); // align with the symmetry
 
-          G4VPhysicalVolume* physiWCBarrelPMT =
-              new G4PVPlacement(WCPMTRotation,             // its rotation
+          //G4VPhysicalVolume* physiWCBarrelPMT =
+              new G4PVPlacement(WCODExtraTowerPMTRotation,             // its rotation
                                 Container,
                                 logicWCODWLSAndPMT,                // its logical volume
                                 "WCExtraBorderCellODContainer",             // its name

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -27,7 +27,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
   G4double pressure    = 1.e-19*pascal;
   G4double temperature = 0.1*kelvin;
   a = 1.01*g/mole;
-  G4Material* Vacuum = 
+  //G4Material* Vacuum = 
     new G4Material("Vacuum", 1., a, density,
                    kStateGas,temperature,pressure);
 
@@ -296,8 +296,9 @@ void WCSimDetectorConstruction::ConstructMaterials()
 // -------------------------------------------------------------
 
 
+  /*
   const G4int NUMENTRIES = 32;
- 
+
   G4double PPCKOV[NUMENTRIES] =
     { 2.034E-9*GeV, 2.068E-9*GeV, 2.103E-9*GeV, 2.139E-9*GeV,
       2.177E-9*GeV, 2.216E-9*GeV, 2.256E-9*GeV, 2.298E-9*GeV,
@@ -307,7 +308,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
       3.026E-9*GeV, 3.102E-9*GeV, 3.181E-9*GeV, 3.265E-9*GeV,
       3.353E-9*GeV, 3.446E-9*GeV, 3.545E-9*GeV, 3.649E-9*GeV,
       3.760E-9*GeV, 3.877E-9*GeV, 4.002E-9*GeV, 4.136E-9*GeV };
-
+  */
 
   // default values
   /*
@@ -511,6 +512,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
 
    // Get from the tuning parameters
+   /*
    G4double MIEFF = WCSimTuningParams->GetMieff();
    //G4double MIEFF = 0.0;
    //    G4cout << "MIEFF: " << MIEFF << G4endl;
@@ -530,6 +532,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
       141456*cm*MIEFF,  122931*cm*MIEFF,  106288*cm*MIEFF, 91395.2*cm*MIEFF,   78125*cm*MIEFF, 
      66355.2*cm*MIEFF, 55968.2*cm*MIEFF, 46851.2*cm*MIEFF, 38896.2*cm*MIEFF,   32000*cm*MIEFF
    };
+   */
 
    //Mie scattering length values when assuming 10 times larger than Rayleigh scattering. 
    /*G4double MIE_water[NUMENTRIES_water] = {
@@ -548,7 +551,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
    };
    */
 
-   G4double MIE_water_const[3]={0.4,0.,1};// gforward, gbackward, forward backward ratio
+   //G4double MIE_water_const[3]={0.4,0.,1};// gforward, gbackward, forward backward ratio
 
 
    //From SFDETSIM
@@ -714,6 +717,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
        0.001*m,0.001*m,0.001*m,0.001*m,0.001*m,0.001*m};
       
        //utter fiction at this stage, does not matter
+   /*
    G4double MIE_air[NUMENTRIES_water] =
      { 0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
        0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
@@ -725,8 +729,9 @@ void WCSimDetectorConstruction::ConstructMaterials()
        0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
        0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,
        0.1*m,0.1*m,0.1*m,0.1*m,0.1*m,0.1*m};
+   */
 
-   G4double MIE_air_const[3]={0.99,0.99,0.8};// gforward, gbackward, forward backward ratio
+   //G4double MIE_air_const[3]={0.99,0.99,0.8};// gforward, gbackward, forward backward ratio
 
      
    //Not used yet, fictional values
@@ -890,8 +895,8 @@ void WCSimDetectorConstruction::ConstructMaterials()
 
   G4MaterialPropertiesTable *WlsPlasticMPT = new G4MaterialPropertiesTable();
 
-  double no_absorption = 1000.*m;
-  double immediate_absorption = 0.*m;
+  //double no_absorption = 1000.*m;
+  //double immediate_absorption = 0.*m;
   double some_absorption = 1.*m;
 
   // active glass will be a thin layer absorbing everything in the right energy range

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -229,7 +229,7 @@ else {
   //*Ugly implementation for Light Cone T.Y. 2018.2.13
   if (0 < lightcollector && lightcollector < 3){
 	G4cout<<"Registering Light Collectors"<<G4endl;
-	G4VPhysicalVolume* physiLightCone =
+	//G4VPhysicalVolume* physiLightCone =
 	  new G4PVPlacement(0,
 		  G4ThreeVector(0, 0, -1.0*logicLightCone->GetOffset()),
 		  logicLightCone,
@@ -366,7 +366,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
                           0,0,0);
 
   G4VisAttributes* visContainer
-      = new G4VisAttributes(G4Colour((0.0, 1.0, 0.0)));
+      = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
   visContainer->SetForceWireframe(true);
 
   logicContainer->SetVisAttributes(G4VisAttributes::Invisible);
@@ -460,7 +460,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
 
   ////////////////////////////////////////////////
   // Ali G. : Do dat placement inda box
-  G4VPhysicalVolume* physiWLS =
+  //G4VPhysicalVolume* physiWLS =
       new G4PVPlacement(0,
                         G4ThreeVector(0, 0, WCODWLSPlatesThickness/2 + WLS_plate_offset),
                         logicWCODWLSPlate,
@@ -472,7 +472,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
 
   if(BuildODWLSCladding) {
 
-    G4VPhysicalVolume* physiWLSCladding =
+    //G4VPhysicalVolume* physiWLSCladding =
       new G4PVPlacement(0,
                         G4ThreeVector(0, 0, WCODWLSPlatesThickness/2 + WLS_plate_offset),
                         logicWCODWLSPlateCladding,
@@ -485,7 +485,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
     new G4LogicalSkinSurface("cladding_surf",   logicWCODWLSPlateCladding,   WlsOdOpCladdingSurface);
   }
 
-  G4VPhysicalVolume* physiPMT =
+  //G4VPhysicalVolume* physiPMT =
       new G4PVPlacement(0,
                         G4ThreeVector(0, 0, -1.0*PMTOffset),
                         logicWCPMT,

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -2028,35 +2028,35 @@ WCSimBasicPMTObject::WCSimBasicPMTObject(){
 }
 
 WCSimBasicPMTObject::WCSimBasicPMTObject(std::map<G4double,G4double> mQE){
-  mapQE=mQE;
+  fMapQE=mQE;
   std::map<G4double, G4double>::iterator itr;
   for(itr = mQE.begin(); itr != mQE.end(); itr++) {
-    wavelength.push_back(itr->first);
-    QE.push_back(itr->second);
+    fWavelength.push_back(itr->first);
+    fQE.push_back(itr->second);
   }
 }
 
 WCSimBasicPMTObject::WCSimBasicPMTObject(std::vector<G4double> wl,std::vector<G4double> qe,G4double max){
-  wavelength=wl;
-  QE=qe;
-  maxQE=max;
+  fWavelength=wl;
+  fQE=qe;
+  fMaxQE=max;
 }
 
 void WCSimBasicPMTObject::DefineQEHist(std::map<G4double,G4double> mapQE){
 
-  if (gQE != NULL) {
-	  delete gQE;
-	  gQE = nullptr;
+  if (fGQE != NULL) {
+	  delete fGQE;
+	  fGQE = nullptr;
   }
-  gQE = new TGraph(mapQE.size());
+  fGQE = new TGraph(mapQE.size());
   G4int iPt=0;
   std::map<G4double, G4double>::iterator itr;
   for(itr = mapQE.begin(); itr != mapQE.end(); itr++) {
-    gQE->SetPoint(iPt,itr->first,itr->second);
+    fGQE->SetPoint(iPt,itr->first,itr->second);
     iPt++;
   }
 }
 
 WCSimBasicPMTObject::~WCSimBasicPMTObject(){
-  delete gQE;
+  delete fGQE;
 }

--- a/src/WCSimRootGeom.cc
+++ b/src/WCSimRootGeom.cc
@@ -28,7 +28,7 @@ WCSimRootGeom::WCSimRootGeom()
 }
 //______________________________________________________________________________
 WCSimRootGeom::WCSimRootGeom(const WCSimRootGeom & in)
-  : TObject()
+  : TObject(in)
 {
   fWCCylRadius   = in.GetWCCylRadius();
   fWCCylLength   = in.GetWCCylLength();
@@ -77,6 +77,7 @@ WCSimRootPMT::WCSimRootPMT()
 }
 //______________________________________________________________________________
 WCSimRootPMT::WCSimRootPMT(const WCSimRootPMT & in)
+  : TObject(in)
 {
   fTubeNo = in.GetTubeNo();
   fCylLoc = in.GetCylLoc();
@@ -104,20 +105,10 @@ WCSimRootPMT::WCSimRootPMT(Int_t tubeNo, Int_t cylLoc, Double_t orientation[3], 
 void WCSimRootGeom::SetPMT(Int_t i, Int_t tubeno, Int_t cyl_loc, 
 			    Double_t rot[3], Double_t pos[3], bool expand)
 {
-   if(expand) (*(fPMTArray)).ExpandCreate(i+2);
+  if(expand) (*(fPMTArray)).ExpandCreate(i+2);
 
   // Set PMT values
-TClonesArray &pmtArray = *fPMTArray;
-    WCSimRootPMT *jPMT = new(pmtArray[i]) WCSimRootPMT(tubeno, cyl_loc, rot, pos);
-    //WCSimRootPMT jPMT = *(WCSimRootPMT*)(*fPMTArray)[i];
-    // jPMT.SetTubeNo(tubeno);
-    // jPMT.SetCylLoc(cyl_loc);
-    // int j;
-    // for (j=0;j<3;j++){
-    //   jPMT.SetOrientation(j,rot[j]);
-    //   jPMT.SetPosition(j,pos[j]);
-    // }
-
+  new((*fPMTArray)[i]) WCSimRootPMT(tubeno, cyl_loc, rot, pos);
 }
 
 //______________________________________________________________________________

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -92,7 +92,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* /*aRun*/)
 
   geoTree = new TTree("wcsimGeoT","WCSim Geometry Tree");
   wcsimrootgeom = new WCSimRootGeom();
-  TBranch *geoBranch = geoTree->Branch("wcsimrootgeom", "WCSimRootGeom", &wcsimrootgeom, bufsize,0);
+  geoTree->Branch("wcsimrootgeom", "WCSimRootGeom", &wcsimrootgeom, bufsize,0);
 
   FillGeoTree();
 

--- a/src/WCSimSteppingAction.cc
+++ b/src/WCSimSteppingAction.cc
@@ -1,9 +1,3 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <WCSimRootEvent.hh>
-#include <G4SIunits.hh>
-#include <G4OpticalPhoton.hh>
-
 #include "WCSimSteppingAction.hh"
 
 #include "G4Track.hh"
@@ -16,9 +10,18 @@
 #include "G4SDManager.hh"
 #include "G4RunManager.hh"
 
+#include <WCSimRootEvent.hh>
+#include <G4SIunits.hh>
+#include <G4OpticalPhoton.hh>
+
+#include <stdlib.h>
+#include <stdio.h>
+
 ///////////////////////////////////////////////
 ///// BEGINNING OF WCSIM STEPPING ACTION //////
 ///////////////////////////////////////////////
+
+constexpr bool verbose = false;  ///< Local compile-time verbosity switch
 
 
 WCSimSteppingAction::WCSimSteppingAction(WCSimRunAction *myRun, WCSimDetectorConstruction *myDet) : runAction(myRun), det(myDet) {
@@ -28,15 +31,19 @@ WCSimSteppingAction::WCSimSteppingAction(WCSimRunAction *myRun, WCSimDetectorCon
 void WCSimSteppingAction::UserSteppingAction(const G4Step* aStep)
 {
   //DISTORTION must be used ONLY if INNERTUBE or INNERTUBEBIG has been defined in BidoneDetectorConstruction.cc
-  
-  const G4Event* evt = G4RunManager::GetRunManager()->GetCurrentEvent();
+ 
+  //const G4Event* evt = G4RunManager::GetRunManager()->GetCurrentEvent();
 
-  const G4Track* track       = aStep->GetTrack();
-  G4VPhysicalVolume* volume  = track->GetVolume();
+  //const G4Track* track       = aStep->GetTrack();
+  //G4VPhysicalVolume* volume  = track->GetVolume();
 
 
-  G4SDManager* SDman   = G4SDManager::GetSDMpointer();
-  G4HCofThisEvent* HCE = evt->GetHCofThisEvent();
+  //G4SDManager* SDman   = G4SDManager::GetSDMpointer();
+  //G4HCofThisEvent* HCE = evt->GetHCofThisEvent();
+
+  if(verbose && aStep != nullptr) {
+    G4cout << "WCSimSteppingAction::UserSteppingAction() does nothing" << G4endl;
+  }
 
 }
 

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -136,35 +136,34 @@ const std::map<G4String,G4AttDef>* WCSimTrajectory::GetAttDefs() const
 std::vector<G4AttValue>* WCSimTrajectory::CreateAttValues() const
 {
   char c[100];
-  //std::ostrstream s(c,100);
-  std::ostringstream s(c);
+  std::ostringstream st(c);
   
   std::vector<G4AttValue>* values = new std::vector<G4AttValue>;
   
-  s.seekp(std::ios::beg);
-  s << fTrackID << std::ends;
+  st.seekp(std::ios::beg);
+  st << fTrackID << std::ends;
   values->push_back(G4AttValue("ID",c,""));
   
-  s.seekp(std::ios::beg);
-  s << fParentID << std::ends;
+  st.seekp(std::ios::beg);
+  st << fParentID << std::ends;
   values->push_back(G4AttValue("PID",c,""));
   
   values->push_back(G4AttValue("PN",ParticleName,""));
   
-  s.seekp(std::ios::beg);
-  s << PDGCharge << std::ends;
+  st.seekp(std::ios::beg);
+  st << PDGCharge << std::ends;
   values->push_back(G4AttValue("Ch",c,""));
 
-  s.seekp(std::ios::beg);
-  s << PDGEncoding << std::ends;
+  st.seekp(std::ios::beg);
+  st << PDGEncoding << std::ends;
   values->push_back(G4AttValue("PDG",c,""));
 
-  s.seekp(std::ios::beg);
-  s << G4BestUnit(initialMomentum,"Energy") << std::ends;
+  st.seekp(std::ios::beg);
+  st << G4BestUnit(initialMomentum,"Energy") << std::ends;
   values->push_back(G4AttValue("IMom",c,""));
 
-  s.seekp(std::ios::beg);
-  s << GetPointEntries() << std::ends;
+  st.seekp(std::ios::beg);
+  st << GetPointEntries() << std::ends;
   values->push_back(G4AttValue("NTP",c,""));
 
   return values;

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -24,20 +24,22 @@ WCSimWCDigitizerBase::WCSimWCDigitizerBase(G4String name,
 										   WCSimWCDAQMessenger* myMessenger,
 										   DigitizerType_t digitype,
 										   G4String detectorElement)
-  :G4VDigitizerModule(name), myDetector(inDetector), DAQMessenger(myMessenger), DigitizerType(digitype),DigitizerClassName(""), detectorElement(detectorElement)
+  :G4VDigitizerModule(name), fMyDetector(inDetector),
+        fDAQMessenger(myMessenger), fDigitizerClassName(""),
+        fDigitizerType(digitype), fDetectorElement(detectorElement)
 {
   // G4String colName = "WCDigitizedStoreCollection";
   G4String colName;
-  if(detectorElement=="tank") colName = "WCDigitizedStoreCollection";
-  else if(detectorElement=="OD") colName = "WCDigitizedStoreCollection_OD";
+  if(fDetectorElement=="tank") colName = "WCDigitizedStoreCollection";
+  else if(fDetectorElement=="OD") colName = "WCDigitizedStoreCollection_OD";
   collectionName.push_back(colName);
   ReInitialize();
 
 #ifdef HYPER_VERBOSITY
-	if(detectorElement=="OD")G4cout<<"WCSimWCDigitizerBase::WCSimWCDigitizerBase ☆ recording collection name "<<colName<<" for "<<detectorElement<<G4endl;
+	if(fDetectorElement=="OD")G4cout<<"WCSimWCDigitizerBase::WCSimWCDigitizerBase ☆ recording collection name "<<colName<<" for "<<fDetectorElement<<G4endl;
 #endif
 
-  if(DAQMessenger == NULL) {
+  if(fDAQMessenger == NULL) {
     G4cerr << "WCSimWCDAQMessenger pointer is NULL when passed to WCSimWCDigitizerBase constructor. Exiting..." 
 	   << G4endl;
     exit(-1);
@@ -50,15 +52,15 @@ WCSimWCDigitizerBase::~WCSimWCDigitizerBase(){
 void WCSimWCDigitizerBase::GetVariables()
 {
   //set the options to digitizer-specific defaults
-  DigitizerDeadTime          = GetDefaultDeadTime();
-  DigitizerIntegrationWindow = GetDefaultIntegrationWindow();
-  DigitizerTimingPrecision   = GetDefaultTimingPrecision();
-  DigitizerPEPrecision       = GetDefaultPEPrecision();
+  fDigitizerDeadTime          = GetDefaultDeadTime();
+  fDigitizerIntegrationWindow = GetDefaultIntegrationWindow();
+  fDigitizerTimingPrecision   = GetDefaultTimingPrecision();
+  fDigitizerPEPrecision       = GetDefaultPEPrecision();
 
   //read the .mac file to override them
-  if(DAQMessenger != NULL) {
-    DAQMessenger->TellMeAboutTheDigitizer(this);
-    DAQMessenger->SetDigitizerOptions();
+  if(fDAQMessenger != NULL) {
+    fDAQMessenger->TellMeAboutTheDigitizer(this);
+    fDAQMessenger->SetDigitizerOptions();
   }
   else {
     G4cerr << "WCSimWCDAQMessenger pointer is NULL when used in WCSimWCDigitizerBase::GetVariables(). Exiting..." 
@@ -66,10 +68,10 @@ void WCSimWCDigitizerBase::GetVariables()
     exit(-1);
   }
 
-  G4cout << "Using digitizer deadtime "           << DigitizerDeadTime          << " ns" << G4endl;
-  G4cout << "Using digitizer integration window " << DigitizerIntegrationWindow << " ns" << G4endl;
-  G4cout << "Using digitizer time resolution "    << DigitizerTimingPrecision   << " ns" << G4endl;
-  G4cout << "Using digitizer charge resolution "  << DigitizerPEPrecision       << " p.e." << G4endl;
+  G4cout << "Using digitizer deadtime "           << fDigitizerDeadTime          << " ns" << G4endl;
+  G4cout << "Using digitizer integration window " << fDigitizerIntegrationWindow << " ns" << G4endl;
+  G4cout << "Using digitizer time resolution "    << fDigitizerTimingPrecision   << " ns" << G4endl;
+  G4cout << "Using digitizer charge resolution "  << fDigitizerPEPrecision       << " p.e." << G4endl;
 }
 
 void WCSimWCDigitizerBase::Digitize()
@@ -77,11 +79,11 @@ void WCSimWCDigitizerBase::Digitize()
   //Input is WCSimWCDigitsCollection with raw PMT hits (photon + dark noise)
   //Output is WCSimWCDigitsCollection with digitied PMT hits
 
-  //Clear the DigiStoreHitMap
+  //Clear the fDigiStoreHitMap
   ReInitialize();
 
   //Temporary Storage of Digitized hits which is passed to the trigger
-  DigiStore = new WCSimWCDigitsCollection(collectionName[0],collectionName[0]);
+  fDigiStore = new WCSimWCDigitsCollection(collectionName[0],collectionName[0]);
 
   G4DigiManager* DigiMan = G4DigiManager::GetDMpointer();
   
@@ -89,8 +91,8 @@ void WCSimWCDigitizerBase::Digitize()
   // G4int WCHCID = DigiMan->GetDigiCollectionID("WCRawPMTSignalCollection");
 
   G4String rawcollectionName;
-  if(detectorElement=="tank") rawcollectionName = "WCRawPMTSignalCollection";
-  else if(detectorElement=="OD") rawcollectionName = "WCRawPMTSignalCollection_OD";
+  if(fDetectorElement=="tank") rawcollectionName = "WCRawPMTSignalCollection";
+  else if(fDetectorElement=="OD") rawcollectionName = "WCRawPMTSignalCollection_OD";
   G4int WCHCID = DigiMan->GetDigiCollectionID(rawcollectionName);
 
   // Get the PMT Digits collection
@@ -98,18 +100,18 @@ void WCSimWCDigitizerBase::Digitize()
     (WCSimWCDigitsCollection*)(DigiMan->GetDigiCollection(WCHCID));
 
 #ifdef HYPER_VERBOSITY
-	if(detectorElement=="OD"){
+	if(fDetectorElement=="OD"){
 		G4cout << "WCSimWCDigitizerBase::Digitize ☆ making digits collection (WCSimWCDigitsCollection*)"<<collectionName[0]
-					 << " for "<<detectorElement<<" and calling DigitizeHits on "<<rawcollectionName<<" to fill it"<<G4endl;}
+					 << " for "<<fDetectorElement<<" and calling DigitizeHits on "<<rawcollectionName<<" to fill it"<<G4endl;}
 #endif
   
   if (WCHCPMT) {
     DigitizeHits(WCHCPMT);
   } else {
-	  G4cout << "WCSimWCDigitizerBase::Digitize didn't find hit collection for " << detectorElement << G4endl;
+	  G4cout << "WCSimWCDigitizerBase::Digitize didn't find hit collection for " << fDetectorElement << G4endl;
   }
   
-  StoreDigiCollection(DigiStore);
+  StoreDigiCollection(fDigiStore);
 
 }
 
@@ -117,8 +119,8 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, double digihittime, d
 {
   //digitised hit information does not have infinite precision
   //so need to round the charge and time information
-  double digihittime_d = Truncate(digihittime, DigitizerTimingPrecision);
-  double peSmeared_d   = Truncate(peSmeared,   DigitizerPEPrecision);
+  double digihittime_d = Truncate(digihittime, fDigitizerTimingPrecision);
+  double peSmeared_d   = Truncate(peSmeared,   fDigitizerPEPrecision);
 
   //gate is not a trigger, but just the position of the digit in the array
   //inside the WCSimWCDigi object
@@ -136,24 +138,24 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, double digihittime, d
 
   //use un-truncated peSmeared here, so that truncation does not affect the test
   if (peSmeared > 0.0) {
-      if ( DigiStoreHitMap[tube] == 0) {
+      if ( fDigiStoreHitMap[tube] == 0) {
 	WCSimWCDigi* Digi = new WCSimWCDigi();
 	Digi->SetTubeID(tube);
 	Digi->SetPe(gate,peSmeared_d);
 	Digi->AddPe(digihittime_d);
 	Digi->SetTime(gate,digihittime_d);
 	Digi->AddDigiCompositionInfo(digi_comp);
-	DigiStoreHitMap[tube] = DigiStore->insert(Digi);
+	fDigiStoreHitMap[tube] = fDigiStore->insert(Digi);
 #ifdef WCSIMWCDIGITIZER_VERBOSE
 	if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	  G4cout << " NEW HIT" << G4endl;
 #endif
       }
       else {
-	(*DigiStore)[DigiStoreHitMap[tube]-1]->SetPe(gate,peSmeared_d);
-	(*DigiStore)[DigiStoreHitMap[tube]-1]->SetTime(gate,digihittime_d);
-	(*DigiStore)[DigiStoreHitMap[tube]-1]->AddPe(digihittime_d);
-	(*DigiStore)[DigiStoreHitMap[tube]-1]->AddDigiCompositionInfo(digi_comp);
+	(*fDigiStore)[fDigiStoreHitMap[tube]-1]->SetPe(gate,peSmeared_d);
+	(*fDigiStore)[fDigiStoreHitMap[tube]-1]->SetTime(gate,digihittime_d);
+	(*fDigiStore)[fDigiStoreHitMap[tube]-1]->AddPe(digihittime_d);
+	(*fDigiStore)[fDigiStoreHitMap[tube]-1]->AddDigiCompositionInfo(digi_comp);
 #ifdef WCSIMWCDIGITIZER_VERBOSE
 	if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	  G4cout << " DEJA VU" << G4endl;
@@ -173,11 +175,11 @@ bool WCSimWCDigitizerBase::AddNewDigit(int tube, int gate, double digihittime, d
 
 void WCSimWCDigitizerBase::SaveOptionsToOutput(WCSimRootOptions * wcopt)
 {
-  wcopt->SetDigitizerClassName(DigitizerClassName);
-  wcopt->SetDigitizerDeadTime(DigitizerDeadTime);
-  wcopt->SetDigitizerIntegrationWindow(DigitizerIntegrationWindow);
-  wcopt->SetDigitizerTimingPrecision(DigitizerTimingPrecision);
-  wcopt->SetDigitizerPEPrecision(DigitizerPEPrecision);
+  wcopt->SetDigitizerClassName(fDigitizerClassName);
+  wcopt->SetDigitizerDeadTime(fDigitizerDeadTime);
+  wcopt->SetDigitizerIntegrationWindow(fDigitizerIntegrationWindow);
+  wcopt->SetDigitizerTimingPrecision(fDigitizerTimingPrecision);
+  wcopt->SetDigitizerPEPrecision(fDigitizerPEPrecision);
 }
 
 
@@ -191,7 +193,7 @@ WCSimWCDigitizerSKI::WCSimWCDigitizerSKI(G4String name,
                                          G4String detectorElement)
   : WCSimWCDigitizerBase(name, myDetector, myMessenger, kDigitizerSKI, detectorElement)
 {
-  DigitizerClassName = "SKI";
+  fDigitizerClassName = "SKI";
   GetVariables();
 }
 
@@ -200,13 +202,13 @@ WCSimWCDigitizerSKI::~WCSimWCDigitizerSKI(){
 
 void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 
-  if(detectorElement=="tank") G4cout << "TANK # ";
-  if(detectorElement=="OD")   G4cout << "OD # ";
+  if(fDetectorElement=="tank") G4cout << "TANK # ";
+  if(fDetectorElement=="OD")   G4cout << "OD # ";
   G4cout << "WCSimWCDigitizerSKI::DigitizeHits START WCHCPMT->entries() = " << WCHCPMT->entries() << G4endl;
 
   //Get the PMT info for hit time smearing
-  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
-  WCSimPMTObject * PMT = myDetector->GetPMTPointer(WCIDCollectionName);
+  G4String WCIDCollectionName = fMyDetector->GetIDCollectionName();
+  WCSimPMTObject * PMT = fMyDetector->GetPMTPointer(WCIDCollectionName);
 
   // G. Pronost 2019/09/09:
   // Hit need to be sorted! (This is done no where!)
@@ -239,8 +241,8 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 #endif
 
       //Sorting done.  Now we integrate the charge on each PMT.
-      // Integration occurs for DigitizerIntegrationWindow ns (user set)
-      // Digitizer is then dead for DigitizerDeadTime ns (user set)
+      // Integration occurs for fDigitizerIntegrationWindow ns (user set)
+      // Digitizer is then dead for fDigitizerDeadTime ns (user set)
 
       //look over all hits on the PMT
       //integrate charge and start digitizing
@@ -263,9 +265,9 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	  //Hits must be sorted in time
 	  if(ip==0) {
 	    intgr_start=time;
-	    peSmeared = 0;
+	    fPESmeared = 0;
 	    //Set the limits of the integration window [intgr_start,upperlimit]                                                                                            
-	    upperlimit = intgr_start + DigitizerIntegrationWindow;
+	    upperlimit = intgr_start + fDigitizerIntegrationWindow;
 	  }
 	  
 #ifdef WCSIMWCDIGITIZER_VERBOSE
@@ -280,7 +282,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 
 	  bool MakeDigit = false;
 	  if(time >= intgr_start && time <= upperlimit) {
-	    peSmeared += pe;
+	    fPESmeared += pe;
 	    photon_unique_id = ip+absoluteindex;
 	    digi_comp.push_back(photon_unique_id);
       
@@ -297,7 +299,7 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	  //if ensures we don't append the same digit multiple times while in the integration window
 	  else if(digi_comp.size()) {
 	    //this hit is outside the integration time window.
-	    //Charge integration is over.  The is now a DigitizerDeadTime ns dead
+	    //Charge integration is over.  The is now a fDigitizerDeadTime ns dead
 	    //time period where no hits can be recorded
 	    MakeDigit = true;
 	  }
@@ -305,17 +307,17 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	  //Make digit here
 	  if(MakeDigit) {
 	    int iflag;
-	    WCSimWCDigitizerSKI::Threshold(peSmeared,iflag);
+	    WCSimWCDigitizerSKI::Threshold(fPESmeared,iflag);
 
 	    //Check if previous hit passed the threshold.  If so we will digitize the hit
 	    if(iflag == 0) {
 	      //apply time smearing
-	      double Q = (peSmeared > 0.5) ? peSmeared : 0.5;
+	      double Q = (fPESmeared > 0.5) ? fPESmeared : 0.5;
 	      //digitize hit
-	      peSmeared *= efficiency;
+	      fPESmeared *= efficiency;
 	      bool accepted = WCSimWCDigitizerBase::AddNewDigit(tube, digi_unique_id,
 								intgr_start + PMT->HitTimeSmearing(Q),
-								peSmeared, digi_comp);
+								fPESmeared, digi_comp);
 	      if(accepted) {
 		digi_unique_id++;
 	      }
@@ -333,21 +335,21 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	  }
 	  
 	  //Now try and deal with the next hit
-	  if(time > upperlimit && time <= upperlimit + DigitizerDeadTime) {
+	  if(time > upperlimit && time <= upperlimit + fDigitizerDeadTime) {
 	    //Now we need to reject hits that are after the integration
 	    //period to the end of the veto signal
 	    continue;
 	  }
-	  else if(time > upperlimit + DigitizerDeadTime){
+	  else if(time > upperlimit + fDigitizerDeadTime){
 #ifdef WCSIMWCDIGITIZER_VERBOSE
 	    if(tube < NPMTS_VERBOSE || tube == VERBOSE_PMT)
 	      G4cout<<"*** PREPARING FOR >1 DIGI ***"<<G4endl;
 #endif
 	    //we now need to start integrating from the hit
 	    intgr_start=time;
-	    peSmeared = pe;
+	    fPESmeared = pe;
 	    //Set the limits of the integration window [intgr_start,upperlimit]
-	    upperlimit = intgr_start + DigitizerIntegrationWindow;
+	    upperlimit = intgr_start + fDigitizerIntegrationWindow;
 
 	    //store the digi composition information
 	    photon_unique_id = ip+absoluteindex;
@@ -357,15 +359,15 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	    //as the loop will not evaluate again
 	    if(ip+1 == (*WCHCPMT)[i]->GetTotalPe()) {
 	      int iflag;
-	      WCSimWCDigitizerSKI::Threshold(peSmeared,iflag);
+	      WCSimWCDigitizerSKI::Threshold(fPESmeared,iflag);
 	      if(iflag == 0) {
 		//apply time smearing
-		double Q = (peSmeared > 0.5) ? peSmeared : 0.5;
+		double Q = (fPESmeared > 0.5) ? fPESmeared : 0.5;
 		//digitize hit
-		peSmeared *= efficiency;
+		fPESmeared *= efficiency;
 		bool accepted = WCSimWCDigitizerBase::AddNewDigit(tube, digi_unique_id,
 								  intgr_start + PMT->HitTimeSmearing(Q),
-								  peSmeared, digi_comp);
+								  fPESmeared, digi_comp);
 		if(accepted) {
 		  digi_unique_id++;
 		}
@@ -385,14 +387,14 @@ void WCSimWCDigitizerSKI::DigitizeHits(WCSimWCDigitsCollection* WCHCPMT) {
 	}//ip (totalpe)
 	absoluteindex+=(*WCHCPMT)[i]->GetTotalPe();
     }//i (WCHCPMT->entries())
-  G4cout<<"WCSimWCDigitizerSKI::DigitizeHits END DigiStore->entries() " << DigiStore->entries() << "\n";
+  G4cout<<"WCSimWCDigitizerSKI::DigitizeHits END fDigiStore->entries() " << fDigiStore->entries() << "\n";
   
 #ifdef WCSIMWCDIGITIZER_VERBOSE
   G4cout<<"\n\n\nCHECK DIGI COMP:"<<G4endl;
-  for (G4int idigi = 0 ; idigi < DigiStore->entries() ; idigi++){
-    int tubeid = (*DigiStore)[idigi]->GetTubeID();
+  for (G4int idigi = 0 ; idigi < fDigiStore->entries() ; idigi++){
+    int tubeid = (*fDigiStore)[idigi]->GetTubeID();
     if(tubeid < NPMTS_VERBOSE) {
-      std::map< int, std::vector<int> > comp = (*DigiStore)[idigi]->GetDigiCompositionInfo();
+      std::map< int, std::vector<int> > comp = (*fDigiStore)[idigi]->GetDigiCompositionInfo();
       for(size_t i = 0; i < comp.size(); i++){
 	G4cout << "tube "  << tubeid
 	       << " gate " << i << " p_id";

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -29,9 +29,9 @@ extern "C" void skrn1pe_(double* );
 G4double WCSimWCPMT::first_time = 0;
 
 WCSimWCPMT::WCSimWCPMT(G4String name,
-                       WCSimDetectorConstruction* myDetector,
-                       G4String detectorElement)
-  :G4VDigitizerModule(name), detectorElement(detectorElement)
+                       WCSimDetectorConstruction* myDet,
+                       G4String detElem)
+  :G4VDigitizerModule(name), myDetector {myDet}, detectorElement {detElem}
 {
   // G4String colName = "WCRawPMTSignalCollection";
   // collectionName.push_back(colName);
@@ -39,7 +39,6 @@ WCSimWCPMT::WCSimWCPMT(G4String name,
   if(detectorElement=="tank") collectionName.push_back("WCRawPMTSignalCollection");
   else if(detectorElement=="OD") collectionName.push_back("WCRawPMTSignalCollection_OD");
   else G4cout << "detectorElement undefined..." << G4endl;
-  this->myDetector = myDetector;
   DigiHitMapPMT.clear();
 
   #ifdef HYPER_VERBOSITY
@@ -138,15 +137,10 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
   std::sort(WCHC->GetVector()->begin(), WCHC->GetVector()->end(), WCSimWCHit::SortFunctor_Hit());
 
   //Get the PMT info for hit time smearing
-  // G4String WCIDCollectionName = myDetector->GetIDCollectionName();
-  // WCSimPMTObject * PMT = myDetector->GetPMTPointer(WCIDCollectionName);
-
   G4String WCCollectionName;
   if(detectorElement=="tank") WCCollectionName = myDetector->GetIDCollectionName();
   else if(detectorElement=="OD") WCCollectionName = myDetector->GetODCollectionName();
 
-  WCSimPMTObject * PMT = myDetector->GetPMTPointer(WCCollectionName);
-  
   // Correct timing to be within 1 sec (needed for radioactive decay as forcing the decay lead to some strange results)
   
 


### PR DESCRIPTION
Eliminates the causes of most trivial compiler warnings when compiled with gcc 4.8.5, and fixes a couple of bugs indicated by some non-trivial compiler warnings.

See notes in spradlin/WCSim#9.

Most of the compiler warnings are variable name clashes, which were addressed by renaming one of the conflicting objects.

Bugs addressed include
- An incorrect use of the G4Colour rgb constructor in `src/WCSimConstructPMT.cc`, and
- Incomplete implementation of inline functions in `include/WCSimRunAction.hh` that allow termination without a return value

The remaining compiler warnings from `include/WCSimTrajectory.hh` indicate an unimplemented feature in `WCSimTrajectory::DrawTrajectory()` that is assumed by invocation in `WCSimEventAction::EndOfEventAction()`.

The remaining compiler warnings from `src/WCSimPrimaryGeneratorAction.cc` indicate potential mismatches in the cosmic muon flux between the version read from a file and the internal representation as a pair of `TH2D`s.