### PR TITLE
Migrate to Geant4.10.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ More detailed information about the simulation is available in
 ## Current notes and how to build
 
 You should have a recent and working version of ROOT and GEANT4.
-(Known to work with GEANT 4.10.1p03 and ROOT v5.28.00)  You also need all of the G4
-data files including hadron xsecs etc.  Those are the only
-requirements.  The code should work with gcc 4.4.7. For v1.6.0 and earlier, use GEANT 4.9.4.p01.
+You also need all of the G4 data files including hadron xsecs etc.
+Those are the only requirements.
+* Known to work with GEANT 4.10.3p03 and ROOT v6.20.04, gcc 4.8.5
+* For v1.10.0 and earlier, use GEANT 4.10.1p03 and ROOT v5.28.00
+* For v1.6.0 and earlier, use GEANT 4.9.4.p01.
 
 ### Build Instructions using make:
 

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -67,9 +67,9 @@
 # 3. The third option means all the QE are applied at the detector
 # Good for the low energy running.
 # 4. Switch off the QE complety, ie. set it at 100%
-/WCSim/PMTQEMethod     Stacking_Only
+#/WCSim/PMTQEMethod     Stacking_Only
 #/WCSim/PMTQEMethod     Stacking_And_SensitiveDetector
-#/WCSim/PMTQEMethod     SensitiveDetector_Only
+/WCSim/PMTQEMethod     SensitiveDetector_Only
 #/WCSim/PMTQEMethod     DoNotApplyQE
 
 #turn on or off the collection efficiency

--- a/setup/env_sukap.sh
+++ b/setup/env_sukap.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # ROOT version as argument, default value is 6 for ROOT6
-#ROOT_ARG=5
 ROOT_ARG=6
 
 if [ ! -z "$1" ] ; then
@@ -13,7 +12,7 @@ fi
 # CMAKE
 ############################
 
-export PATH=/usr/local/cmake-3.18.1/bin/:$PATH
+cmake --version
 
 ############################
 # ROOT/CERN
@@ -26,17 +25,19 @@ if [[ "$ROOT_ARG" == 5 ]] ; then
 	#
 	export ROOT_DIR=/home/pronost/software/root-5.34.38-build
 	export ROOT_STR=ROOT5
-else
+elif [[ "$ROOT_ARG" == 6 ]] ; then
 	echo "Use ROOT6"
 	# Note: There is no official ROOT 6 installation 
 	#  Temporary use Guillaume Pronost's version. Should change in the future.
 	export ROOT_DIR=/home/pronost/software/root-6.22.00-build
 	export ROOT_STR=ROOT6
+else
+    echo "Unknown argument: $1"
+    echo "Usage: env_sukap.sh [5|6]"
+    echo "Defaults to using ROOT 6"
+    return
 fi
 	
-# Note: There is no official ROOT 6 installation 
-#  Temporary use Guillaume Pronost's version. Should change in the future.
-#export ROOT_DIR=/home/pronost/software/root-6.22.00-build
 source ${ROOT_DIR}/bin/thisroot.sh
 
 alias root='root -l'
@@ -46,17 +47,20 @@ alias root='root -l'
 ############################
 
 pwd=$PWD
-cd /usr/local/geant4.10/geant4.10.03.p02/bin/
+GEANT4VERSION=geant4.10.05.p01
+#alternative naming convention used by the share/ folder...
+GEANT4VERSION_ALT=Geant4-10.5.1
+cd /usr/local/sklib_gcc8/$GEANT4VERSION/bin/
 source geant4.sh
-cd /usr/local/geant4.10/geant4.10.03.p02/share/Geant4-10.3.2/geant4make/
+cd /usr/local/sklib_gcc8/$GEANT4VERSION/share/$GEANT4VERSION_ALT/geant4make/
 source geant4make.sh
-echo "Connect a PATH of Geant4.10"
+echo "Using $GEANT4VERSION"
 cd "$pwd"
 
 ############################
 # WCSim
 ############################
 export BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-export WCSIMDIR=$(pwd)-build/ROOT5/$BRANCH_NAME
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$WCSIMDIR
-
+export WCSIMDIR=$(pwd)-build/$ROOT_STR/$BRANCH_NAME
+export LD_LIBRARY_PATH=$WCSIMDIR:$LD_LIBRARY_PATH
+export WCSIMREPO=$(pwd)

--- a/src/WCSimVisManager.cc
+++ b/src/WCSimVisManager.cc
@@ -146,8 +146,8 @@ void WCSimVisManager::RegisterGraphicsSystems () {
     G4cout <<
       "\nYou have successfully chosen to use the following graphics systems."
 	 << G4endl;
-    PrintAvailableGraphicsSystems (); //use this version for Geant4.10.1
-    //PrintAvailableGraphicsSystems (GetVerbosityValue(fVerbose)); //use this version for Geant4.10.2+
+    //PrintAvailableGraphicsSystems (); //use this version for Geant4.10.1
+    PrintAvailableGraphicsSystems (GetVerbosityValue(fVerbose)); //use this version for Geant4.10.2+
   }
   RegisterModel(mymodel);
 


### PR DESCRIPTION
In order to use any version of Geant4 since 4.10.2, a minor change is required to the WCSim code due to a method argument change
If you are simulating radioactivity, 4.10.3 is the minimum version you should use, due to known bugs in previous versions
The nuPRISM version already uses the new version

The sukap setup script has also been modified to use Geant4.10.5.p01, simply because this is a version that is already installed on sukap. I must warn that changes to the output of WCSim are only known to be small between Geant 4.10.1 & 4.10.3. There may be large changes between Geant 4.10.3 & 4.10.5

I will let this PR sit for a while, as it concerns changing the recommended version of Geant4, which is not a trivial change. A new version will be tagged too