### PR TITLE
Suppress compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ include(${Geant4_USE_FILE})  ## NOT needed for Dict
 #########
 
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.7)
-    set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++11")
+    set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++11 -Wno-overloaded-virtual")
 else()
     set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -std=c++0x")
 endif()

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -72,6 +72,10 @@ int main(int argc,char** argv)
   // Execute command for processing input macros
   const G4String execommand = "/control/execute ";
 
+  //stop GCC complaining about the fallthrough from 3->default
+  // This is something we want
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough="
   // Check arguments, set execution mode and perform some prep.
   switch(argc) {
 #ifdef G4UI_USE
@@ -103,6 +107,7 @@ int main(int argc,char** argv)
       // Exit.
       return -1;
   }
+#pragma GCC diagnostic pop
 
   // define random number generator parameters
   WCSimRandomParameters *randomparameters = new WCSimRandomParameters();

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -328,7 +328,13 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 		char strZ[10]={0};
 		long int A=0,Z=0;
 		sprintf(strPDG,"%i",abs(pdgid));
+		//stop GCC complaining about string truncation
+		// - we're copying from the middle of a long string
+		// - we do terminate the string correctly below
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 		strncpy(strZ, &strPDG[3], 3);
+#pragma GCC diagnostic pop
 		strncpy(strA, &strPDG[6], 3);
 		strA[3]='\0';
 		strZ[3]='\0';
@@ -550,7 +556,13 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       char strA[10]={0};
       char strZ[10]={0};
       sprintf(strPDG,"%i",abs(pdg));
+      //stop GCC complaining about string truncation
+      // - we're copying from the middle of a long string
+      // - we do terminate the string correctly below
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
       strncpy(strZ, &strPDG[3], 3);
+#pragma GCC diagnostic pop
       strncpy(strA, &strPDG[6], 3);
       strA[3]='\0';
       strZ[3]='\0';


### PR DESCRIPTION
Not the best way to suppress compiler warnings (telling GCC not to check parts of the code) but the code is doing exactly what it should be doing in the `.cc` files

The worst thing about this is adding `-Wno-overloaded-virtual` to the gcc. But since the warning is so vague (see below & #360) and so pervasive (most `.o` files have ~10 lines of this when compiled) I don't see any other way to do it
```
<built-in>: warning:   by ‘operator’ [-Woverloaded-virtual]
```