### PR TITLE
Feature/save id od boundary points

### DIFF
--- a/include/WCSimEnumerations.hh
+++ b/include/WCSimEnumerations.hh
@@ -31,6 +31,13 @@ typedef enum ERandomGeneratorType {
   RANDOM_E_HEPJAMES=3
 } WCSimRandomGenerator_t;
 
+typedef enum EBoundaryType {
+  kNull=0,
+  kBlackSheet,
+  kTyvek,
+  kCave
+} BoundaryType_t;
+
 class WCSimEnumerations
 {
 public:
@@ -38,6 +45,7 @@ public:
   static std::string EnumAsString(DigitizerType_t d);
   static std::string EnumAsString(TriggerType_t t);
   static std::string EnumAsString(WCSimRandomGenerator_t r);
+  static std::string EnumAsString(BoundaryType_t b);
   static TriggerType_t TriggerTypeFromString(std::string s);
 
 };

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -43,6 +43,9 @@ private:
   Double_t fTime;
   Int_t fId;
   Int_t fParentId;
+  std::vector<std::vector<double>> boundaryPoints;
+  std::vector<double> boundaryKEs;
+  std::vector<int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 
 public:
   WCSimRootTrack() {}
@@ -60,7 +63,10 @@ public:
 		 Int_t parenttype,
 		 Double_t time,
 		 Int_t id,
-		 Int_t idParent);
+		 Int_t idParent,
+     std::vector<std::vector<double>> bPs,
+     std::vector<double> bKEs,
+     std::vector<int> bTypes);
   virtual ~WCSimRootTrack() { }
   bool CompareAllVariables(const WCSimRootTrack * c) const;
 
@@ -79,8 +85,11 @@ public:
   Double_t   GetTime() const { return fTime;}
   Int_t     GetId() const {return fId;}
   Int_t     GetParentId() const {return fParentId;}
+  std::vector<std::vector<double>> GetBoundaryPoints() {return boundaryPoints;}
+  std::vector<double> GetBoundaryKEs() {return boundaryKEs;}
+  std::vector<int> GetBoundaryTypes() {return boundaryTypes;}
 
-  ClassDef(WCSimRootTrack,3)
+  ClassDef(WCSimRootTrack,4)
 };
 
 
@@ -447,7 +456,10 @@ public:
 				   Int_t parenttype,
 				   Double_t time,
 				   Int_t id,
-				   Int_t idParent);
+				   Int_t idParent,
+           std::vector<std::vector<double>> bPs,
+           std::vector<double> bKEs,
+           std::vector<int> bTypes);
 
   WCSimRootTrack * AddTrack   (WCSimRootTrack * track);
   WCSimRootTrack * RemoveTrack(WCSimRootTrack * track);
@@ -480,7 +492,7 @@ public:
 
   TClonesArray	      *GetCaptures() const {return fCaptures;}
 
-  ClassDef(WCSimRootTrigger,4) //WCSimRootEvent structure
+  ClassDef(WCSimRootTrigger,5) //WCSimRootEvent structure
 };
 
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -87,10 +87,10 @@ public:
   Double_t   GetTime() const { return fTime;}
   Int_t     GetId() const {return fId;}
   Int_t     GetParentId() const {return fParentId;}
-  std::vector<std::vector<float>> GetBoundaryPoints() {return boundaryPoints;}
-  std::vector<float> GetBoundaryKEs() {return boundaryKEs;}
-  std::vector<double> GetBoundaryTimes() {return boundaryTimes;}
-  std::vector<int> GetBoundaryTypes() {return boundaryTypes;}
+  std::vector<std::vector<float>> GetBoundaryPoints() const {return boundaryPoints;}
+  std::vector<float> GetBoundaryKEs() const {return boundaryKEs;}
+  std::vector<double> GetBoundaryTimes() const {return boundaryTimes;}
+  std::vector<int> GetBoundaryTypes() const {return boundaryTypes;}
 
   ClassDef(WCSimRootTrack,4)
 };

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -45,6 +45,7 @@ private:
   Int_t fParentId;
   std::vector<std::vector<float>> boundaryPoints;
   std::vector<float> boundaryKEs;
