### PR TITLE
Make having an invalid PMT position file fatal.

### DIFF
--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -614,7 +614,7 @@ void WCSimDetectorConstruction::ReadGeometryTableFromFile(){
     G4cerr<<"Number of column = "<<Column<<" which is not equal to 7. "<<G4endl;
     G4cerr<<"Inappropriate input --> Exiting..."<<G4endl;
     readFromTable = false;
-    return;
+    exit(-1);
   }
   Data.seekg(SavePoint);
 

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -611,8 +611,8 @@ void WCSimDetectorConstruction::ReadGeometryTableFromFile(){
 	while (std::getline(stream,tmp,' ')) Column++;
 	if (Column!=7)
   {
-    G4cout<<"Number of column = "<<Column<<" which is not equal to 7. "<<G4endl;
-    G4cout<<"Inappropriate input --> Revert to default positioning"<<G4endl;
+    G4cerr<<"Number of column = "<<Column<<" which is not equal to 7. "<<G4endl;
+    G4cerr<<"Inappropriate input --> Exiting..."<<G4endl;
     readFromTable = false;
     return;
   }


### PR DESCRIPTION
Otherwise, people won't see the error message lost in the `cout` stream, and they'll assume everything is fine

@kmtsui can you please approve, or convince me why this PR a bad idea?