### PR TITLE
Install missing *.hpp files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,10 @@
 # Core library
 
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
-file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh ${PROJECT_SOURCE_DIR}/include/*.h)
+file(GLOB headers 
+        ${PROJECT_SOURCE_DIR}/include/*.hh 
+        ${PROJECT_SOURCE_DIR}/include/*.h
+        ${PROJECT_SOURCE_DIR}/include/*.hpp)
 
 # ###########
 # # Library #


### PR DESCRIPTION
This PR adds the *.hpp files into the install directory.

As today it is relevant for the json.hpp file. 

Since this file was not installed, WCSim dependent code needing needing this file (such as WCSimFQTuner) is using the system's (for Linux installs) json.hpp which may differ.

This fixs allows the WCSimFQTuner to be installed in MacOS systems without extra changes in the CMakeLists.