### PR TITLE
Revert "bug fix: Make daq.mac PreTriggerWindows take effect"

### DIFF
--- a/include/WCSimWCDAQMessenger.hh
+++ b/include/WCSimWCDAQMessenger.hh
@@ -73,7 +73,6 @@ private:
   G4bool                StoreNDigitsAdjustForNoise;
   G4UIcmdWithAnInteger* NDigitsPreTriggerWindow;
   G4int                 StoreNDigitsPreWindow;
-  G4bool                NDigitsPreWindowSetByUser; //because this is typically negative, a foolproof(?) workaround
   G4UIcmdWithAnInteger* NDigitsPostTriggerWindow;
   G4int                 StoreNDigitsPostWindow;
   G4UIcmdWithADouble* TriggerOffset;

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -12,7 +12,7 @@
 #include <string>
 
 WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
-  WCSimEvent(eventaction), NDigitsPreWindowSetByUser(false)
+  WCSimEvent(eventaction)
 {
   initialiseString = " (this is a default set; it may be overwritten by user commands)";
   initialised = false;
@@ -323,7 +323,6 @@ void WCSimWCDAQMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   else if (command == NDigitsPreTriggerWindow) {
     G4cout << "NDigits pretrigger window set to " << newValue << " ns" << initialiseString.c_str() << G4endl;
     StoreNDigitsPreWindow = NDigitsPreTriggerWindow->GetNewIntValue(newValue);
-    NDigitsPreWindowSetByUser = true;
   }
   else if (command == NDigitsPostTriggerWindow) {
     G4cout << "NDigits posttrigger window set to " << newValue << " ns" << initialiseString.c_str() << G4endl;
@@ -359,10 +358,14 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
   G4cout << "\t" << failuremode << G4endl;
   WCSimTrigger->SetSaveFailuresTime(StoreSaveFailuresTime);
   G4cout << "\tTrigger time for events which fail all triggers will be set to " << StoreSaveFailuresTime << " ns" << G4endl;
-  WCSimTrigger->SetSaveFailuresPreTriggerWindow(StoreSaveFailuresPreWindow);
-  G4cout << "\tSaveFailures pretrigger window set to " << StoreSaveFailuresPreWindow << " ns" << G4endl;
-  WCSimTrigger->SetSaveFailuresPostTriggerWindow(StoreSaveFailuresPostWindow);
-  G4cout << "\tSaveFailures posttrigger window set to " << StoreSaveFailuresPostWindow << " ns" << G4endl;
+  if(StoreSaveFailuresPreWindow >= -1E6) {
+    WCSimTrigger->SetSaveFailuresPreTriggerWindow(StoreSaveFailuresPreWindow);
+    G4cout << "\tSaveFailures pretrigger window set to " << StoreSaveFailuresPreWindow << " ns" << G4endl;
+  }
+  if(StoreSaveFailuresPostWindow >= 0) {
+    WCSimTrigger->SetSaveFailuresPostTriggerWindow(StoreSaveFailuresPostWindow);
+    G4cout << "\tSaveFailures posttrigger window set to " << StoreSaveFailuresPostWindow << " ns" << G4endl;
+  }
 
   if(StoreNDigitsThreshold >= 0) {
    WCSimTrigger->SetNDigitsThreshold(StoreNDigitsThreshold);
@@ -375,7 +378,7 @@ void WCSimWCDAQMessenger::SetTriggerOptions()
     WCSimTrigger->SetNDigitsWindow(StoreNDigitsWindow);
     G4cout << "\tNDigits trigger window set to " << StoreNDigitsWindow << " ns" << G4endl;
   }
-  if(NDigitsPreWindowSetByUser) {
+  if(StoreNDigitsPreWindow >= 0) {
     WCSimTrigger->SetNDigitsPreTriggerWindow(StoreNDigitsPreWindow);
     G4cout << "\tNDigits pretrigger window set to " << StoreNDigitsPreWindow << " ns" << G4endl;
   }


### PR DESCRIPTION
Reverts WCSim/WCSim#358

Realised the CI was not flagging plot differences... let's start today again