+  std::vector<double> boundaryTimes;
   std::vector<int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 
 public:
@@ -66,6 +67,7 @@ public:
 		 Int_t idParent,
      std::vector<std::vector<float>> bPs,
      std::vector<float> bKEs,
+     std::vector<double> bTimes,
      std::vector<int> bTypes);
   virtual ~WCSimRootTrack() { }
   bool CompareAllVariables(const WCSimRootTrack * c) const;
@@ -87,6 +89,7 @@ public:
   Int_t     GetParentId() const {return fParentId;}
   std::vector<std::vector<float>> GetBoundaryPoints() {return boundaryPoints;}
   std::vector<float> GetBoundaryKEs() {return boundaryKEs;}
+  std::vector<double> GetBoundaryTimes() {return boundaryTimes;}
   std::vector<int> GetBoundaryTypes() {return boundaryTypes;}
 
   ClassDef(WCSimRootTrack,4)
@@ -459,6 +462,7 @@ public:
 				   Int_t idParent,
            std::vector<std::vector<float>> bPs,
            std::vector<float> bKEs,
+           std::vector<double> bTimes,
            std::vector<int> bTypes);
 
   WCSimRootTrack * AddTrack   (WCSimRootTrack * track);

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -43,8 +43,8 @@ private:
   Double_t fTime;
   Int_t fId;
   Int_t fParentId;
-  std::vector<std::vector<double>> boundaryPoints;
-  std::vector<double> boundaryKEs;
+  std::vector<std::vector<float>> boundaryPoints;
+  std::vector<float> boundaryKEs;
   std::vector<int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 
 public:
@@ -64,8 +64,8 @@ public:
 		 Double_t time,
 		 Int_t id,
 		 Int_t idParent,
-     std::vector<std::vector<double>> bPs,
-     std::vector<double> bKEs,
+     std::vector<std::vector<float>> bPs,
+     std::vector<float> bKEs,
      std::vector<int> bTypes);
   virtual ~WCSimRootTrack() { }
   bool CompareAllVariables(const WCSimRootTrack * c) const;
@@ -85,8 +85,8 @@ public:
   Double_t   GetTime() const { return fTime;}
   Int_t     GetId() const {return fId;}
   Int_t     GetParentId() const {return fParentId;}
-  std::vector<std::vector<double>> GetBoundaryPoints() {return boundaryPoints;}
-  std::vector<double> GetBoundaryKEs() {return boundaryKEs;}
+  std::vector<std::vector<float>> GetBoundaryPoints() {return boundaryPoints;}
+  std::vector<float> GetBoundaryKEs() {return boundaryKEs;}
   std::vector<int> GetBoundaryTypes() {return boundaryTypes;}
 
   ClassDef(WCSimRootTrack,4)
@@ -457,8 +457,8 @@ public:
 				   Double_t time,
 				   Int_t id,
 				   Int_t idParent,
-           std::vector<std::vector<double>> bPs,
-           std::vector<double> bKEs,
+           std::vector<std::vector<float>> bPs,
+           std::vector<float> bKEs,
            std::vector<int> bTypes);
 
   WCSimRootTrack * AddTrack   (WCSimRootTrack * track);

--- a/include/WCSimRootTools.hh
+++ b/include/WCSimRootTools.hh
@@ -28,5 +28,7 @@ bool ComparisonPassedVec(const vector<float> & val1, const vector<float> & val2,
 			 const char * callerclass, const char * callerfunc, const char * tag);
 bool ComparisonPassedVec(const vector<double> & val1, const vector<double> & val2,
 			 const char * callerclass, const char * callerfunc, const char * tag);
+bool ComparisonPassedVecVec(const vector<vector<float>> & val1, const vector<vector<float>> & val2,
+			 const char * callerclass, const char * callerfunc, const char * tag);
 
 #endif //WCSimRootTools_h

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -72,6 +72,26 @@ public: // with description
    inline void SetStoppingVolume(G4VPhysicalVolume* currentVolume)
    { stoppingVolume = currentVolume;}
 
