### PR TITLE
Feature/install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ make.result
 bin/
 tmp/
 doxygen/
+cmake-build-*
+build
 
 #ignore run results
 *.root
@@ -25,3 +27,4 @@ geofile.txt
 
 ##ignore compiled python scripts
 *.pyc
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,98 +1,53 @@
-## Based on CMakeLists.txt from AnaEx02 in examples/extended of Geant4.9.6 ##
-## Modified for ROOT6 support on 2020/11/26 by Guillaume Pronost
-#----------------------------------------------------------------------------
-# Setup the project
-cmake_minimum_required(VERSION 2.8.10 FATAL_ERROR)
-project(WCSim)
+# Minimum cmake verison 3.1 required for the variable CMAKE_CXX_STANDARD
+cmake_minimum_required(VERSION 3.1)
 
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
-    message(STATUS "GCC version >= 4.4 required!")
-    return()
-endif()
+# ##############################################################################
+# setup #
+# ##############################################################################
 
-#----------------------------------------------------------------------------
-# Find ROOT (required package) in CONFIG mode. Looking for ROOTConfig.cmake.
-# Crucial for loading the proper definitions!
-#
+set(PROJECT_NAME WCSim)
+set(PROJECT_VERSION 1.0)
+
+project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
+
+# From https://blog.kitware.com/cmake-and-the-default-build-type/
+# Set a default build type to Release if none was specified
+# This has to be before Scarab PackageBuilder since the package builder defines the default mode to DEBUG...
+set(default_build_type "Release")
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+            STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+            "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif ()
+
+set(PBUILDER ON)
+list(APPEND CMAKE_MODULE_PATH
+        ${PROJECT_SOURCE_DIR}/cmake)
+include(PackageBuilder)
+
+pbuilder_prepare_project()
+
+set(CMAKE_CXX_STANDARD 14) # Enable c++14 standard
+
+
+######
+# ROOT
+######
+
 find_package(ROOT COMPONENTS CONFIG REQUIRED)
-if(NOT ROOT_FOUND)
-  message(STATUS "ROOT package not found.") 
-  return()
-endif()
+if (ROOT_FOUND)
 
-message(STATUS "ROOT VERSION ${ROOT_VERSION}")
+else (ROOT_FOUND)
+    message(FATAL "Unable to find ROOT")
+endif (ROOT_FOUND)
 
-## Load macros: need to compile ROOT through cmake first and execute bin/thisroot.sh
 include(${ROOT_USE_FILE})
+include_directories (${ROOT_INCLUDE_DIR})
+LIST(APPEND PUBLIC_EXT_LIBS ${ROOT_LIBRARIES})
 
-#----------------------------------------------------------------------------
-# Locate sources and headers for this project
-# ## NOT NEEDED FOR DICT
-include_directories(${PROJECT_SOURCE_DIR}/include 
-                    ${PROJECT_SOURCE_DIR}/../shared/include 
-                    ${Geant4_INCLUDE_DIR}
-                    ${ROOT_INCLUDE_DIR})
-
-#----------------------------------------------------------------------------
-# Add libraries: need to compile the Dict before linking WCSim !!
-# in standard makefile, need to make rootcint anyway before standard make
-#
-
-ADD_CUSTOM_TARGET(LinkDirectories ALL
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/include 	${CMAKE_CURRENT_BINARY_DIR}/include
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/src 		${CMAKE_CURRENT_BINARY_DIR}/src)
-
-## WCSimRootDict.cc regeneration by rootcint
-
-## WCSimRootDict.cc regeneration by rootcint
-## Use ROOT 5.34.32 as some issues with PARSE_ARGUMENTS were found in older ROOT versions (ROOT 5.34.11)
-if ( ${ROOT_VERSION} GREATER_EQUAL 6 )
-	# ROOT6 doesn't accept '/' in target and header names, use include_directories instead 
-	# and move the dict source after
-	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-	ROOT_GENERATE_DICTIONARY(	WCSimRootDict 
-					WCSimRootEvent.hh 
-					WCSimRootGeom.hh 
-					WCSimPmtInfo.hh 
-					WCSimEnumerations.hh 
-					WCSimRootOptions.hh 
-					WCSimRootTools.hh 
-					LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
-else()
-	# ROOT5 need the full path
-	## Use ROOT 5.34.32 as some issues with PARSE_ARGUMENTS were found in older ROOT versions (ROOT 5.34.11)
-	ROOT_GENERATE_DICTIONARY(	WCSimRootDict 
-					${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootEvent.hh 
-					${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootGeom.hh 
-					${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimPmtInfo.hh 
-					${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimEnumerations.hh  
-					${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootOptions.hh 
-					${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootTools.hh 
-					LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)			
-endif()
-
-## Crucial for reading ROOT classes: make shared object library
-add_library(WCSimRoot SHARED 
-		./src/WCSimRootEvent.cc 
-		./src/WCSimRootGeom.cc 
-		./src/WCSimPmtInfo.cc 
-		./src/WCSimEnumerations.cc 
-		./src/WCSimRootOptions.cc 
-		./src/WCSimRootTools.cc 
-		WCSimRootDict.cxx)
-target_link_libraries(WCSimRoot  ${ROOT_LIBRARIES})
-
-# Create libWCSimRootDict.so (needed for ROOT6)
-add_custom_command(TARGET WCSimRoot
-		POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.so 	${CMAKE_CURRENT_BINARY_DIR}/libWCSimRootDict.so)
-
-if ( ${ROOT_VERSION} LESS 6 )
-	# Create Rootmap (not automatically done for ROOT5)
-	add_custom_command(TARGET WCSimRoot
-		POST_BUILD
-		COMMAND rlibmap -o ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.rootmap -l ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.so -c ${CMAKE_CURRENT_SOURCE_DIR}/include/WCSimRootLinkDef.hh)
-endif()
 
 #----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
@@ -101,10 +56,12 @@ endif()
 #
 option(WITH_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
 if(WITH_GEANT4_UIVIS)
-  find_package(Geant4 REQUIRED ui_all vis_all)
+    find_package(Geant4 REQUIRED ui_all vis_all)
 else()
-  find_package(Geant4 REQUIRED)
+    find_package(Geant4 REQUIRED)
 endif()
+LIST(APPEND PUBLIC_EXT_LIBS ${Geant4_LIBRARIES})
+MESSAGE(${PUBLIC_EXT_LIBS})
 
 #----------------------------------------------------------------------------
 # Setup Geant4 include directories and compile definitions
@@ -112,75 +69,33 @@ endif()
 #
 include(${Geant4_USE_FILE})  ## NOT needed for Dict
 
+#########
+# sources
+#########
 
-#----------------------------------------------------------------------------
-# Locate sources and headers for this project
-# NB: headers are included so they will show up in IDEs
-#
-file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
-file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
-
-
-#----------------------------------------------------------------------------
-# Add the executable, and link it to the Geant4 libraries
-#
-# To use <unordered_map>, ie. use C++11 now from GCC 4.4 onwards support for unordered_maps.
-# Had to change G4float to G4double for QE because of double arithmatic inside the array.
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.7)
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++11")
 else()
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()
 
-
 # Set flag for git version to be used as c++ preprocessor macro
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`cd ${PROJECT_SOURCE_DIR};git describe --always --long --tags --dirty`\\\"\"")
 
-add_executable(WCSim WCSim.cc ${sources} ${headers})
-target_link_libraries(WCSim ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} WCSimRoot Tree)
 
-
-
-#----------------------------------------------------------------------------
-# Copy all scripts to the build directory, i.e. the directory in which we
-# build WCSim. This is so that we can run the executable directly because it
-# relies on these scripts being in the current working directory.
-#
-set(WCSIM_SCRIPTS
-  macros/jobOptions.mac
-  WCSim.mac
-  macros/daq.mac
-  macros/visOGLSX.mac
-  macros/visRayTracer.mac
-  macros/visOGLQt.mac	
-  macros/tuning_parameters.mac
-  macros/OD.mac
-  macros/OD_10k.mac
-  data/MuonFlux-HyperK-ThetaPhi.dat
-  )
-
-foreach(_script ${WCSIM_SCRIPTS})
-  configure_file(
-    ${PROJECT_SOURCE_DIR}/${_script}
-    ${PROJECT_BINARY_DIR}/${_script}
-    COPYONLY
-    )
-endforeach()
-
-file(
-	COPY ${PROJECT_SOURCE_DIR}/rootwc
-	DESTINATION ${PROJECT_BINARY_DIR}
+include_directories (
+    ${ROOT_INCLUDE_DIR}
+    ${PROJECT_SOURCE_DIR}/include
 )
 
-#----------------------------------------------------------------------------
-# For internal Geant4 use - but has no effect if you build this
-# example standalone
-#
-#add_custom_target(WCSim DEPENDS WCSim)
+add_subdirectory (src)
 
-#----------------------------------------------------------------------------
-# Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
-#
-#install(TARGETS WCSim DESTINATION bin)
+configure_file(${PROJECT_SOURCE_DIR}/WCSimConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/WCSimConfig.cmake @ONLY)
+pbuilder_do_package_config()
 
+#configure_file(this_daq.sh.in this_daq.sh)
+#pbuilder_install_files(${BIN_INSTALL_DIR} ${CMAKE_CURRENT_BINARY_DIR}/this_daq.sh)
 
+add_custom_target(install_${PROJECT_NAME}
+        "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target install
+        COMMENT "Installing ${PROJECT_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,28 @@ add_subdirectory (src)
 configure_file(${PROJECT_SOURCE_DIR}/WCSimConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/WCSimConfig.cmake @ONLY)
 pbuilder_do_package_config()
 
-#configure_file(this_daq.sh.in this_daq.sh)
-#pbuilder_install_files(${BIN_INSTALL_DIR} ${CMAKE_CURRENT_BINARY_DIR}/this_daq.sh)
+# data and macros copy
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/data
+        ${PROJECT_SOURCE_DIR}/data/MuonFlux-HyperK-ThetaPhi.dat)
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/macros
+        ${PROJECT_SOURCE_DIR}/macros/jobOptions.mac
+        ${PROJECT_SOURCE_DIR}/macros/daq.mac
+        ${PROJECT_SOURCE_DIR}/macros/visOGLSX.mac
+        ${PROJECT_SOURCE_DIR}/macros/visRayTracer.mac
+        ${PROJECT_SOURCE_DIR}/macros/visOGLQt.mac
+        ${PROJECT_SOURCE_DIR}/macros/tuning_parameters.mac
+        ${PROJECT_SOURCE_DIR}/macros/OD.mac
+        ${PROJECT_SOURCE_DIR}/macros/OD_10k.mac
+        )
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}
+        ${PROJECT_SOURCE_DIR}/WCSim.mac
+        )
+
+configure_file(this_wcsim.sh.in this_wcsim.sh)
+pbuilder_install_files(${BIN_INSTALL_DIR} ${CMAKE_CURRENT_BINARY_DIR}/this_wcsim.sh)
 
 add_custom_target(install_${PROJECT_NAME}
         "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ else()
     find_package(Geant4 REQUIRED)
 endif()
 LIST(APPEND PUBLIC_EXT_LIBS ${Geant4_LIBRARIES})
-MESSAGE(${PUBLIC_EXT_LIBS})
 
 #----------------------------------------------------------------------------
 # Setup Geant4 include directories and compile definitions
@@ -82,13 +81,49 @@ endif()
 # Set flag for git version to be used as c++ preprocessor macro
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_HASH=\"\\\"`cd ${PROJECT_SOURCE_DIR};git describe --always --long --tags --dirty`\\\"\"")
 
+# data and macros copy
 
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/data
+        ${PROJECT_SOURCE_DIR}/data/MuonFlux-HyperK-ThetaPhi.dat)
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/macros
+        ${PROJECT_SOURCE_DIR}/macros/jobOptions.mac
+        ${PROJECT_SOURCE_DIR}/macros/daq.mac
+        ${PROJECT_SOURCE_DIR}/macros/visOGLSX.mac
+        ${PROJECT_SOURCE_DIR}/macros/visRayTracer.mac
+        ${PROJECT_SOURCE_DIR}/macros/visOGLQt.mac
+        ${PROJECT_SOURCE_DIR}/macros/tuning_parameters.mac
+        ${PROJECT_SOURCE_DIR}/macros/OD.mac
+        ${PROJECT_SOURCE_DIR}/macros/OD_10k.mac
+        )
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}
+        ${PROJECT_SOURCE_DIR}/WCSim.mac
+        )
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/bin/rootwc
+        ${PROJECT_SOURCE_DIR}/rootwc/loadincs.C
+        ${PROJECT_SOURCE_DIR}/rootwc/loadlibs.C
+        ${PROJECT_SOURCE_DIR}/rootwc/rootwc
+        ${PROJECT_SOURCE_DIR}/rootwc/rootwc.C
+        )
+
+configure_file(cmake/this_wcsim.sh.in this_wcsim.sh)
+pbuilder_install_files(${BIN_INSTALL_DIR} ${CMAKE_CURRENT_BINARY_DIR}/this_wcsim.sh)
+
+add_custom_target(install_${PROJECT_NAME}
+        /include
+)
+
+# Library
 include_directories (
-    ${ROOT_INCLUDE_DIR}
-    ${PROJECT_SOURCE_DIR}/include
+        ${ROOT_INCLUDE_DIR}
+        ${PROJECT_SOURCE_DIR}/include
 )
 
 add_subdirectory (src)
