### PR TITLE
Disable the WCTE geometry

### DIFF
--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -1097,7 +1097,12 @@ void WCSimDetectorConstruction::SetNuPrism_mPMTGeometry()
 // WCTE with mPMTs (M.Shinoki)
 void WCSimDetectorConstruction::SetNuPrismBeamTest_mPMTGeometry()
 {
-    WCDetectorName = "NuPRISMBeamTest_mPMT";
+  WCDetectorName = "NuPRISMBeamTest_mPMT";
+  G4cerr << "**********************************" << G4endl
+		 << WCDetectorName << " is not supported in this version of WCSim" << G4endl
+		 << "Please use code from the WCTE/WCSim repository to simulate WCTE" << G4endl
+		 << "Exiting..." << G4endl;
+  exit(-1);
     WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
 	mPMT_ID_PMT = "PMT3inchR12199_02";    //can be changed in macro through mPMT settings.
 	mPMT_OD_PMT = "PMT3inchR12199_02";


### PR DESCRIPTION
As pointed out by @pdeperio it is clearer to not allow an outdated WCTE geometry to be used in this version of the code.
WCTE/WCSim should be the place to do WCTE work from

@pdeperio please check if you're happy with the message, then I'll merge