### PR TITLE
Fix bug for photon tracking

### DIFF
--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -91,7 +91,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   G4float photonStartTime;
   G4ThreeVector photonStartPos;
   G4ThreeVector photonStartDir;
-  parentSavedTrackID = aStep->GetTrack()->GetTrackID();
+  parentSavedTrackID = aStep->GetTrack()->GetParentID();
   photonStartTime = aStep->GetTrack()->GetGlobalTime() - aStep->GetTrack()->GetLocalTime(); // current time minus elapsed time of track
   photonStartPos = aStep->GetTrack()->GetVertexPosition();
   photonStartDir = aStep->GetTrack()->GetVertexMomentumDirection();


### PR DESCRIPTION
One-line fix for bug that apparently crept in when renaming the "ParentID" variables to "ParentSavedTrackID" for true cherenkov hits. In the version recenently merged in PR #390 the track ID being saved for a hit was mistakenly changed to the ID of the photon track, but it should be the ID of the parent of the photon track, since that is the track which is actually saved in the output.

I've tested by generating some electron events and checking that now, for all true non-dark-noise hits, the track with the ID given in WCSimRootCherenkovHitTime class's "ParentSavedTrackID" is actually a track that is saved in the output (dark noise has parent -1, as before).