+
+
 
 configure_file(${PROJECT_SOURCE_DIR}/WCSimConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/WCSimConfig.cmake @ONLY)
 pbuilder_do_package_config()
@@ -113,9 +148,16 @@ pbuilder_install_files(${CMAKE_INSTALL_PREFIX}
         ${PROJECT_SOURCE_DIR}/WCSim.mac
         )
 
-configure_file(this_wcsim.sh.in this_wcsim.sh)
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/bin/rootwc
+        ${PROJECT_SOURCE_DIR}/rootwc/loadincs.C
+        ${PROJECT_SOURCE_DIR}/rootwc/loadlibs.C
+        ${PROJECT_SOURCE_DIR}/rootwc/rootwc
+        ${PROJECT_SOURCE_DIR}/rootwc/rootwc.C
+        )
+
+configure_file(cmake/this_wcsim.sh.in this_wcsim.sh)
 pbuilder_install_files(${BIN_INSTALL_DIR} ${CMAKE_CURRENT_BINARY_DIR}/this_wcsim.sh)
 
-add_custom_target(install_${PROJECT_NAME}
-        "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target install
-        COMMENT "Installing ${PROJECT_NAME}")
+#add_custom_target(install_${PROJECT_NAME}
+#        "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target install
+#        COMMENT "Installing ${PROJECT_NAME}")

--- a/Dockerfile.cmake
+++ b/Dockerfile.cmake
@@ -1,0 +1,25 @@
+### Created by Dr. Benjamin Richards (b.richards@qmul.ac.uk) 
+
+### Download base image from cern repo on docker hub
+FROM wcsim/wcsim:base
+
+### Run the following commands as super user (root):
+USER root
+
+### Add cmake3
+RUN yum install -y cmake3 \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+### Get and build WCSim
+WORKDIR $HYPERKDIR
+COPY . WCSim
+RUN mkdir $HYPERKDIR/WCSim-build $HYPERKDIR/WCSim-install
+WORKDIR $HYPERKDIR/WCSim-build
+RUN source $HYPERKDIR/env-WCSim.sh &&\
+    cmake3 $HYPERKDIR/WCSim &&\
+    make -j4 install
+
+### Open terminal
+ENTRYPOINT source $HYPERKDIR/env-WCSim.sh && /bin/bash
+ 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ If you want to use these libraries with an external program then also do:
 ### Build Instructions using CMake:
 
 CMake is cross-platform software for managing the build process in 