+// Functions to Set/Get boundary points
+  inline void SetBoundaryPoints(std::vector<std::vector<G4double>> bPs,
+                                std::vector<G4double> bKEs,
+                                std::vector<G4int> bTypes)
+  {
+    boundaryPoints = bPs;
+    boundaryKEs = bKEs;
+    boundaryTypes = bTypes;
+  }
+  inline void AddBoundaryPoint(std::vector<G4double> bPs,
+                               G4double bKEs,
+                               G4int bTypes)
+  {
+    boundaryPoints.push_back(bPs);
+    boundaryKEs.push_back(bKEs);
+    boundaryTypes.push_back(bTypes);
+  }
+  inline std::vector<std::vector<G4double>> GetBoundaryPoints() {return boundaryPoints;}
+  inline std::vector<G4double> GetBoundaryKEs() {return boundaryKEs;}
+  inline std::vector<G4int> GetBoundaryTypes() {return boundaryTypes;}
 
 // Other member functions
    virtual void ShowTrajectory(std::ostream& os=G4cout) const;
@@ -107,6 +127,11 @@ public: // with description
   G4bool SaveIt;
   G4String creatorProcess;
   G4double                  globalTime;
+
+  // Boundary points;
+  std::vector<std::vector<G4double>> boundaryPoints;
+  std::vector<G4double> boundaryKEs;
+  std::vector<G4int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 };
 
 /***            TEMP  : M FECHNER ***********

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -75,22 +75,27 @@ public: // with description
 // Functions to Set/Get boundary points
   inline void SetBoundaryPoints(std::vector<std::vector<G4float>> bPs,
                                 std::vector<G4float> bKEs,
+                                std::vector<G4double> bTimes,
                                 std::vector<G4int> bTypes)
   {
     boundaryPoints = bPs;
     boundaryKEs = bKEs;
+    boundaryTimes = bTimes;
     boundaryTypes = bTypes;
   }
   inline void AddBoundaryPoint(std::vector<G4float> bPs,
                                G4float bKEs,
+                               G4double bTimes,
                                G4int bTypes)
   {
     boundaryPoints.push_back(bPs);
     boundaryKEs.push_back(bKEs);
+    boundaryTimes.push_back(bTimes);
     boundaryTypes.push_back(bTypes);
   }
   inline std::vector<std::vector<G4float>> GetBoundaryPoints() {return boundaryPoints;}
   inline std::vector<G4float> GetBoundaryKEs() {return boundaryKEs;}
+  inline std::vector<G4double> GetBoundaryTimes() {return boundaryTimes;}
   inline std::vector<G4int> GetBoundaryTypes() {return boundaryTypes;}
 
 // Other member functions
@@ -131,6 +136,7 @@ public: // with description
   // Boundary points;
   std::vector<std::vector<G4float>> boundaryPoints;
   std::vector<G4float> boundaryKEs;
+  std::vector<G4double> boundaryTimes;
   std::vector<G4int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 };
 

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -73,24 +73,24 @@ public: // with description
    { stoppingVolume = currentVolume;}
 
 // Functions to Set/Get boundary points
-  inline void SetBoundaryPoints(std::vector<std::vector<G4double>> bPs,
-                                std::vector<G4double> bKEs,
+  inline void SetBoundaryPoints(std::vector<std::vector<G4float>> bPs,
+                                std::vector<G4float> bKEs,
                                 std::vector<G4int> bTypes)
   {
     boundaryPoints = bPs;
     boundaryKEs = bKEs;
     boundaryTypes = bTypes;
   }
-  inline void AddBoundaryPoint(std::vector<G4double> bPs,
-                               G4double bKEs,
+  inline void AddBoundaryPoint(std::vector<G4float> bPs,
+                               G4float bKEs,
                                G4int bTypes)
   {
     boundaryPoints.push_back(bPs);
     boundaryKEs.push_back(bKEs);
     boundaryTypes.push_back(bTypes);
   }
-  inline std::vector<std::vector<G4double>> GetBoundaryPoints() {return boundaryPoints;}
-  inline std::vector<G4double> GetBoundaryKEs() {return boundaryKEs;}
+  inline std::vector<std::vector<G4float>> GetBoundaryPoints() {return boundaryPoints;}
+  inline std::vector<G4float> GetBoundaryKEs() {return boundaryKEs;}
   inline std::vector<G4int> GetBoundaryTypes() {return boundaryTypes;}
 
 // Other member functions
@@ -129,8 +129,8 @@ public: // with description
   G4double                  globalTime;
 
   // Boundary points;
-  std::vector<std::vector<G4double>> boundaryPoints;
-  std::vector<G4double> boundaryKEs;
+  std::vector<std::vector<G4float>> boundaryPoints;
+  std::vector<G4float> boundaryKEs;
   std::vector<G4int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 };
 

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -14,6 +14,8 @@ class WCSimTrajectory;
 #include "G4Track.hh"
 #include "G4Step.hh"
 
+#include "WCSimEnumerations.hh"
+
 class G4Polyline;                   // Forward declaration.
 
 typedef std::vector<G4VTrajectoryPoint*>  TrajectoryPointContainer;
@@ -76,7 +78,7 @@ public: // with description
   inline void SetBoundaryPoints(std::vector<std::vector<G4float>> bPs,
                                 std::vector<G4float> bKEs,
                                 std::vector<G4double> bTimes,
-                                std::vector<G4int> bTypes)
+                                std::vector<BoundaryType_t> bTypes)
   {
     boundaryPoints = bPs;
     boundaryKEs = bKEs;
@@ -86,7 +88,7 @@ public: // with description
   inline void AddBoundaryPoint(std::vector<G4float> bPs,
                                G4float bKEs,
                                G4double bTimes,
-                               G4int bTypes)
+                               BoundaryType_t bTypes)
   {
     boundaryPoints.push_back(bPs);
     boundaryKEs.push_back(bKEs);
@@ -96,7 +98,14 @@ public: // with description
   inline std::vector<std::vector<G4float>> GetBoundaryPoints() {return boundaryPoints;}
   inline std::vector<G4float> GetBoundaryKEs() {return boundaryKEs;}
   inline std::vector<G4double> GetBoundaryTimes() {return boundaryTimes;}
-  inline std::vector<G4int> GetBoundaryTypes() {return boundaryTypes;}
+  inline std::vector<BoundaryType_t> GetBoundaryTypes() {return boundaryTypes;}
+  inline std::vector<int> GetBoundaryTypesAsInt() 
+  {
+    std::vector<int> bTypes;
+    for (auto t : boundaryTypes)
+      bTypes.push_back((int)t);
+    return bTypes;
+  }
 
 // Other member functions
    virtual void ShowTrajectory(std::ostream& os=G4cout) const;
@@ -137,7 +146,7 @@ public: // with description
   std::vector<std::vector<G4float>> boundaryPoints;
   std::vector<G4float> boundaryKEs;
   std::vector<G4double> boundaryTimes;
-  std::vector<G4int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
+  std::vector<BoundaryType_t> boundaryTypes; // kBlackSheet=1, kTyvek, kCave
 };
 
 /***            TEMP  : M FECHNER ***********

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -139,6 +139,16 @@ int sample_readfile(const char *filename="../wcsim.root", bool verbose=false)
         printf("  Track initial momentum magnitude [MeV/c]: %f\n", wcsimroottrack->GetP());
         printf("  Track mass [MeV/c2]: %f\n", wcsimroottrack->GetM());
         printf("  Track ID: %d\n", wcsimroottrack->GetId());
+        printf("  Number of ID/OD crossings: %zu\n", wcsimroottrack->GetBoundaryPoints().size());
+        if (wcsimroottrack->GetBoundaryPoints().size()>0)
+          printf("  First crossing position [mm]: (%f %f %f), KE [MeV]: %f, time [ns]: %f, type: %d\n", 
+                  wcsimroottrack->GetBoundaryPoints().at(0).at(0),
+                  wcsimroottrack->GetBoundaryPoints().at(0).at(1),
+                  wcsimroottrack->GetBoundaryPoints().at(0).at(2),
+                  wcsimroottrack->GetBoundaryKEs().at(0),
+                  wcsimroottrack->GetBoundaryTimes().at(0),
+                  wcsimroottrack->GetBoundaryTypes().at(0)
+                );
       }//verbose
     }  // itrack // End of loop over tracks
     

--- a/src/WCSimEnumerations.cc
+++ b/src/WCSimEnumerations.cc
@@ -60,6 +60,25 @@ std::string WCSimEnumerations::EnumAsString(WCSimRandomGenerator_t r)
   return "";
 }
 
+std::string WCSimEnumerations::EnumAsString(BoundaryType_t b)
+{
+  switch(b) {
+  case (kBlackSheet) :
+    return "Blacksheet";
+    break;
+  case (kTyvek) :
+    return "Tyvek";
+    break;
+  case (kCave) :
+    return "Cave";
+    break;
+  default:
+    return "";
+    break;
+  }
+  return "";
+}
+
 TriggerType_t WCSimEnumerations::TriggerTypeFromString(std::string s)
 {
   for(int i = int(kTriggerUndefined)+1; i <= kTriggerFailure; i++) {

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1213,6 +1213,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                   0,
                   std::vector<std::vector<float>>(),
                   std::vector<float>(),
+                  std::vector<double>(),
                   std::vector<int>());
   }
 
@@ -1356,6 +1357,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                                    idPrnt,
                                    trj->GetBoundaryPoints(),
                                    trj->GetBoundaryKEs(),
+                                   trj->GetBoundaryTimes(),
                                    trj->GetBoundaryTypes());
       }
 
@@ -1751,6 +1753,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
                  0,
                  std::vector<std::vector<float>>(),
                  std::vector<float>(),
+                 std::vector<double>(),
                  std::vector<int>());
   }
 
@@ -1890,6 +1893,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
                                    idPrnt,
                                    trj->GetBoundaryPoints(),
                                    trj->GetBoundaryKEs(),
+                                   trj->GetBoundaryTimes(),
                                    trj->GetBoundaryTypes());
       }
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1358,7 +1358,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                                    trj->GetBoundaryPoints(),
                                    trj->GetBoundaryKEs(),
                                    trj->GetBoundaryTimes(),
-                                   trj->GetBoundaryTypes());
+                                   trj->GetBoundaryTypesAsInt());
       }
 
 
@@ -1894,7 +1894,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
                                    trj->GetBoundaryPoints(),
                                    trj->GetBoundaryKEs(),
                                    trj->GetBoundaryTimes(),
-                                   trj->GetBoundaryTypes());
+                                   trj->GetBoundaryTypesAsInt());
       }
 
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1211,8 +1211,8 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 			      injhfNtuple.time[k],
                   0,
                   0,
-                  std::vector<std::vector<double>>(),
-                  std::vector<double>(),
+                  std::vector<std::vector<float>>(),
+                  std::vector<float>(),
                   std::vector<int>());
   }
 
@@ -1749,8 +1749,8 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 			     injhfNtuple.time[k],
                  0,
                  0,
-                 std::vector<std::vector<double>>(),
-                 std::vector<double>(),
+                 std::vector<std::vector<float>>(),
+                 std::vector<float>(),
                  std::vector<int>());
   }
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1210,7 +1210,10 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 			      injhfNtuple.parent[k],
 			      injhfNtuple.time[k],
                   0,
-                  0);
+                  0,
+                  std::vector<std::vector<double>>(),
+                  std::vector<double>(),
+                  std::vector<int>());
   }
 
   // the rest of the tracks come from WCSimTrajectory
@@ -1350,7 +1353,10 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                                    parentType,
                                    ttime,
                                    id,
-                                   idPrnt);
+                                   idPrnt,
+                                   trj->GetBoundaryPoints(),
+                                   trj->GetBoundaryKEs(),
+                                   trj->GetBoundaryTypes());
       }
 
 
@@ -1742,7 +1748,10 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 			      injhfNtuple.parent[k],
 			     injhfNtuple.time[k],
                  0,
-                 0);
+                 0,
+                 std::vector<std::vector<double>>(),
+                 std::vector<double>(),
+                 std::vector<int>());
   }
 
   // the rest of the tracks come from WCSimTrajectory
@@ -1878,7 +1887,10 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
                                    parentType,
                                    ttime,
                                    id,
-                                   idPrnt);
+                                   idPrnt,
+                                   trj->GetBoundaryPoints(),
+                                   trj->GetBoundaryKEs(),
+                                   trj->GetBoundaryTypes());
       }
 
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -820,6 +820,10 @@ bool WCSimRootTrack::CompareAllVariables(const WCSimRootTrack * c) const
   failed = (!ComparisonPassed(fTime, c->GetTime(), typeid(*this).name(), __func__, "Time")) || failed;
   failed = (!ComparisonPassed(fId, c->GetId(), typeid(*this).name(), __func__, "Id")) || failed;
   failed = (!ComparisonPassed(fParentId, c->GetParentId(), typeid(*this).name(), __func__, "ParentId")) || failed;
+  failed = (!ComparisonPassedVecVec(boundaryPoints, c->GetBoundaryPoints(), typeid(*this).name(), __func__, "boundaryPoints")) || failed;
+  failed = (!ComparisonPassedVec(boundaryKEs, c->GetBoundaryKEs(), typeid(*this).name(), __func__, "boundaryKEs")) || failed;
+  failed = (!ComparisonPassedVec(boundaryTimes, c->GetBoundaryTimes(), typeid(*this).name(), __func__, "boundaryTimes")) || failed;
+  failed = (!ComparisonPassedVec(boundaryTypes, c->GetBoundaryTypes(), typeid(*this).name(), __func__, "boundaryTypes")) || failed;
 
   return !failed;
 }

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -407,6 +407,7 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   Int_t idParent,
              std::vector<std::vector<float>> bPs,
              std::vector<float> bKEs,
+             std::vector<double> bTimes,
              std::vector<int> bTypes)
 {
   // Add a new WCSimRootTrack to the list of tracks for this event.
@@ -434,6 +435,7 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 						idParent,
             bPs,
             bKEs,
+            bTimes,
             bTypes);
   fNtrack++;
   return track;
@@ -475,6 +477,7 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(WCSimRootTrack * track)
 					  track->GetParentId(),
             track->GetBoundaryPoints(),
             track->GetBoundaryKEs(),
+            track->GetBoundaryTimes(),
             track->GetBoundaryTypes());
   fNtrack++;
   return track_out;
@@ -509,6 +512,7 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 			       Int_t idParent,
              std::vector<std::vector<float>> bPs,
              std::vector<float> bKEs,
+             std::vector<double> bTimes,
              std::vector<int> bTypes)
 {
 
@@ -535,6 +539,7 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
   fParentId = idParent;
   boundaryPoints = bPs;
   boundaryKEs = bKEs;
+  boundaryTimes = bTimes;
   boundaryTypes = bTypes;
 }
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -405,8 +405,8 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   Double_t time,
 					   Int_t id,
 					   Int_t idParent,
-             std::vector<std::vector<double>> bPs,
-             std::vector<double> bKEs,
+             std::vector<std::vector<float>> bPs,
+             std::vector<float> bKEs,
              std::vector<int> bTypes)
 {
   // Add a new WCSimRootTrack to the list of tracks for this event.
@@ -507,8 +507,8 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 			       Double_t time,
 			       Int_t id,
 			       Int_t idParent,
-             std::vector<std::vector<double>> bPs,
-             std::vector<double> bKEs,
+             std::vector<std::vector<float>> bPs,
+             std::vector<float> bKEs,
              std::vector<int> bTypes)
 {
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -404,7 +404,10 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   Int_t parenttype,
 					   Double_t time,
 					   Int_t id,
-					   Int_t idParent)
+					   Int_t idParent,
+             std::vector<std::vector<double>> bPs,
+             std::vector<double> bKEs,
+             std::vector<int> bTypes)
 {
   // Add a new WCSimRootTrack to the list of tracks for this event.
   // To avoid calling the very time consuming operator new for each track,
@@ -428,7 +431,10 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 						parenttype,
 						time,
 						id,
-						idParent);
+						idParent,
+            bPs,
+            bKEs,
+            bTypes);
   fNtrack++;
   return track;
 }
@@ -466,7 +472,10 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(WCSimRootTrack * track)
 					  track->GetParenttype(),
 					  track->GetTime(),
 					  track->GetId(),
-					  track->GetParentId());
+					  track->GetParentId(),
+            track->GetBoundaryPoints(),
+            track->GetBoundaryKEs(),
+            track->GetBoundaryTypes());
   fNtrack++;
   return track_out;
 }
@@ -497,7 +506,10 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 			       Int_t parenttype,
 			       Double_t time,
 			       Int_t id,
-			       Int_t idParent)
+			       Int_t idParent,
+             std::vector<std::vector<double>> bPs,
+             std::vector<double> bKEs,
+             std::vector<int> bTypes)
 {
 
   // Create a WCSimRootTrack object and fill it with stuff
@@ -521,6 +533,9 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
   fTime = time;
   fId = id;
   fParentId = idParent;
+  boundaryPoints = bPs;
+  boundaryKEs = bKEs;
+  boundaryTypes = bTypes;
 }
 
 //_____________________________________________________________________________

--- a/src/WCSimRootTools.cc
+++ b/src/WCSimRootTools.cc
@@ -156,3 +156,17 @@ bool ComparisonPassedVec(const vector<double> & val1, const vector<double> & val
   }
   return !failed;
 }
+
+bool ComparisonPassedVecVec(const vector<vector<float>> & val1, const vector<vector<float>> & val2, const char * callerclass, const char * callerfunc, const char * tag)
+{
+  bool failed = false;
+  if(val1.size() != val2.size()) {
+    cerr << callerclass << "::" << callerfunc << " " << tag << " have unequal sizes: " << val1.size() << ", " << val2.size() << endl;
+    failed = true;
+  }
+  const int n = TMath::Min(val1.size(), val2.size());
+  for(int i = 0; i < n; i++) {
+    failed = (!ComparisonPassedVec(val1[i], val2[i], callerclass, callerfunc, TString::Format("%s[%d]", tag, i)));
+  }
+  return !failed;
+}

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -209,7 +209,7 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
     if (ty>0)
     {
       const G4Track* track       = aStep->GetTrack();
-      std::vector<G4double> bPs(3);
+      std::vector<G4float> bPs(3);
       bPs[0] = track->GetPosition().x(); bPs[1] = track->GetPosition().y(); bPs[2] = track->GetPosition().z();
       AddBoundaryPoint(bPs, track->GetKineticEnergy(), ty);
       // G4cout<<"Step point "<<track->GetCurrentStepNumber () <<" "<<track->GetPosition().x()<<" "<<track->GetPosition().y()<<" "<<track->GetPosition().z()<<

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -24,6 +24,7 @@ WCSimTrajectory::WCSimTrajectory()
 {
   boundaryPoints.clear();
   boundaryKEs.clear();
+  boundaryTimes.clear();
   boundaryTypes.clear();
 }
 
@@ -56,6 +57,7 @@ WCSimTrajectory::WCSimTrajectory(const G4Track* aTrack)
 
   boundaryPoints.clear();
   boundaryKEs.clear();
+  boundaryTimes.clear();
   boundaryTypes.clear();
 }
 
@@ -83,6 +85,7 @@ WCSimTrajectory::WCSimTrajectory(WCSimTrajectory & right):G4VTrajectory()
 
   boundaryPoints = right.boundaryPoints;
   boundaryKEs = right.boundaryKEs;
+  boundaryTimes = right.boundaryTimes;
   boundaryTypes = right.boundaryTypes;
 }
 
@@ -99,6 +102,7 @@ WCSimTrajectory::~WCSimTrajectory()
 
   boundaryPoints.clear();
   boundaryKEs.clear();
+  boundaryTimes.clear();
   boundaryTypes.clear();
 }
 
@@ -211,7 +215,7 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
       const G4Track* track       = aStep->GetTrack();
       std::vector<G4float> bPs(3);
       bPs[0] = track->GetPosition().x(); bPs[1] = track->GetPosition().y(); bPs[2] = track->GetPosition().z();
-      AddBoundaryPoint(bPs, track->GetKineticEnergy(), ty);
+      AddBoundaryPoint(bPs, track->GetKineticEnergy(), track->GetGlobalTime(), ty);
       // G4cout<<"Step point "<<track->GetCurrentStepNumber () <<" "<<track->GetPosition().x()<<" "<<track->GetPosition().y()<<" "<<track->GetPosition().z()<<
       //    " "<<track->GetKineticEnergy()<<" "<<thePrePV->GetName()<<" "<<thePostPV->GetName()<<G4endl;
     }
@@ -244,7 +248,10 @@ void WCSimTrajectory::MergeTrajectory(G4VTrajectory* secondTrajectory)
   ent = (seco->GetBoundaryPoints()).size();
   for (G4int i=0;i<ent;i++)
   {
-    AddBoundaryPoint((seco->GetBoundaryPoints()).at(i),(seco->GetBoundaryKEs()).at(i),(seco->GetBoundaryTypes()).at(i));
+    AddBoundaryPoint((seco->GetBoundaryPoints()).at(i),
+                     (seco->GetBoundaryKEs()).at(i),
+                     (seco->GetBoundaryTimes()).at(i),
+                     (seco->GetBoundaryTypes()).at(i));
   }
 }
 

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -206,11 +206,11 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
   {
     G4String thePrePVName = thePrePV->GetName();
     G4String thePostPVName = thePostPV->GetName();
-    G4int ty = 0;
-    if (thePrePVName.contains("BlackSheet") || thePostPVName.contains("BlackSheet")) ty = 1;
-    else if (thePrePVName.contains("Cave") || thePostPVName.contains("Cave")) ty = 3;
-    else if (thePrePVName.contains("Tyvek") || thePostPVName.contains("Tyvek")) ty = 2;
-    if (ty>0)
+    BoundaryType_t ty = kNull;
+    if (thePrePVName.contains("BlackSheet") || thePostPVName.contains("BlackSheet")) ty = kBlackSheet;
+    else if (thePrePVName.contains("Cave") || thePostPVName.contains("Cave")) ty = kCave;
+    else if (thePrePVName.contains("Tyvek") || thePostPVName.contains("Tyvek")) ty = kTyvek;
+    if (ty!=kNull)
     {
       const G4Track* track       = aStep->GetTrack();
       std::vector<G4float> bPs(3);


### PR DESCRIPTION
Following discussion in Issues https://github.com/WCSim/WCSim/issues/369, we will save extra trajectory information for OD study.

Logic is as follows:
Check pre-step and post-step volume names and save trajectory points whenever crossing ID blacksheet or OD tyvek.

These trajectory points are saved within WCSimRootTrack class and can be accessed with functions GetBoundaryPoints, etc. Usage are demonstrated in `sample-root-scripts/sample_readfile.C`

For example, for a muon travelling downward from ID to OD, these trajectory points are saved
```
Pos -5.25971 6.10425 -32875.5  KE 1829.99 Time 2.92452 Type 1 // ID-blacksheet boundary
Pos -5.47037 6.29294 -32895.5  KE 1824.9 Time 2.99134 Type 1 // blacksheet-deadspace boundary
Pos -14.6706 11.4114 -33475  KE 1712.68 Time 4.92775 Type 2 // deadspace-inner tyvek boundary
Pos -14.6868 11.4162 -33476  KE 1712.6 Time 4.9311 Type 2 // inner tyvek-OD boundary
Pos -63.8851 34.7864 -35497  KE 1297.24 Time 11.6899 Type 3 // OD-outer tyvek boundary
Pos -63.9199 34.7951 -35498  KE 1297.19 Time 11.6932 Type 3 // outer tyvek-outside world boundary
```