### PR TITLE
Update Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ USER root
 RUN yum install -y \
     wget \
     tar \
-    cmake \
+    cmake3 \
     gcc-c++ \
     gcc \
     binutils \


### PR DESCRIPTION
`cmake` -> `cmake3`
@brichards64 I think it best if you try to build & push this. If it doesn't work, we obviously still need an older `cmake` for something or other - if we do I can install both the older `cmake` and `cmake3`