-a compiler-independent way (cmake.org). 
+a compiler-independent way (cmake.org).
+**Cmake 3.1+ is required.**
 It is recommended to build ROOT and GEANT4 also through CMake. The 
 latter is very CMake friendly since GEANT 4.9.6, while it started introducing
 builds through CMake from 4.9.4 onwards (http://geant4.web.cern.ch/geant4/support/ReleaseNotes4.9.4.html#10.).
@@ -64,27 +65,33 @@ Using cmake, builds and source code need to well separated and make
 it easier to build many versions of the same software.
 
 A recommended way to set up the directory structure in your own
-preferred WCSIM_HOME:
+preferred `WCSIM_HOME`:
 - `${WCSIM_HOME}/WCSim` : contains the src dir, typically the cloned or 
   unzipped code from GitHub
 - `${WCSIM_HOME}/WCSim_build` : contains directories for each build, eg.
+   for each branch you want to test or for different releases, comparing
+  debugged versions, etc.
+  Each subdirectory like `WCSim_dev` or `WCSim_v1.2` would contain the intermediate files produced
+  during compilation and not the finale ones
+- `${WCSIM_HOME}/WCSim_install` : contains directories for each build, eg.
   for each branch you want to test or for different releases, comparing
   debugged versions, etc.
-  This directory will contain the executable, the example macros and
-  library for ROOT.
+  Each subdirectory like `WCSim_dev` or `WCSim_v1.2` will contain the final executable and libraries, 
+  the example macros and library for ROOT.
 
 To compile you need to have `CMakeLists.txt` in the WCSim source dir.
-* `mkdir ${WCSIM_HOME}/WCSim_build/mydir ; cd ${WCSIM_HOME}/WCSim_build/mydir`
+* `mkdir -p ${WCSIM_HOME}/WCSim_build/WCSim_dev ; cd ${WCSIM_HOME}/WCSim_build/WCSim_dev`
 * Set up the Geant4_Dir: `export Geant4_DIR=${HOME}/Geant4/install/geant4.9.6.p04`
-  (from the make install phase of Geant4)
-* `cmake ../../WCSim` : this executes the commands in `CMakeLists.txt` and generates
-  the Makefiles for both the ROOT library as the main executable.
+  (from the make install phase of Geant4). Alternatively, source the `geant4.sh` setup script 
+located under e.g. `${HOME}/Geant4/install/geant4.9.6.p04/bin`.
+* `cmake3 ../../WCSim` : this executes the commands in `CMakeLists.txt` and generates
+  the Makefiles for both the ROOT library as the main executable (for some OS, `cmake3` is just `cmake`).
 * `make clean` : if necessary
-* `make` : will first compile the libWCSimRoot.so which you need for using
-  the ROOT Dict from WCSim and then compile WCSim.
+* `make -j3 install` : will first compile the libWCSimRoot.so and libWCSimCore.so which you need for using
+ the ROOT Dict from WCSim and then compile WCSim.
 
 To recompile:
-* Typically just `make` will be enough and also redo the cmake phase if
+* Typically just `make install` will be enough and also redo the cmake phase if
   something changed.
 * Sometimes you need to `make clean` first.
 * When there are problems, try removing `CMakeCache.txt`, and redo the cmake.

--- a/WCSimConfig.cmake.in
+++ b/WCSimConfig.cmake.in
@@ -1,0 +1,7 @@
+# DAQConfig.cmake
+
+get_filename_component( WCSim_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH )
+
+include( CMakeFindDependencyMacro )
+
+include("${WCSim_CMAKE_DIR}/WCSim_Library_Targets.cmake")

--- a/WCSimConfig.cmake.in
+++ b/WCSimConfig.cmake.in
@@ -1,4 +1,4 @@
-# DAQConfig.cmake
+# WCSimConfig.cmake
 
 get_filename_component( WCSim_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH )
 

--- a/cmake/PackageBuilder.cmake
+++ b/cmake/PackageBuilder.cmake
@@ -1,0 +1,171 @@
+# PackageBuilder.cmake
+# Author: Noah Oblath
+#
+# Default settings and macros for PackageBuilder builds
+#
+# Parts of this script are based on work done by Sebastian Voecking and Marco Haag in the Kasper package
+#
+# Requires: CMake v3.12 or better (FindPython3)
+
+# CMake policies
+cmake_policy( SET CMP0011 NEW )
+cmake_policy( SET CMP0012 NEW ) # how if-statements work
+cmake_policy( SET CMP0042 NEW ) # rpath on mac os x
+cmake_policy( SET CMP0048 NEW ) # version in project()
+
+include ( PackageBuilderMacros )
+
+include( CMakeParseArguments ) # required until cmake v3.5, when this was added as a built-in command
+
+# check if this is a stand-alone build
+set( PBUILDER_STANDALONE FALSE CACHE INTERNAL "Flag for whether or not this is a stand-alone build" )
+set( PBUILDER_CHILD_NAME_EXTENSION "${PROJECT_NAME}" CACHE INTERNAL "Submodule library name modifier" )
+if( ${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR} )
+    set( PBUILDER_STANDALONE TRUE )
+    
+    if( CMAKE_GENERATOR MATCHES ".*(Make|Ninja).*" AND NOT CMAKE_BUILD_TYPE )
+  		set( CMAKE_BUILD_TYPE "DEBUG" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel" FORCE )
+  		message( STATUS "CMAKE_BUILD_TYPE not specified. Using ${CMAKE_BUILD_TYPE} build" )
+    endif()
+
+    # option to force linking when using g++
+    if( CMAKE_COMPILER_IS_GNUCXX )
+        option( GCC_FORCE_LINKING "Fix linker errors with some GCC versions by adding the --no-as-needed flag" ON )
+        if( GCC_FORCE_LINKING )
+            set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed" )
+        endif( GCC_FORCE_LINKING )
+    endif( CMAKE_COMPILER_IS_GNUCXX )
+endif( ${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR} )
+
+# define a variable pointing to the directory containing this file
+set( PBUILDER_DIR ${CMAKE_CURRENT_LIST_DIR} )
+
+# preprocessor defintion for debug build
+if( "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" )
+    add_definitions(-D${PROJECT_NAME}_DEBUG )
+else( "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" )
+    remove_definitions(-D${PROJECT_NAME}_DEBUG )    
+endif( "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" )
+
+message( STATUS "Build type: ${CMAKE_BUILD_TYPE}" )
+
+# Setup the default install prefix
+# This gets set to the binary directory upon first configuring.
+# If the user changes the prefix, but leaves the flag OFF, then it will remain as the user specified.
+# If the user wants to reset the prefix to the default (i.e. the binary directory), then the flag should be set ON.
+if( NOT DEFINED SET_INSTALL_PREFIX_TO_DEFAULT )
+    set( SET_INSTALL_PREFIX_TO_DEFAULT ON )
+endif( NOT DEFINED SET_INSTALL_PREFIX_TO_DEFAULT )
+if( SET_INSTALL_PREFIX_TO_DEFAULT )
+    set( CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR} CACHE PATH "Install prefix" FORCE )
+    set( SET_INSTALL_PREFIX_TO_DEFAULT OFF CACHE BOOL "Reset default install path when when configuring" FORCE )
+endif( SET_INSTALL_PREFIX_TO_DEFAULT )
+
+# install subdirectories
+set( INCLUDE_INSTALL_SUBDIR "include/${PROJECT_NAME}" CACHE PATH "Install subdirectory for headers" )
+if( ${CMAKE_SYSTEM_NAME} MATCHES "Windows" )
+    set( LIB_INSTALL_SUBDIR "bin" CACHE PATH "Install subdirectory for libraries" )
+else( ${CMAKE_SYSTEM_NAME} MATCHES "Windows" )
+    set( LIB_INSTALL_SUBDIR "lib" CACHE PATH "Install subdirectory for libraries" )
+endif( ${CMAKE_SYSTEM_NAME} MATCHES "Windows" )
+set( PACKAGE_CONFIG_SUBDIR "${LIB_INSTALL_SUBDIR}/cmake/${PROJECT_NAME}" CACHE PATH "Install subdirectory for CMake config files" )
+set( BIN_INSTALL_SUBDIR "bin" CACHE PATH "Install subdirectory for binaries" )
+set( CONFIG_INSTALL_SUBDIR "config" CACHE PATH "Install subdirectory for config files" )
+set( DATA_INSTALL_SUBDIR "data" CACHE PATH "Install subdirectory for data files" )
+
+set( INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_SUBDIR}" )
+set( LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_SUBDIR}" )
+set( PACKAGE_CONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}/${PACKAGE_CONFIG_SUBDIR}" )
+set( BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_SUBDIR}" )
+set( CONFIG_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${CONFIG_INSTALL_SUBDIR}" )
+set( DATA_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${DATA_INSTALL_SUBDIR}" )
+
+#if( NOT DEFINED TOP_PROJECT_INCLUDE_INSTALL_DIR )
+if( PBUILDER_STANDALONE )
+    # this is for standalone builds, but has to be done down here rather than in the standalone if block above
+    set( TOP_PROJECT_INCLUDE_INSTALL_DIR "${INCLUDE_INSTALL_DIR}" CACHE INTERNAL "Top-project include installation path" )
+    set( TOP_PROJECT_INCLUDE_INSTALL_SUBDIR "${INCLUDE_INSTALL_SUBDIR}" CACHE INTERNAL "Top-project include installation subdirectory" )
+    message( STATUS "TOP_PROJECT_INCLUDE_INSTALL_DIR being set to ${TOP_PROJECT_INCLUDE_INSTALL_DIR}" )
+
+    set( TOP_PROJECT_CMAKE_CONFIG_DIR "${PACKAGE_CONFIG_PREFIX}" CACHE INTERNAL "Top-project CMake config installation path" )
+    message( STATUS "TOP_PROJECT_CMAKE_CONFIG_DIR being set to ${TOP_PROJECT_CMAKE_CONFIG_DIR}" )
+    set( ${PROJECT_NAME}_CMAKE_CONFIG_DIR "${PACKAGE_CONFIG_PREFIX}" CACHE INTERNAL "${PROJECT_NAME} CMake config installation path" )
+    message( STATUS "${PROJECT_NAME}_CMAKE_CONFIG_DIR being set to ${${PROJECT_NAME}_CMAKE_CONFIG_DIR}" )
+endif()
+
+
+# flag for building test programs
+option( ${PROJECT_NAME}_ENABLE_TESTING "Turn on or off the building of test programs" OFF )
+
+# flag for building executables (other than test programs)
+# this is particularly useful if a project is used multiple times and installed in a general location, where executables would overwrite each other.
+option( ${PROJECT_NAME}_ENABLE_EXECUTABLES "Turn on or off the building of executables (other than test programs)" ON )
+
+# default version of C++
+# acceptable values are any used by the CXX_STANDARD property of your CMake
+set( CMAKE_CXX_STANDARD 11 )
+
+# build shared libraries
+set( BUILD_SHARED_LIBS ON )
+
+# turn on RPATH for Mac OSX
+set( CMAKE_MACOSX_RPATH ON )
+
+# add the library install directory to the rpath
+SET(CMAKE_INSTALL_RPATH "${LIB_INSTALL_DIR}" )
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
+
+set( LIB_POSTFIX )
+set( INC_PREFIX )
+
+# in windows, disable the min and max macros
+if( WIN32 )
+    # disable the min and max macros
+    add_definitions( -DNOMINMAX )
+	# libraries and linking
+	set( CMAKE_SHARED_LIBRARY_PREFIX "" )
+	set( CMAKE_IMPORT_LIBRARY_PREFIX "" )
+	set( CMAKE_LINK_DEF_FILE_FLAG "" )
+	add_definitions( -DBOOST_ALL_DYN_LINK )
+endif( WIN32 )
+
+# default package name is the project name
+set( ${PROJECT_NAME}_PACKAGE_NAME "${PROJECT_NAME}" )
+
+# Full project name, expanded according to the submodule hierarchy
+pbuilder_expand_lib_name( ${PROJECT_NAME} )
+set( ${PROJECT_NAME}_FULL_PROJECT_NAME ${FULL_LIB_NAME} )
+message( STATUS "Full project name: ${PROJECT_NAME}_FULL_PROJECT_NAME = ${${PROJECT_NAME}_FULL_PROJECT_NAME}" )
+
+# if git is used, get the commit SHA1
+find_package( Git )
+if( GIT_FOUND )
+    # check whether this is a git repo
+    execute_process( COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-git-dir WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} OUTPUT_VARIABLE IS_GIT_REPO )
+    if( IS_GIT_REPO )
+        execute_process( COMMAND ${GIT_EXECUTABLE} rev-parse -q HEAD  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} OUTPUT_VARIABLE ${PROJECT_NAME}_GIT_COMMIT  OUTPUT_STRIP_TRAILING_WHITESPACE )
+        execute_process( COMMAND ${GIT_EXECUTABLE} describe --tags --long  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} OUTPUT_VARIABLE ${PROJECT_NAME}_GIT_DESCRIBE  OUTPUT_STRIP_TRAILING_WHITESPACE )
+        execute_process( COMMAND ${GIT_EXECUTABLE} remote get-url origin WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} OUTPUT_VARIABLE GIT_ORIGIN OUTPUT_STRIP_TRAILING_WHITESPACE )
+        if( GIT_ORIGIN )
+            message( STATUS "Git origin: ${GIT_ORIGIN}")
+            string( REGEX MATCH "[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$" GIT_PACKAGE ${GIT_ORIGIN} )
+        else( GIT_ORIGIN )
+            execute_process( COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} OUTPUT_VARIABLE TOP_DIR OUTPUT_STRIP_TRAILING_WHITESPACE )
+            execute_process( COMMAND basename ${TOP_DIR} OUTPUT_VARIABLE GIT_PACKAGE )
+        endif( GIT_ORIGIN )
+        message( STATUS "Git package: ${GIT_PACKAGE}" )
+
+        # override package name with git package
+        set( ${PROJECT_NAME}_PACKAGE_NAME "${GIT_PACKAGE}" )
+    endif( IS_GIT_REPO )
+endif( GIT_FOUND )
+# check if we set the _PACKAGE_NAME variable; if we didn't, then we'll use an alternate setting
+if( NOT ${PROJECT_NAME}_PACKAGE_NAME )
+    set( ${PROJECT_NAME}_PACKAGE_NAME "${PROJECT_NAME}" )
+endif()
+
+# define the variables to describe the package (will go in the [ProjectName]Config.hh file)
+set( ${PROJECT_NAME}_PACKAGE_STRING "${PROJECT_NAME} ${${PROJECT_NAME}_VERSION}" )

