### PR TITLE
Make jobOptions.mac usable for WCSimOpticalPhysics

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -223,7 +223,7 @@
 ##################
 # OPTICAL PHYSICS
 ##################
-## The WCSimOpticalPhysics class uses the same Messenger commands as G4OpticalPhysics
+## The WCSimOpticalPhysics class uses the same Messenger commands as G4OpticalPhysics (need to set macros/jobOptions.mac)
 ## New photocathode models can be used for PMT photon detection. See macros/tuning_parameters.mac
 
 

--- a/include/WCSimPhysicsListFactory.hh
+++ b/include/WCSimPhysicsListFactory.hh
@@ -10,6 +10,7 @@
 
 #include "WCSimPhysicsListFactoryMessenger.hh"
 #include "WCSimRootOptions.hh"
+#include "WCSimOpticalPhysics.hh"
 
 //class WCSimPhysicsList;
 
@@ -40,6 +41,8 @@ class WCSimPhysicsListFactory : public G4VModularPhysicsList
 
     WCSimPhysicsListFactoryMessenger* PhysicsMessenger;
     G4PhysListFactory* factory;
+
+    WCSimOpticalPhysics* fOpticalPhysics;
 
 };
 

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -9,7 +9,6 @@
 #include <G4HadronicInteractionRegistry.hh>
 #include <G4RadioactiveDecayPhysics.hh>
 #include "WCSimPhysicsListFactory.hh"
-#include "WCSimOpticalPhysics.hh"
 
 #include "GdNeutronHPCapture.hh"
 
@@ -20,7 +19,8 @@
 
 
 
-WCSimPhysicsListFactory::WCSimPhysicsListFactory() :  G4VModularPhysicsList()
+WCSimPhysicsListFactory::WCSimPhysicsListFactory() :  G4VModularPhysicsList(),
+  fOpticalPhysics(0)
 {
  defaultCutValue = 1.0*mm;
  SetVerboseLevel(1);
@@ -40,6 +40,8 @@ WCSimPhysicsListFactory::WCSimPhysicsListFactory() :  G4VModularPhysicsList()
  //G4cout << "ValidListsString=" << ValidListsString << G4endl;
 
  PhysicsMessenger = new WCSimPhysicsListFactoryMessenger(this, ValidListsString);
+
+ fOpticalPhysics = new WCSimOpticalPhysics();
 
 }
 
@@ -148,10 +150,8 @@ void WCSimPhysicsListFactory::InitializeList(){
       RegisterPhysics(elem);
     }
     G4cout << "RegisterPhysics: OpticalPhysics" << G4endl;
-    WCSimOpticalPhysics* opticalPhysics = new WCSimOpticalPhysics();
-    RegisterPhysics(opticalPhysics);
-    opticalPhysics->SetWLSTimeProfile("exponential");
-    
+    RegisterPhysics(fOpticalPhysics);
+    fOpticalPhysics->SetWLSTimeProfile("exponential");
     // Add Radioactive Decay:
     G4cout << "RegisterPhysics: RadioactiveDecayPhysics" << G4endl;
     RegisterPhysics( new G4RadioactiveDecayPhysics ); 


### PR DESCRIPTION
Define `WCSimOpticalPhysics` in `WCSimPhysicsListFactory` constructor, then we can use macro commands in `jobOptions.mac` to control `WCSimOpticalPhysics` options