--- a/cmake/PackageBuilder.cmake
+++ b/cmake/PackageBuilder.cmake
@@ -53,13 +53,10 @@ message( STATUS "Build type: ${CMAKE_BUILD_TYPE}" )
 # This gets set to the binary directory upon first configuring.
 # If the user changes the prefix, but leaves the flag OFF, then it will remain as the user specified.
 # If the user wants to reset the prefix to the default (i.e. the binary directory), then the flag should be set ON.
-if( NOT DEFINED SET_INSTALL_PREFIX_TO_DEFAULT )
-    set( SET_INSTALL_PREFIX_TO_DEFAULT ON )
-endif( NOT DEFINED SET_INSTALL_PREFIX_TO_DEFAULT )
-if( SET_INSTALL_PREFIX_TO_DEFAULT )
+if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
     set( CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR} CACHE PATH "Install prefix" FORCE )
-    set( SET_INSTALL_PREFIX_TO_DEFAULT OFF CACHE BOOL "Reset default install path when when configuring" FORCE )
-endif( SET_INSTALL_PREFIX_TO_DEFAULT )
+endif( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+MESSAGE(STATUS "CMAKE_INSTALL_PREFIX being set to ${CMAKE_INSTALL_PREFIX}")
 
 # install subdirectories
 set( INCLUDE_INSTALL_SUBDIR "include/${PROJECT_NAME}" CACHE PATH "Install subdirectory for headers" )

--- a/cmake/PackageBuilderMacros.cmake
+++ b/cmake/PackageBuilderMacros.cmake
@@ -1,0 +1,541 @@
+# PackageBuilderMacros.cmake
+# Author: Noah Oblath
+#
+# Convenient macros for PackageBuilder builds
+#
+# Requires: CMake v3.12 or better (FindPython3)
+
+# Conveniece function for overriding the value of an option (aka a cached bool variable)
+macro( set_option VARIABLE VALUE )
+    set( ${VARIABLE} ${VALUE} CACHE BOOL "" FORCE )
+endmacro()
+
+# This should be called after setting options, and before adding submodules and building the project
+macro( pbuilder_prepare_project )
+
+    # Deprecated C++ version options
+    if( DEFINED USE_CPP17 )
+        message( AUTHOR_WARNING "USE_CPP%% variables are deprecated as of Scarab v3.4; Please set CMAKE_CXX_STANDARD directly" )
+        set( CMAKE_CXX_STANDARD 17 )
+    elseif( DEFINED USE_CPP14 )
+        message( AUTHOR_WARNING "USE_CPP%% variables are deprecated as of Scarab v3.4; Please set CMAKE_CXX_STANDARD directly" )
+        set( CMAKE_CXX_STANDARD 14 )
+    elseif( DEFINED USE_CPP11 )
+        message( AUTHOR_WARNING "USE_CPP%% variables are deprecated as of Scarab v3.4; Please set CMAKE_CXX_STANDARD directly" )
+        set( CMAKE_CXX_STANDARD 11 )
+    endif()
+
+    # Add/remove C++ version macros
+    if( CMAKE_CXX_STANDARD GREATER 20 AND NOT CMAKE_CXX_STANDARD EQUAL 98 )
+        add_definitions( -DUSE_CPP20 -DUSE_CPP17 -DUSE_CPP14 -DUSE_CPP11 )
+        message( AUTHOR_WARNING "PackageBuilder does not currently include \"USE_CPP%%\" macros for higher that C++20" )
+    elseif( CMAKE_CXX_STANDARD EQUAL 20 )
+        add_definitions( -DUSE_CPP20 -DUSE_CPP17 -DUSE_CPP14 -DUSE_CPP11 )
+    elseif( CMAKE_CXX_STANDARD EQUAL 17 )
+        remove_definitions( -DUSE_CPP20 )
+        add_definitions( -DUSE_CPP17 -DUSE_CPP14 -DUSE_CPP11 )
+    elseif( CMAKE_CXX_STANDARD EQUAL 14 )
+        remove_definitions( -DUSE_CPP20 -DUSE_CPP17 )
+        add_definitions( -DUSE_CPP14 -DUSE_CPP11 )
+    elseif( CMAKE_CXX_STANDARD EQUAL 11 )
+        remove_definitions( -DUSE_CPP20 -DUSE_CPP17 -DUSE_CPP14 )
+        add_definitions( -DUSE_CPP11 )
+    elseif( CMAKE_CXX_STANDARD EQUAL 98 )
+        remove_definitions( -DUSE_CPP20 -DUSE_CPP17 -DUSE_CPP14 -DUSE_CPP11 )
+    endif()
+
+
+endmacro()
+
+macro( pbuilder_add_submodule SM_NAME SM_LOCATION )
+    if( NOT IS_ABSOLUTE ${SM_LOCATION} )
+        set( SM_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/${SM_LOCATION}" )
+    endif()
+
+    # Conditions that let us in this loop:
+    #  1. Submodule SM_NAME has not yet been found
+    #  2. This is the location of the submodule SM_NAME
+    message( STATUS "${SM_NAME}_LOCATION: ${${SM_NAME}_LOCATION}" )
+    message( STATUS "CMAKE_CURRENT_LIST_DIR/SM_LOCATION: ${CMAKE_CURRENT_LIST_DIR}/${SM_LOCATION}" )
+    if( NOT ${SM_NAME}_FOUND OR "${${SM_NAME}_LOCATION}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}/${SM_LOCATION}" )
+        message( "Adding submodule ${SM_NAME} in location ${CMAKE_CURRENT_LIST_DIR}/${SM_LOCATION}" )
+
+        set( ${SM_NAME}_FOUND TRUE CACHE INTERNAL "" )
+        set( ${SM_NAME}_LOCATION ${CMAKE_CURRENT_LIST_DIR}/${SM_LOCATION} CACHE INTERNAL "" )
+        set( ${SM_NAME}_BINARY_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${SM_LOCATION} CACHE INTERNAL "" )
+
+        # Determine the library name suffix for this submodule with respect to its parent if it's not already defined
+        if( NOT DEFINED ${SM_NAME}_PARENT_LIB_NAME_SUFFIX )
+            set( ${SM_NAME}_PARENT_LIB_NAME_SUFFIX "_${PROJECT_NAME}${${PROJECT_NAME}_PARENT_LIB_NAME_SUFFIX}" CACHE INTERNAL "Scoped library name suffix for submodule ${SM_NAME}" )
+            message( STATUS "PARENT_LIB_NAME_SUFFIX being set for SM ${SM_NAME}: ${${SM_NAME}_PARENT_LIB_NAME_SUFFIX}" )
+        endif()
+
+        # Set submodule include subdirectory
+        set( SM_INCLUDE_SUBDIR "/${SM_NAME}" )
+        message( STATUS "Include files for submodule ${SM_NAME} will be installed in ${TOP_PROJECT_INCLUDE_INSTALL_DIR}${SM_INCLUDE_SUBDIR}" )
+
+        # Set CMake config subdirectory
+        set( ${SM_NAME}_CMAKE_CONFIG_DIR "${PACKAGE_CONFIG_PREFIX}/${SM_NAME}" CACHE INTERNAL "${SM_NAME} CMake config installation path" )
+    
+        message( STATUS "SM ${SM_NAME} cached variables:" )
+        message( STATUS "${SM_NAME}_FOUND: ${${SM_NAME}_FOUND}" )
+        message( STATUS "${SM_NAME}_LOCATION: ${${SM_NAME}_LOCATION}" )
+        message( STATUS "${SM_NAME}_BINARY_LOCATION: ${${SM_NAME}_BINARY_LOCATION}" )
+        message( STATUS "${SM_NAME}_PARENT_LIB_NAME_SUFFIX: ${${SM_NAME}_PARENT_LIB_NAME_SUFFIX}")
+        message( STATUS "${SM_NAME}_CMAKE_CONFIG_DIR: ${${SM_NAME}_CMAKE_CONFIG_DIR}" )
+
+        message( STATUS "Proceeding into subdirectory: ${SM_LOCATION}" )
+        add_subdirectory( ${SM_LOCATION} )
+
+        if( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${SM_LOCATION}/${SM_NAME}Config.cmake )
+            message( STATUS "Loading config file for submodule ${SM_NAME}" )
+            include( ${CMAKE_CURRENT_BINARY_DIR}/${SM_LOCATION}/${SM_NAME}Config.cmake )
+        else()
+            message( STATUS "No config file present for submodule ${SM_NAME} (${CMAKE_CURRENT_BINARY_DIR}/${SM_LOCATION}/${SM_NAME}Config.cmake)" )
+        endif()
+
+        # Need to unset the submodule subdirectories since we're in a macro
+        unset( SM_INCLUDE_SUBDIR )
+        unset( SM_CMAKE_CONFIG_SUBDIR )
+
+    endif( NOT ${SM_NAME}_FOUND OR "${${SM_NAME}_LOCATION}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}/${SM_LOCATION}" )
+endmacro()
+
+macro( pbuilder_expand_lib_name_2 LIB_NAME SM_NAME )
+    # Output is in the form of the variable FULL_LIB_NAME
+    set( FULL_LIB_NAME "${LIB_NAME}${${SM_NAME}_PARENT_LIB_NAME_SUFFIX}" )
+endmacro()
+
+macro( pbuilder_expand_lib_name LIB_NAME )
+    # Output is in the form of the variable FULL_LIB_NAME
+    pbuilder_expand_lib_name_2( ${LIB_NAME} ${PROJECT_NAME} )
+endmacro()
+
+macro( pbuilder_expand_lib_names )
+    # Supply library targets as additional macro arguments
+    # Output is in the form of the variable FULL_LIB_NAMES
+    set( LIB_NAMES ${ARGN} )
+    #message( STATUS "expanding these project libraries: ${LIB_NAMES}" )
+    set( FULL_LIB_NAMES )
+    foreach( lib ${LIB_NAMES} )
+        pbuilder_expand_lib_name( ${lib} )
+        list( APPEND FULL_LIB_NAMES ${FULL_LIB_NAME} )
+    endforeach( lib )
+    message( STATUS "expanded to full project library names: ${FULL_LIB_NAMES}" )
+endmacro()
+
+macro( pbuilder_use_sm_library LIB_NAME SM_NAME )
+    pbuilder_expand_lib_name_2( ${LIB_NAME} ${SM_NAME} )
+    list( APPEND ${PROJECT_NAME}_SM_LIBRARIES ${FULL_LIB_NAME} )
+    #message( STATUS "Added SM library ${FULL_LIB_NAME} to ${PROJECT_NAME}_SM_LIBRARIES" )
+endmacro()
+
+function( pbuilder_library )
+    # Builds a shared-object library
+    #
+    # Combines pbuilder_add_library() and pbuilder_link_library()
+    #
+    # Parameters:
+    #     TARGET: library target name
+    #     SOURCES: source files to include
+    #     PROJECT_LIBRARIES: libraries from the same project to be linked against
+    #     PUBLIC_EXTERNAL_LIBRARIES: public external libraries to be linked against
+    #     PRIVATE_ETERNAL_LIBRARIES: private external libraries to be linked against
+    #     COMPILE_DEFINITIONS: compile definitions to add to this target
+
+    set( OPTIONS )
+    set( ONEVALUEARGS TARGET )
+    set( MULTIVALUEARGS SOURCES PROJECT_LIBRARIES PUBLIC_EXTERNAL_LIBRARIES PRIVATE_EXTERNAL_LIBRARIES COMPILE_DEFINITIONS )
+    cmake_parse_arguments( LIB "${OPTIONS}" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN} )
+
+    message( "Building library ${LIB_TARGET}" )
+    message( STATUS "${PROJECT_NAME}_PARENT_LIB_NAME_SUFFIX is ${${PROJECT_NAME}_PARENT_LIB_NAME_SUFFIX}" )
+
+    pbuilder_add_library(
+        TARGET ${LIB_TARGET}
+        SOURCES ${LIB_SOURCES}
+    )
+
+    pbuilder_link_library(
+        TARGET ${LIB_TARGET}
+        PROJECT_LIBRARIES ${LIB_PROJECT_LIBRARIES}
+        PUBLIC_EXTERNAL_LIBRARIES ${LIB_PUBLIC_EXTERNAL_LIBRARIES}
+        PRIVATE_EXTERNAL_LIBRARIES ${LIB_PRIVATE_EXTERNAL_LIBRARIES}
+        COMPILE_DEFINITIONS ${LIB_COMPILE_DEFINITIONS}
+    )
+
+endfunction()
+
+function( pbuilder_add_library )
+    # Adding a shared-object library
+    #
+    # Parameters:
+    #     TARGET: library target name
+    #     SOURCES: source files to include
+
+    set( OPTIONS )
+    set( ONEVALUEARGS TARGET )
+    set( MULTIVALUEARGS SOURCES PROJECT_LIBRARIES PUBLIC_EXTERNAL_LIBRARIES PRIVATE_EXTERNAL_LIBRARIES COMPILE_DEFINITIONS )
+    cmake_parse_arguments( LIB "${OPTIONS}" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN} )
+
+    message( "Adding library ${LIB_TARGET}" )
+
+    pbuilder_expand_lib_name( ${LIB_TARGET} )
+    set( FULL_LIB_TARGET ${FULL_LIB_NAME} )
+    set( ${LIB_TARGET}_FULL_TARGET_NAME  ${FULL_LIB_NAME} CACHE INTERNAL "Full target name for library ${LIB_TARGET}" )
+    message( STATUS "lib target: ${LIB_TARGET}" )
+    message( STATUS "full lib target: ${FULL_LIB_TARGET}" )
+    message( STATUS "internal cache ${LIB_TARGET}_FULL_TARGET_NAME: ${${LIB_TARGET}_FULL_TARGET_NAME}" )
+    message( STATUS "SM library dependencies (public): ${${PROJECT_NAME}_SM_LIBRARIES}" )
+    message( STATUS "external library dependencies (public): ${LIB_PUBLIC_EXTERNAL_LIBRARIES}" )
+    message( STATUS "external library dependencies (private): ${LIB_PRIVATE_EXTERNAL_LIBRARIES}" )
+
+    message( STATUS "pbuilder: will build library <${FULL_LIB_TARGET}>" )
+    add_library( ${FULL_LIB_TARGET} ${LIB_SOURCES} )
+
+    # Set the version of the library
+    set_target_properties( ${FULL_LIB_TARGET} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION} )
+
+    # Grab the include directories, which will be used for the build-interface target includes
+    get_target_property( SOURCE_TREE_INCLUDE_DIRS ${FULL_LIB_TARGET} INCLUDE_DIRECTORIES )
+    message( STATUS "Adding install interface include dir: ${TOP_PROJECT_INCLUDE_INSTALL_SUBDIR}${SM_INCLUDE_SUBDIR}" )
+    message( STATUS "Adding build interface include dirs: ${SOURCE_TREE_INCLUDE_DIRS}" )
+    
+    # this will set the INTERFACE_INCLUDE_DIRECTORIES property using the INTERFACE option
+    # it's assumed that the include_directories() command was used to set the INCLUDE_DIRECTORIES property for the private side.
+    target_include_directories( ${FULL_LIB_TARGET} 
+        INTERFACE 
+            "$<BUILD_INTERFACE:${SOURCE_TREE_INCLUDE_DIRS}>"
+            "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${TOP_PROJECT_INCLUDE_INSTALL_SUBDIR}${SM_INCLUDE_SUBDIR}>"
+    )
+
+
+endfunction()
+
+function( pbuilder_link_library )
+    # Linking a shared-object library
+    #
+    # Parameters:
+    #     TARGET: library target name
+    #     PROJECT_LIBRARIES: libraries from the same project to be linked against
+    #     PUBLIC_EXTERNAL_LIBRARIES: public external libraries to be linked against
+    #     PRIVATE_ETERNAL_LIBRARIES: private external libraries to be linked against
+    #     COMPILE_DEFINITIONS: compile definitions to add to this target
+
+    set( OPTIONS )
+    set( ONEVALUEARGS TARGET )
+    set( MULTIVALUEARGS SOURCES PROJECT_LIBRARIES PUBLIC_EXTERNAL_LIBRARIES PRIVATE_EXTERNAL_LIBRARIES COMPILE_DEFINITIONS )
+    cmake_parse_arguments( LIB "${OPTIONS}" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN} )
+
+    message( "Linking library ${LIB_TARGET}" )
+
+    pbuilder_expand_lib_name( ${LIB_TARGET} )
+    set( FULL_LIB_TARGET ${FULL_LIB_NAME} )
+
+    pbuilder_expand_lib_names( ${LIB_PROJECT_LIBRARIES} )
+    set( FULL_PROJECT_LIBRARIES ${FULL_LIB_NAMES} )
+    message( STATUS "full project library dependencies (lib): ${FULL_PROJECT_LIBRARIES}" )
+
+    target_link_libraries( ${FULL_LIB_TARGET} 
+        PUBLIC
+            ${FULL_PROJECT_LIBRARIES} ${${PROJECT_NAME}_SM_LIBRARIES} ${LIB_PUBLIC_EXTERNAL_LIBRARIES}
+        PRIVATE
+            ${LIB_PRIVATE_EXTERNAL_LIBRARIES} 
+    )
+
+    # Add target compile definitions
+    if( LIB_COMPILE_DEFINITIONS )
+        target_compile_definitions( ${FULL_LIB_TARGET}
+            PUBLIC
+                ${LIB_COMPILE_DEFINITIONS}
+        )
+    endif()
+
+endfunction()
+
+function( pbuilder_executables )
+    # Builds multiple executables, assuming one executable per source file
+    # Strips extensino from source file and uses that as the executable name (target and file)
+    #
+    # Parameters
+    #     TARGETS_VAR (output, optional): variable in which to store the names of the executables created
+    #     SOURCES: source files to be builT
+    #     PROJECT_LIBRARIES: libraries from the same project to be linked against
+    #     PUBLIC_EXTERNAL_LIBRARIES: public external libraries to be linked against
+    #     PRIVATE_ETERNAL_LIBRARIES: private external libraries to be linked against
+
+
+    set( OPTIONS )
+    set( ONEVALUEARGS TARGETS_VAR )
+    set( MULTIVALUEARGS SOURCES PROJECT_LIBRARIES PUBLIC_EXTERNAL_LIBRARIES PRIVATE_EXTERNAL_LIBRARIES )
+    cmake_parse_arguments( EXES "${OPTIONS}" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN} )
+
+    message( "Building multiple executables" )
+    message( STATUS "executable source files: ${EXES_SOURCES}" )
+    message( STATUS "project library dependencies: ${EXES_PROJECT_LIBRARIES}" )
+    message( STATUS "submodule library dependencies (public): ${${PROJECT_NAME}_SM_LIBRARIES}" )
+    message( STATUS "external library dependencies (public): ${EXES_PUBLIC_EXTERNAL_LIBRARIES}" )
+    message( STATUS "external library dependencies (private): ${EXES_PRIVATE_EXTERNAL_LIBRARIES}" )
+
+    set( targets )
+
+    foreach( source ${EXES_SOURCES} )
+        get_filename_component( program ${source} NAME_WE )
+        if( NOT TARGET ${program} )
+            pbuilder_executable( EXECUTABLE ${program} 
+                SOURCES ${source} 
+                PROJECT_LIBRARIES ${EXES_PROJECT_LIBRARIES} 
+                PUBLIC_EXTERNAL_LIBRARIES ${EXES_PUBLIC_EXTERNAL_LIBRARIES} 
+                PRIVATE_EXTERNAL_LIBRARIES ${EXES_PRIVATE_EXTERNAL_LIBRARIES} 
+            )
+            list( APPEND targets ${program} )
+        else()
+            message( FATAL "Duplicate target: ${program}" )
+        endif()
+    endforeach( source )
+
+    message( STATUS "Targets produced: ${targets}" )
+    if( EXES_TARGETS_VAR )
+        message( STATUS "output var for targets: ${EXES_TARGETS_VAR}" )
+        set( ${EXES_TARGETS_VAR} ${targets} PARENT_SCOPE )
+    endif()
+
+endfunction()
+
+function( pbuilder_executable )
+    # Builds a single executable from one or more source files
+    #
+    # Parameters
+    #     EXECUTABLE: executable target
+    #     SOURCES: list of sources to be built into one executable
+    #     PROJECT_LIBRARIES: libraries from the same project to be linked against
+    #     PUBLIC_EXTERNAL_LIBRARIES: public external libraries to be linked against
+    #     PRIVATE_ETERNAL_LIBRARIES: private external libraries to be linked against
+
+    set( OPTIONS )
+    set( ONEVALUEARGS EXECUTABLE )
+    set( MULTIVALUEARGS SOURCES PROJECT_LIBRARIES PUBLIC_EXTERNAL_LIBRARIES PRIVATE_EXTERNAL_LIBRARIES )
+    cmake_parse_arguments( EXE "${OPTIONS}" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN} )
+
+    message( "Building executable ${EXE_EXECUTABLE} with ${EXE_SOURCES}" )
+    message( STATUS "\tlinking with: (project) ${EXE_PROJECT_LIBRARIES} -- (submodule) ${${PROJECT_NAME}_SM_LIBRARIES} --  (public ext) ${EXE_PUBLIC_EXTERNAL_LIBRARIES} -- (private ext) ${EXE_PRIVATE_EXTERNAL_LIBRARIES}")
+
+    add_executable( ${EXE_EXECUTABLE} ${EXE_SOURCES} )
+
+    pbuilder_expand_lib_names( ${EXE_PROJECT_LIBRARIES} )
+    set( FULL_PROJECT_LIBRARIES ${FULL_LIB_NAMES} )
+    message( STATUS "full project library dependencies (exe): ${FULL_PROJECT_LIBRARIES}" )
+
+    target_link_libraries( ${EXE_EXECUTABLE} 
+        PUBLIC
+            ${FULL_PROJECT_LIBRARIES} ${${PROJECT_NAME}_SM_LIBRARIES} ${EXE_PUBLIC_EXTERNAL_LIBRARIES}
+        PRIVATE
+            ${EXE_PRIVATE_EXTERNAL_LIBRARIES} 
+    )
+
+endfunction()
+
+function( pbuilder_component_install_and_export )
+    # This function installs library and executable targets, and makes sure they're exported correctly.
+    #
+    # Parameters:
+    #     COMPONENT: build component being installed; required if this function is used multiple times in a project
+    #                if a build does not actually have multiple components, a name still needs to be given (e.g. "library")
+    #     LIBTARGETS: all library targets to be installed
+    #     EXETARGETS: all executable targets to be installed
+
+    set( OPTIONS )
+    set( ONEVALUEARGS COMPONENT )
+    set( MULTIVALUEARGS LIBTARGETS EXETARGETS )
+    cmake_parse_arguments( CIE "${OPTIONS}" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN} )
+
+    if( CIE_COMPONENT )
+        set( INSERT_COMPONENT "_${CIE_COMPONENT}" )
+    endif()
+
+    # Libraries
+    if( CIE_LIBTARGETS )
+        message( "Installing and exporting libraries for component <${CIE_COMPONENT}>" )
+        message( STATUS "Targets are: ${CIE_LIBTARGETS}" )
+
+        # expand library names
+        pbuilder_expand_lib_names( ${CIE_LIBTARGETS} )
+        set( FULL_LIBTARGETS ${FULL_LIB_NAMES} )
+        message( STATUS "Expanded lib names: ${FULL_LIBTARGETS}" )
+
+        # make targets available at build time
+        export( TARGETS ${FULL_LIBTARGETS}
+            APPEND
+            FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}${INSERT_COMPONENT}_Targets.cmake
+        )
+
+        # install libraries and add to export for installation
+        install( TARGETS ${FULL_LIBTARGETS} 
+            EXPORT ${PROJECT_NAME}${INSERT_COMPONENT}_Targets
+            COMPONENT ${CIE_COMPONENT}
+            LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+        )
+    endif()
+
+    # Executables
+    if( CIE_EXETARGETS )
+        message( "Installing and exporting executables for component <${CIE_COMPONENT}>" )
+        message( STATUS "Targets are: ${CIE_EXETARGETS}" )
+
+        # make targets available at build time
+        #message( STATUS "******* build-time exe targets file: ${PROJECT_BINARY_DIR}/${PROJECT_NAME}${INSERT_COMPONENT}_Targets.cmake" )
+        export( TARGETS ${CIE_EXETARGETS}
+            APPEND
+            FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}${INSERT_COMPONENT}_Targets.cmake
+        )
+        
+        # install executables and add to export for installation
+        #message( STATUS "******* installed exe targets export: ${PROJECT_NAME}${INSERT_COMPONENT}_Targets")
+        install( TARGETS ${CIE_EXETARGETS}
+            EXPORT ${PROJECT_NAME}${INSERT_COMPONENT}_Targets
+            COMPONENT ${CIE_COMPONENT}
+            RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+        )
+    endif()
+
+    # Export installation
+    message( "Installing export ${PROJECT_NAME}${INSERT_COMPONENT}_Targets" )
+    message( STATUS "Output file will be ${${PROJECT_NAME}_CMAKE_CONFIG_DIR}/${PROJECT_NAME}${INSERT_COMPONENT}_Targets.cmake" )
+    install( EXPORT ${PROJECT_NAME}${INSERT_COMPONENT}_Targets
+        NAMESPACE
+            ${PROJECT_NAME}::
+        DESTINATION
+            ${${PROJECT_NAME}_CMAKE_CONFIG_DIR}
+    )
+
+
+endfunction()
+
+macro( pbuilder_install_headers )
+    #message( STATUS "installing headers in ${INCLUDE_INSTALL_DIR}${${PROJECT_NAME}_PARENT_INC_DIR_PATH}" )
+    install( FILES ${ARGN} 
+        DESTINATION ${TOP_PROJECT_INCLUDE_INSTALL_DIR}${SM_INCLUDE_SUBDIR}
+    )
+endmacro()
+
+macro( pbuilder_install_header_dirs FILE_PATTERN )
+    install( DIRECTORY ${ARGN} 
+        DESTINATION ${INCLUDE_INSTALL_DIR}${${PROJECT_NAME}_PARENT_INC_DIR_PATH} 
+        FILES_MATCHING PATTERN "${FILE_PATTERN}" 
+    )
+endmacro()
+
+macro( pbuilder_install_config )
+    install( FILES ${ARGN} 
+        DESTINATION ${CONFIG_INSTALL_DIR} 
+    )
+endmacro()
+
+macro( pbuilder_install_data )
+    install( FILES ${ARGN} 
+        DESTINATION ${DATA_INSTALL_DIR} 
+    )
+endmacro()
+
+macro( pbuilder_install_files DEST_DIR )
+    install( FILES ${ARGN} 
+        DESTINATION ${DEST_DIR} 
+    )
+endmacro()
+
+function( pbuilder_do_package_config )
+    # This macro sets up and installs the configuration files used tospecify the install information for the project.
+    # It installs an already-created "config" file.
+    # It creates and installs the "version-config" and "targets" files.
+    # Arguments: 
+    #   
+    #   CONFIG_LOCATION -- Directory in which to find the already-created config file.
+    #                      If not specified, the default is ${PROJECT_BINARY_DIR}.
+    #   FILE_PREFIX -- Portion of the filename that preceeds `Config.cmake`, `Targets.cmake`, and `ConfigVersion.cmake` for the 
+    #                  config, targets, and config-version files, respectively.  If not specified, the default is ${PROJECT_NAME}.
+    #   CONFIG_FILENAME -- Optional specification of the full config filename.  If specified, overrules the default described above.
+    #   VERSION_FILENAME -- Optional specification of the full version-config filename.  If specified, overrules the default described above.
+
+    # Parse macro arguments
+    set( oneValueArgs CONFIG_LOCATION FILE_PREFIX CONFIG_FILENAME VERSION_FILENAME )
+    cmake_parse_arguments( PKG_CONF "" "${oneValueArgs}" "" ${ARGN} )
+
+    # Handle arguments and apply defaults
+
+    if( NOT PKG_CONF_CONFIG_LOCATION )
+        set( PKG_CONF_CONFIG_LOCATION ${PROJECT_BINARY_DIR} )
+    endif()
+
+    if( NOT PKG_CONF_FILE_PREFIX )
+        set( PKG_CONF_FILE_PREFIX ${PROJECT_NAME} )
+    endif()
+
+    if( NOT PKG_CONF_CONFIG_FILENAME )
+        set( PKG_CONF_CONFIG_FILENAME ${PKG_CONF_FILE_PREFIX}Config.cmake )
+    endif()
+    set( CONFIG_PATH ${PKG_CONF_CONFIG_LOCATION}/${PKG_CONF_CONFIG_FILENAME} )
+    message( STATUS "Config file path: ${CONFIG_PATH}" )
+
+    if( NOT PKG_CONF_VERSION_FILENAME )
+        set( PKG_CONF_VERSION_FILENAME ${PKG_CONF_FILE_PREFIX}ConfigVersion.cmake )
+    endif()
+    set( CONFIG_VERSION_PATH ${CMAKE_CURRENT_BINARY_DIR}/${PKG_CONF_VERSION_FILENAME} )
+    message( STATUS "Config version file path: ${CONFIG_VERSION_PATH}" )
+
+    # Config file must exist already
+    if( NOT EXISTS ${CONFIG_PATH} )
+        message( FATAL_ERROR "Package config file does not exist: ${CONFIG_PATH}" )
+    endif()
+
+    include( CMakePackageConfigHelpers )
+    write_basic_package_version_file(
+        ${CONFIG_VERSION_PATH}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install( 
+        FILES 
+            ${CONFIG_VERSION_PATH}
+            ${CONFIG_PATH}
+        DESTINATION 
+            ${${PROJECT_NAME}_CMAKE_CONFIG_DIR}
+    )
+
+endfunction()
+
+function( pbuilder_add_pybind11_module PY_MODULE_NAME PROJECT_LIBRARIES )
+    # Adds a pybind11 module that is linked to the specified project libraries, PUBLIC_EXT_LIBS, and PRIVATE_EXT_LIBS
+    # Installs the library in the standard lib directory unless indicated by the definition of the variable PBUILDER_PY_INSTALL_IN_SITELIB
+
+    pbuilder_expand_lib_names( ${PROJECT_LIBRARIES} )
+    set( FULL_PROJECT_LIBRARIES ${FULL_LIB_NAMES} )
+    message( STATUS "full project libraries (pybind11): ${FULL_PROJECT_LIBRARIES}" )
+
+    message( STATUS "submodule libraries (pybind11): ${${PROJECT_NAME}_SM_LIBRARIES}" )
+
+    # Potential point of confusion: the C++ library is "Scarab" and the python library is "scarab"
+    # Other possible naming schemes seemed less desirable, and we'll hopefully avoid confusion with these comments
+    pybind11_add_module( ${PY_MODULE_NAME} ${PYBINDING_SOURCEFILES} )
+
+    get_target_property( SOURCE_TREE_INCLUDE_DIRS ${PY_MODULE_NAME} INCLUDE_DIRECTORIES )
+    message( STATUS "Adding install interface include dir: ${INCLUDE_INSTALL_SUBDIR}" )
+    message( STATUS "Adding build interface include dirs: ${SOURCE_TREE_INCLUDE_DIRS}" )
+
+    target_include_directories( ${PY_MODULE_NAME}
+        INTERFACE 
+            "$<BUILD_INTERFACE:${SOURCE_TREE_INCLUDE_DIRS}>"
+            "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INCLUDE_INSTALL_SUBDIR}>"
+    )
+
+    target_link_libraries( ${PY_MODULE_NAME} PRIVATE ${FULL_PROJECT_LIBRARIES} ${${PROJECT_NAME}_SM_LIBRARIES} ${PUBLIC_EXT_LIBS} ${PRIVATE_EXT_LIBS} )
+
+    set( PY_MODULE_INSTALL_DIR ${LIB_INSTALL_DIR} )
+    # Override that install location if specified by the user
+    if( DEFINED PBUILDER_PY_INSTALL_IN_SITELIB AND DEFINED Python3_SITELIB )
+        set( PY_MODULE_INSTALL_DIR ${Python3_SITELIB} )
+    endif( DEFINED PBUILDER_PY_INSTALL_IN_SITELIB AND DEFINED Python3_SITELIB )
+    message( STATUS "Installing module ${PY_MODULE_NAME} in ${PY_MODULE_INSTALL_DIR}" )
+
+    install( TARGETS ${PY_MODULE_NAME} DESTINATION ${PY_MODULE_INSTALL_DIR} )
+    
+endfunction()

--- a/cmake/this_wcsim.sh.in
+++ b/cmake/this_wcsim.sh.in
@@ -1,4 +1,4 @@
-# Sets necessary environment variables to use this installation of PTheta in ROOT
+# Sets necessary environment variables to use this installation of WCSim in ROOT
 # Also set PATH and LD_LIBRARY_PATH for convenience
 
 export ROOT_INCLUDE_PATH=@INCLUDE_INSTALL_DIR@@WCSim_PARENT_INC_DIR_PATH@:$ROOT_INCLUDE_PATH

--- a/make.sh
+++ b/make.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-cmake --version 
+cmake3 --version
 
 wcsim_name=${PWD##*/}
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 
 wcsim_directory=${PWD}
 build_directory=${wcsim_directory}/../${wcsim_name}-build/${ROOT_STR}/${branch_name}
+install_directory=${wcsim_directory}/../${wcsim_name}-install/${ROOT_STR}/${branch_name}
 # If ROOT_STR is not set, this will have no effect, if ROOT_STR is set, we can manage two or more different ROOT versions
 
 if [ ! -d ${build_directory} ]; then
@@ -19,11 +20,14 @@ if [ ! -d ${build_directory} ]; then
 	
 	echo "Creating build directory ${build_directory}"
 	mkdir -p ${build_directory}
+
+	echo "Creating install directory ${build_directory}"
+	mkdir -p ${install_directory}
 	
 	cd ${build_directory}
-	cmake -DCMAKE_PREFIX_PATH=${G4INSTALLDIR} ${wcsim_directory}
+	cmake3 -DCMAKE_PREFIX_PATH=${G4INSTALLDIR} -DCMAKE_INSTALL_PREFIX=${install_directory} ${wcsim_directory}
 	
-	cp -r ${wcsim_directory}/sample-root-scripts ${build_directory}/.
+#	cp -r ${wcsim_directory}/sample-root-scripts ${build_directory}/.
 else 
 	cd ${build_directory}
 fi
@@ -31,7 +35,7 @@ fi
 
 if [ -d ${build_directory} ]; then
 	make clean
-	make -j7
+	make -j7 install
 	
 	cd ${wcsim_directory}
 fi	

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,15 +11,15 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 # If there were other libraries in this package on which this library depends, then they would be put in this variable
 #set(PACKAGE_LIBS )
 #
-#set( CORE_LINKDEF_HEADERFILE WCSimRootLinkDef.hh )
+#set( linkdef_header WCSimRootLinkDef.hh )
 #set( sources ${sources} )
-#set( CORE_DICT_PCMFILE ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict_rdict.pcm )
+#set( pcm_file ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict_rdict.pcm )
 #
 ###################################################
 #set( EVENT_SOURCEFILES ${EVENT_SOURCEFILES} ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict.cxx )
-#ROOT_GENERATE_DICTIONARY( CCoreDict ${headers} LINKDEF ${CORE_LINKDEF_HEADERFILE}  OPTIONS -inlineInputHeader )
+#ROOT_GENERATE_DICTIONARY( CCoreDict ${headers} LINKDEF ${linkdef_header}  OPTIONS -inlineInputHeader )
 #
-#pbuilder_install_files(${LIB_INSTALL_DIR} ${CORE_DICT_PCMFILE})
+#pbuilder_install_files(${LIB_INSTALL_DIR} ${pcm_file})
 
 # ###########
 # # Library #
@@ -43,8 +43,8 @@ set (dict_headers
         ${PROJECT_SOURCE_DIR}/include/WCSimRootOptions.hh
         ${PROJECT_SOURCE_DIR}/include/WCSimRootTools.hh )
 
-set( CORE_LINKDEF_HEADERFILE ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
-#set( sources ${sources} )
+set( linkdef_header
+        ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
 set(sources_root
         WCSimRootEvent.cc
         WCSimRootGeom.cc
@@ -52,19 +52,13 @@ set(sources_root
         WCSimEnumerations.cc
         WCSimRootOptions.cc
         WCSimRootTools.cc)
-set( CORE_LINKDEF_HEADERFILE ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
-set(CORE_DICT_PCMFILE ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot_rdict.pcm)
-set(CORE_DICT_ROOTMAPFILE ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.rootmap)
+set( linkdef_header ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
+set(pcm_file ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot_rdict.pcm)
+set(rootmap_file ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.rootmap)
 set(sources ${sources} ${CMAKE_CURRENT_BINARY_DIR}/G__WCSimRoot.cxx)
-#set( CORE_DICT_PCMFILE ${CMAKE_CURRENT_BINARY_DIR}/WCSimDict_rdict.pcm )
-#
-###################################################
-#set( EVENT_SOURCEFILES ${EVENT_SOURCEFILES} ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict.cxx )
 
-ROOT_GENERATE_DICTIONARY(G__WCSimRoot ${dict_headers} LINKDEF ${CORE_LINKDEF_HEADERFILE})
-#ROOT_GENERATE_DICTIONARY( WCSimDict ${headers} LINKDEF ${CORE_LINKDEF_HEADERFILE}  OPTIONS -inlineInputHeader )
-
-pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/lib ${CORE_DICT_PCMFILE} ${CORE_DICT_ROOTMAPFILE})
+ROOT_GENERATE_DICTIONARY(G__WCSimRoot ${dict_headers} LINKDEF ${linkdef_header})
+pbuilder_install_files(${LIB_INSTALL_DIR} ${pcm_file} ${rootmap_file})
 set(sources_root
         ${sources_root}
         G__WCSimRoot.cxx)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,115 @@
+# CMakeLists for src
+# Author: M. Guigue
+# Date: Jul 27, 2022
+
+# Core library
+
+file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
+
+
+# If there were other libraries in this package on which this library depends, then they would be put in this variable
+#set(PACKAGE_LIBS )
+#
+#set( CORE_LINKDEF_HEADERFILE WCSimRootLinkDef.hh )
+#set( sources ${sources} )
+#set( CORE_DICT_PCMFILE ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict_rdict.pcm )
+#
+###################################################
+#set( EVENT_SOURCEFILES ${EVENT_SOURCEFILES} ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict.cxx )
+#ROOT_GENERATE_DICTIONARY( CCoreDict ${headers} LINKDEF ${CORE_LINKDEF_HEADERFILE}  OPTIONS -inlineInputHeader )
+#
+#pbuilder_install_files(${LIB_INSTALL_DIR} ${CORE_DICT_PCMFILE})
+
+# ###########
+# # Library #
+# ###########
+
+pbuilder_library(
+        TARGET WCSimCore
+        SOURCES ${sources}
+        PROJECT_LIBRARIES ${PACKAGE_LIBS}
+        PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
+        PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
+)
+
+# WCSimRoot library
+
+set (dict_headers
+        ${PROJECT_SOURCE_DIR}/include/WCSimRootEvent.hh
+        ${PROJECT_SOURCE_DIR}/include/WCSimRootGeom.hh
+        ${PROJECT_SOURCE_DIR}/include/WCSimPmtInfo.hh
+        ${PROJECT_SOURCE_DIR}/include/WCSimEnumerations.hh
+        ${PROJECT_SOURCE_DIR}/include/WCSimRootOptions.hh
+        ${PROJECT_SOURCE_DIR}/include/WCSimRootTools.hh )
+
+set( CORE_LINKDEF_HEADERFILE ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
+#set( sources ${sources} )
+set(sources_root
+        WCSimRootEvent.cc
+        WCSimRootGeom.cc
+        WCSimPmtInfo.cc
+        WCSimEnumerations.cc
+        WCSimRootOptions.cc
+        WCSimRootTools.cc)
+set( CORE_LINKDEF_HEADERFILE ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
+set(CORE_DICT_PCMFILE ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot_rdict.pcm)
+set(CORE_DICT_ROOTMAPFILE ${CMAKE_CURRENT_BINARY_DIR}/libWCSimRoot.rootmap)
+set(sources ${sources} ${CMAKE_CURRENT_BINARY_DIR}/G__WCSimRoot.cxx)
+#set( CORE_DICT_PCMFILE ${CMAKE_CURRENT_BINARY_DIR}/WCSimDict_rdict.pcm )
+#
+###################################################
+#set( EVENT_SOURCEFILES ${EVENT_SOURCEFILES} ${CMAKE_CURRENT_BINARY_DIR}/CCoreDict.cxx )
+
+ROOT_GENERATE_DICTIONARY(G__WCSimRoot ${dict_headers} LINKDEF ${CORE_LINKDEF_HEADERFILE})
+#ROOT_GENERATE_DICTIONARY( WCSimDict ${headers} LINKDEF ${CORE_LINKDEF_HEADERFILE}  OPTIONS -inlineInputHeader )
+
+pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/lib ${CORE_DICT_PCMFILE} ${CORE_DICT_ROOTMAPFILE})
+set(sources_root
+        ${sources_root}
+        G__WCSimRoot.cxx)
+
+pbuilder_library(
+        TARGET WCSimRoot
+        SOURCES ${sources_root}
+        PROJECT_LIBRARIES ${PACKAGE_LIBS}
+        PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
+        PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
+)
+
+
+
+pbuilder_component_install_and_export(
+        COMPONENT Library
+        LIBTARGETS WCSimCore WCSimRoot
+)
+
+pbuilder_install_headers(${headers})
+
+
+##############
+# Executable
+##############
+
+set (exe_sources
+        ${PROJECT_SOURCE_DIR}/WCSim.cc
+        )
+set(exe_libraries
+        WCSimCore WCSimRoot
+        )
+
+MESSAGE(${PUBLIC_EXT_LIBS})
+
+pbuilder_executables(
+        SOURCES ${exe_sources}
+        TARGETS_VAR programs
+        PROJECT_LIBRARIES ${exe_libraries}
+        PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
+        PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
+)
+
+pbuilder_component_install_and_export(
+        COMPONENT Executables
+        EXETARGETS ${programs}
+)
+

--- a/this_wcsim.sh.in
+++ b/this_wcsim.sh.in
@@ -1,0 +1,6 @@
+# Sets necessary environment variables to use this installation of PTheta in ROOT
+# Also set PATH and LD_LIBRARY_PATH for convenience
+
+export ROOT_INCLUDE_PATH=@INCLUDE_INSTALL_DIR@@WCSim_PARENT_INC_DIR_PATH@:$ROOT_INCLUDE_PATH
+export PATH=@BIN_INSTALL_DIR@:$PATH
+export LD_LIBRARY_PATH=@LIB_INSTALL_DIR@:$LD_LIBRARY_PATH


### PR DESCRIPTION
This is a rather big rework of the cmake in order to include a `install` target.
The primary goal of this target is to allow clean installation where the intermediate files (like CMakeCache or .o binary files) are not in the final install folder (similarly to G4 and ROOT).
A couple of modifications were made:
- this relies on two cmake files called PackageBuilder which contain useful macros for making this easier. We could live without them and have less macros, but this made my life easier. These macros are used in other packages (HK, P-Theta...) and are rather well-maintained.
- Instead of one single library (WCSimRoot), two libraries are created:
    - WCSimRoot: related to the linkDef and root libraries
    - WCSimCore: contains all the classes needed by the WCSim executable (so that people could just link to this one instead of compiling any source file)
- the `install` target will copy all the libraries, executables, data files, cmake config files and headers to a location defined by the `-D CMAKE_INSTALL_PREFIX=XXX` option. If none is provided, make install will copy things into the binary folder (where the cmake command was run).
- A WCSimConfig.cmake file is produced: this offers the possibility to use CMake instructions like `Find(WCSim <version>)` in derived projects (very useful for HK where projects like hk-eventDisplay will use such Find instruction to find ROOT and WCSim). 
- A generic `this_wcsim.sh` file is produced with the install target, this sets PATH and LD_LIBRARY_PATH to point to this installation. (could be called within other setup bash script)
- support to Root5 was not tested, only Root6 (not sure where I can find a Root5 installation in order to test this).
