### PR TITLE
Feature/photon history

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,14 @@ option(WCSim_Geometry_Overlaps_CHECK
 )
 set( WCSIM_CHECK_GEOMETRY_OVERLAPS $<IF:$<BOOL:${WCSim_Geometry_Overlaps_CHECK}>,true,false>)
 
+option(WCSIM_SAVE_PHOTON_HISTORY_FLAG
+  "Toggle WCSim to save photon scattering and reflection history"
+  OFF
+)
+if(WCSIM_SAVE_PHOTON_HISTORY_FLAG STREQUAL ON)
+  add_definitions(-DWCSIM_SAVE_PHOTON_HISTORY)
+endif()
+
 #########
 # copy extra data files
 #########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ set( WCSIM_CHECK_GEOMETRY_OVERLAPS $<IF:$<BOOL:${WCSim_Geometry_Overlaps_CHECK}>
 
 option(WCSIM_SAVE_PHOTON_HISTORY_FLAG
   "Toggle WCSim to save photon scattering and reflection history"
-  ON
+  OFF
 )
 if(WCSIM_SAVE_PHOTON_HISTORY_FLAG STREQUAL ON)
   add_definitions(-DWCSIM_SAVE_PHOTON_HISTORY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ set( WCSIM_CHECK_GEOMETRY_OVERLAPS $<IF:$<BOOL:${WCSim_Geometry_Overlaps_CHECK}>
 
 option(WCSIM_SAVE_PHOTON_HISTORY_FLAG
   "Toggle WCSim to save photon scattering and reflection history"
-  OFF
+  ON
 )
 if(WCSIM_SAVE_PHOTON_HISTORY_FLAG STREQUAL ON)
   add_definitions(-DWCSIM_SAVE_PHOTON_HISTORY)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Useful cmake commands:
 #### WCSim cmake build options
 * `-DWCSim_Geometry_Overlaps_CHECK=<ON|OFF>` If ON, turns on geometry overlap checking (slow, but important when setting new detector geometry options). Default: OFF
 * `-DWCSim_DEBUG_COMPILE_FLAG=<ON|OFF>` If ON, turns on the gcc debug compiler flag `-g`. Default: OFF
+* `-DWCSim_DEBUG_COMPILE_FLAG=<ON|OFF>` If ON, turns on photon scattering/reflection history saving. The data class `WCSimRootCherenkovHitHistory` is used in a similar way as `WCSimRootCherenkovHitTime`. Default: OFF
 
 #### Build with CMake on sukap:
 

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -380,7 +380,6 @@
 #/Tracking/trackProcess Cerenkov
 ## Due to the typically very large number of optical photons, a fraction can be tracked by setting the percentage to randomly draw
 ## Note that the value is a percentage from 0.0 to 100.0, not fraction 0.0 to 1.0
-## This command is ignored when -DWCSIM_SAVE_PHOTON_HISTORY_FLAG=ON is set, and 100% of photons are stored
 /Tracking/fractionOpticalPhotonsToDraw 0.0
 
 

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -380,6 +380,7 @@
 #/Tracking/trackProcess Cerenkov
 ## Due to the typically very large number of optical photons, a fraction can be tracked by setting the percentage to randomly draw
 ## Note that the value is a percentage from 0.0 to 100.0, not fraction 0.0 to 1.0
+## This command is ignored when -DWCSIM_SAVE_PHOTON_HISTORY_FLAG=ON is set, and 100% of photons are stored
 /Tracking/fractionOpticalPhotonsToDraw 0.0
 
 

--- a/include/WCSimEnumerations.hh
+++ b/include/WCSimEnumerations.hh
@@ -38,6 +38,13 @@ typedef enum EBoundaryType {
   kCave
 } BoundaryType_t;
 
+typedef enum EReflectionSurface {
+  kOtherS=0,
+  kBlackSheetS,
+  kReflectorS,
+  kPhotocathodeS
+} ReflectionSurface_t;
+
 class WCSimEnumerations
 {
 public:
@@ -46,6 +53,7 @@ public:
   static std::string EnumAsString(TriggerType_t t);
   static std::string EnumAsString(WCSimRandomGenerator_t r);
   static std::string EnumAsString(BoundaryType_t b);
+  static std::string EnumAsString(ReflectionSurface_t r);
   static TriggerType_t TriggerTypeFromString(std::string s);
 
 };

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -170,17 +170,19 @@ class WCSimRootCherenkovHitHistory : public TObject {
 
 private:
   
-  Int_t   fScat;
-  std::vector<Int_t> fReflec;
+  Int_t   fNRayScat;
+  Int_t   fNMieScat;
+  std::vector<ReflectionSurface_t> fReflec;
 
 public:
   WCSimRootCherenkovHitHistory() {}
-  WCSimRootCherenkovHitHistory(Int_t scat, std::vector<Int_t> refle);
+  WCSimRootCherenkovHitHistory(Int_t nRayScat, Int_t nMieScat, std::vector<ReflectionSurface_t> refle);
   virtual ~WCSimRootCherenkovHitHistory() { }
   bool CompareAllVariables(const WCSimRootCherenkovHitHistory * c) const;
 
-  Int_t     GetScatter() const { return fScat; }
-  std::vector<Int_t> GetReflection() const { return fReflec; }
+  Int_t     GetNRayScatters() const { return fNRayScat; } // Get the number of Rayleigh scattering a photon experienced
+  Int_t     GetNMieScatters() const { return fNMieScat; } // Get the number of Mie scattering a photon experienced
+  std::vector<ReflectionSurface_t> GetReflectionSurfaces() const { return fReflec; } //  Get the vector of reflection surfaces a photon experienced
 
   ClassDef(WCSimRootCherenkovHitHistory,1)
 };
@@ -504,8 +506,9 @@ public:
 					   std::vector<TVector3>  photonEndPos,
 					   std::vector<TVector3>  photonStartDir,
 					   std::vector<TVector3>  photonEndDir);
-  WCSimRootCherenkovHitHistory   *AddCherenkovHitHistory(Int_t scat,
-					   std::vector<Int_t> reflec);
+  WCSimRootCherenkovHitHistory   *AddCherenkovHitHistory(Int_t nRayScat,
+             Int_t nMieScat,
+					   std::vector<ReflectionSurface_t> reflec);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
   TClonesArray        *GetCherenkovHitHistories() const {return fCherenkovHitHistories;}

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -165,6 +165,26 @@ public:
   ClassDef(WCSimRootCherenkovHitTime,2)
 };
 
+// Scattering and reflection history for each Cherenkov hit (photon)
+class WCSimRootCherenkovHitHistory : public TObject {
+
+private:
+  
+  Int_t   fScat;
+  std::vector<Int_t> fReflec;
+
+public:
+  WCSimRootCherenkovHitHistory() {}
+  WCSimRootCherenkovHitHistory(Int_t scat, std::vector<Int_t> refle);
+  virtual ~WCSimRootCherenkovHitHistory() { }
+  bool CompareAllVariables(const WCSimRootCherenkovHitHistory * c) const;
+
+  Int_t     GetScatter() const { return fScat; }
+  std::vector<Int_t> GetReflection() const { return fReflec; }
+
+  ClassDef(WCSimRootCherenkovHitHistory,1)
+};
+
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -362,6 +382,8 @@ private:
   Int_t                fCherenkovHitCounter;
   Int_t                fNcherenkovhittimes;      // Number of hits in the array
   TClonesArray         *fCherenkovHitTimes;      //-> Array of WCSimRootCherenkovHits
+  Int_t                fNcherenkovhithistories;      // Number of hits in the array
+  TClonesArray         *fCherenkovHitHistories;  //-> Array of WCSimRootCherenkovHitHistories
 
   Int_t                fNumDigitizedTubes;  // Number of digitized tubes
   Int_t                fNcherenkovdigihits;  // Number of digihits in the array
@@ -440,6 +462,7 @@ public:
   Int_t               GetNtrack_slots()       const {return fTracks->GetLast() + 1; } //don't use fNtrack_slots directly as it doesn't take into account automatic TClonesArray shortening when tracks at start/end are removed
   Int_t               GetNcherenkovhits()     const {return fNcherenkovhits; }
   Int_t               GetNcherenkovhittimes() const {return fNcherenkovhittimes;}
+  Int_t               GetNcherenkovhithistories() const {return fNcherenkovhithistories;}
   Int_t               GetNcherenkovdigihits() const {return fNcherenkovdigihits;}
   Int_t               GetNcherenkovdigihits_slots() const {return fCherenkovDigiHits->GetLast() + 1; } //don't use fNcherenkovdigihits_slots directly as it doesn't take into account automatic TClonesArray shortening when digits at start/end are removed
   Float_t             GetSumQ()               const { return fSumQ;}
@@ -481,8 +504,11 @@ public:
 					   std::vector<TVector3>  photonEndPos,
 					   std::vector<TVector3>  photonStartDir,
 					   std::vector<TVector3>  photonEndDir);
+  WCSimRootCherenkovHitHistory   *AddCherenkovHitHistory(Int_t scat,
+					   std::vector<Int_t> reflec);
   TClonesArray        *GetCherenkovHits() const {return fCherenkovHits;}
   TClonesArray        *GetCherenkovHitTimes() const {return fCherenkovHitTimes;}
+  TClonesArray        *GetCherenkovHitHistories() const {return fCherenkovHitHistories;}
 
   WCSimRootCherenkovDigiHit   *AddCherenkovDigiHit(Double_t q,
 						   Double_t t,
@@ -497,7 +523,7 @@ public:
 
   TClonesArray	      *GetCaptures() const {return fCaptures;}
 
-  ClassDef(WCSimRootTrigger,5) //WCSimRootEvent structure
+  ClassDef(WCSimRootTrigger,6) //WCSimRootEvent structure
 };
 
 

--- a/include/WCSimRootLinkDef.hh
+++ b/include/WCSimRootLinkDef.hh
@@ -11,6 +11,7 @@
 #pragma link C++ class WCSimRootCherenkovDigiHit+;
 #pragma link C++ class WCSimRootCherenkovHit+;
 #pragma link C++ class WCSimRootCherenkovHitTime+;
+#pragma link C++ class WCSimRootCherenkovHitHistory+;
 #pragma link C++ class WCSimRootTrack+;
 #pragma link C++ class WCSimRootEventHeader+;
 #pragma link C++ class WCSimRootTrigger+;

--- a/include/WCSimTrackingAction.hh
+++ b/include/WCSimTrackingAction.hh
@@ -36,6 +36,8 @@ private:
   // TF: define in macro now
   G4double percentageOfCherenkovPhotonsToDraw;
 
+  bool SAVE_PHOTON_HISTORY;
+
   WCSimTrackingMessenger* messenger;
   
   G4int primaryID;

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -114,10 +114,12 @@ public: // with description
   }
 
 // Functions to set/get photon history
-  inline void AddPhotonScatter(G4int val) { pScatter += val; }
-  inline void AddPhotonReflection(G4int val) { pReflec.push_back(val); }
-  inline G4int GetPhotonScatter() const { return pScatter; }
-  inline std::vector<int> GetPhotonReflection() const { return pReflec; } 
+  inline void AddPhotonRayScatter(G4int val) { pRayScatter += val; }
+  inline void AddPhotonMieScatter(G4int val) { pMieScatter += val; }
+  inline void AddPhotonReflection(ReflectionSurface_t val) { pReflec.push_back(val); }
+  inline G4int GetPhotonRayScatter() const { return pRayScatter; }
+  inline G4int GetPhotonMieScatter() const { return pMieScatter; }
+  inline std::vector<ReflectionSurface_t> GetPhotonReflection() const { return pReflec; } 
 
 // Other member functions
    virtual void ShowTrajectory(std::ostream& os=G4cout) const;
@@ -164,8 +166,9 @@ public: // with description
   std::vector<BoundaryType_t> boundaryTypes; // kBlackSheet=1, kTyvek, kCave
 
   // Photon reflection/scattering history
-  G4int pScatter;
-  std::vector<G4int> pReflec;
+  G4int pRayScatter;
+  G4int pMieScatter;
+  std::vector<ReflectionSurface_t> pReflec;
   WCSimOpBoundaryProcess* fBoundary;
 };
 

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -15,6 +15,7 @@ class WCSimTrajectory;
 #include "G4Step.hh"
 
 #include "WCSimEnumerations.hh"
+#include "WCSimOpBoundaryProcess.hh"
 
 class G4Polyline;                   // Forward declaration.
 
@@ -112,6 +113,12 @@ public: // with description
     return bTypes;
   }
 
+// Functions to set/get photon history
+  inline void AddPhotonScatter(G4int val) { pScatter += val; }
+  inline void AddPhotonReflection(G4int val) { pReflec.push_back(val); }
+  inline G4int GetPhotonScatter() const { return pScatter; }
+  inline std::vector<int> GetPhotonReflection() const { return pReflec; } 
+
 // Other member functions
    virtual void ShowTrajectory(std::ostream& os=G4cout) const;
    virtual void DrawTrajectory(/*G4int i_mode=0*/) const;
@@ -155,6 +162,11 @@ public: // with description
   std::vector<G4float> boundaryKEs;
   std::vector<G4double> boundaryTimes;
   std::vector<BoundaryType_t> boundaryTypes; // kBlackSheet=1, kTyvek, kCave
+
+  // Photon reflection/scattering history
+  G4int pScatter;
+  std::vector<G4int> pReflec;
+  WCSimOpBoundaryProcess* fBoundary;
 };
 
 /***            TEMP  : M FECHNER ***********

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -66,6 +66,8 @@ public: // with description
   inline void SetSaveFlag(G4bool value) { SaveIt = value; }
   inline G4bool GetProducesHit() const { return producesHit; }
   inline void SetProducesHit(G4bool value) { producesHit = value; }
+  inline G4bool GetSavePhotonTrack() const { return savePhotonTrack; }
+  inline void SetSavePhotonTrack(G4bool value) { savePhotonTrack = value; }
 
   inline WCSimTrajectory* GetParentTrajectory() const { return parentTrajectory; }
   inline void SetParentTrajectory(WCSimTrajectory* trajectory) { parentTrajectory = trajectory; }
@@ -156,6 +158,7 @@ public: // with description
   G4bool producesHit;
   G4String creatorProcess;
   G4double                  globalTime;
+  G4bool savePhotonTrack;
 
   WCSimTrajectory* parentTrajectory;
 

--- a/include/WCSimWCDigi.hh
+++ b/include/WCSimWCDigi.hh
@@ -63,13 +63,13 @@ private:
    *  The second digit is made up of photons: 10,11,13,14
    */
   std::map<int, std::vector<int> > fDigiComp;
+  std::map<int, G4int>            trackID; // TrackID of the photon of the Hit (do not use for Digits)
   std::map<int, G4int>    parentSavedTrackID; ///< Primary parent ID of the Hit (do not use for Digits)
   std::map<int, G4float>    photonStartTime; ///< Primary parent ID of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonStartPos; ///< Start point of the photon of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonEndPos; ///< End point of the photon of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonStartDir; ///< Start dir of the photon of the Hit (do not use for Digits)
   std::map<int, G4ThreeVector>    photonEndDir; ///< End dir of the photon of the Hit (do not use for Digits)
-  
 
   //integrated hit/digit parameters
   G4int                 totalPe;
@@ -78,7 +78,6 @@ private:
   G4int                 totalPeInGate;
   G4double         edep;
   static G4int     maxPe;
-  G4int            trackID;
 
 public:
   void RemoveDigitizedGate(G4int gate);
@@ -90,6 +89,7 @@ public:
   inline void SetPe(G4int gate,  G4double Q)      {pe[gate]     = Q;};
   inline void SetTime(G4int gate, G4double T)    {time[gate]   = T;};
   inline void SetPreSmearTime(G4int gate, G4double T)    {time_presmear[gate]   = T;};
+  inline void SetTrackID(G4int gate, G4int track) { trackID[gate] = track; };
   inline void SetParentID(G4int gate, G4int parent) { parentSavedTrackID[gate] = parent; };
   inline void SetPhotonStartTime(G4int gate, G4float starttime) { photonStartTime[gate] = starttime; };
   inline void SetPhotonStartPos(G4int gate, const G4ThreeVector &position) { photonStartPos[gate] = position; };
@@ -108,13 +108,13 @@ public:
     digi_comp.clear();
   }
 
+  inline G4int          GetTrackID(int gate)    { return trackID[gate];};
   inline G4int          GetParentID(int gate)    { return parentSavedTrackID[gate];};
   inline G4float        GetPhotonStartTime(int gate)    { return photonStartTime[gate];};
   inline G4ThreeVector  GetPhotonStartPos(int gate)    { return photonStartPos[gate];};
   inline G4ThreeVector  GetPhotonEndPos(int gate)    { return photonEndPos[gate];};
   inline G4ThreeVector  GetPhotonStartDir(int gate)    { return photonStartDir[gate];};
   inline G4ThreeVector  GetPhotonEndDir(int gate)    { return photonEndDir[gate];};
-  inline G4int          GetTrackID()    { return trackID;};
   inline G4double GetGateTime(int gate) { return TriggerTimes[gate];}
   inline G4int   GetTubeID() {return tubeID;};
   inline G4String   GetTubeType() {return tubeType;};
@@ -159,7 +159,6 @@ public:
   void SetPos          (G4ThreeVector xyz)          { pos = xyz; };
   void SetOrientation  (G4ThreeVector xyz)          { orient = xyz; };
   void SetLogicalVolume(G4LogicalVolume* logV)      { pLogV = logV;}
-  void SetTrackID      (G4int track)                { trackID = track; };
   void SetRot          (G4RotationMatrix rotMatrix) { rot = rotMatrix; };
   G4int         GetTotalPe()    { return totalPe;};
   
@@ -180,6 +179,7 @@ public:
     int i, j;
 
     double index_time,index_timepresmear,index_pe;
+    int index_trackID;
     int index_parentSavedTrackID;
     std::vector<int> index_digicomp;
     float index_photonstarttime;
@@ -199,6 +199,7 @@ public:
         index_timepresmear  = time_presmear.at(i);
         index_pe = pe.at(i);
         if(sort_digi_compositions) index_digicomp = fDigiComp.at(i);
+        index_trackID = trackID.at(i);
         index_parentSavedTrackID = parentSavedTrackID.at(i);
 	index_photonstarttime = photonStartTime[i];
 	index_photonstartpos = photonStartPos[i];
@@ -210,6 +211,7 @@ public:
           time_presmear.at(j) = time_presmear.at(j-1);
           pe.at(j) = pe.at(j-1);
           if(sort_digi_compositions) fDigiComp.at(j) = fDigiComp.at(j-1);
+          trackID.at(j) = trackID.at(j-1);
           parentSavedTrackID.at(j) = parentSavedTrackID.at(j-1);
 	  photonStartTime.at(j) = photonStartTime.at(j-1);
 	  photonStartPos.at(j) = photonStartPos.at(j-1);
@@ -222,6 +224,7 @@ public:
         time_presmear.at(j) = index_timepresmear;
         pe.at(j) = index_pe;
         if(sort_digi_compositions) fDigiComp.at(j) = index_digicomp;
+        trackID.at(j) = index_trackID;
         parentSavedTrackID.at(j) = index_parentSavedTrackID;
 	photonStartTime.at(j) = index_photonstarttime;
 	photonStartPos.at(j) = index_photonstartpos;

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -31,7 +31,7 @@ class WCSimWCHit : public G4VHit
  public:
   
   void SetTubeID       (G4int tube)                 { tubeID = tube; };
-  void SetTrackID      (G4int track)                { trackID = track; };
+  void SetTrackID      (G4int track)                { trackID.push_back(track); };
   void SetEdep         (G4double de)                { edep = de; };
   void SetPos          (G4ThreeVector xyz)          { pos = xyz; };
   void SetOrientation  (G4ThreeVector xyz)          { orient = xyz; };
@@ -61,7 +61,7 @@ class WCSimWCHit : public G4VHit
   }
  
   G4int         GetTubeID()     { return tubeID; };
-  G4int         GetTrackID()    { return trackID; };
+  G4int         GetTrackID(int i)    { return trackID[i]; };
   G4ThreeVector GetPos()        { return pos; };
   G4ThreeVector GetOrientation()        { return orient; };
   G4int         GetTotalPe()    { return totalPe;};
@@ -136,7 +136,6 @@ class WCSimWCHit : public G4VHit
   void HSVtoRGB(double& fR, double& fG, double& fB, double& fH, double& fS, double& fV);
 
   G4int            tubeID;
-  G4int            trackID;
   G4double         edep;
   G4ThreeVector    pos;
   G4ThreeVector    orient;
@@ -151,6 +150,7 @@ class WCSimWCHit : public G4VHit
 
   G4int                 totalPe;
   std::vector<G4double> time;
+  std::vector<G4int>    trackID;
   std::vector<G4int>    parentSavedTrackID;
   std::vector<G4float>  photonStartTime;
   std::vector<G4ThreeVector> photonStartPos;

--- a/include/WCSimWCHit.hh
+++ b/include/WCSimWCHit.hh
@@ -31,12 +31,12 @@ class WCSimWCHit : public G4VHit
  public:
   
   void SetTubeID       (G4int tube)                 { tubeID = tube; };
-  void SetTrackID      (G4int track)                { trackID.push_back(track); };
   void SetEdep         (G4double de)                { edep = de; };
   void SetPos          (G4ThreeVector xyz)          { pos = xyz; };
   void SetOrientation  (G4ThreeVector xyz)          { orient = xyz; };
   void SetRot          (G4RotationMatrix rotMatrix) { rot = rotMatrix; };
   void SetLogicalVolume(G4LogicalVolume* logV)      { pLogV = logV;}
+  void AddTrackID      (G4int track)                { trackID.push_back(track); };
   void AddParentID     (G4int myParentSavedTrackID) { parentSavedTrackID.push_back(myParentSavedTrackID); }
   void AddPhotonStartTime (G4float photStartTime) { photonStartTime.push_back(photStartTime); }
   void AddPhotonStartPos  (const G4ThreeVector &photStartPos) { photonStartPos.push_back(photStartPos); }

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -265,8 +265,8 @@ int sample_readfile(const char *filename="../wcsim.root", bool verbose=false)
 	      if(thehithistoryobject)
         {
           // Number of scattering, and types of reflection surface (WCSimEnumerations)
-          cout<<" Scattering: "<<thehithistoryobject->GetScatter()<<", Reflection: ";
-          for (auto r: thehithistoryobject->GetReflection()) cout<<r<<" ";
+          cout<<" Rayleigh Scattering: "<<thehithistoryobject->GetNRayScatters()<<", Mie Scattering: "<<thehithistoryobject->GetNMieScatters()<<", Reflection: ";
+          for (auto r: thehithistoryobject->GetReflectionSurfaces()) cout<<WCSimEnumerations::EnumAsString(r)<<" ";
           cout<<";";
 	      }
 #endif

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -14,6 +14,9 @@
 #include "WCSimRootGeom.hh"
 #include "WCSimRootEvent.hh"
 
+// Only access the photon history class when -DWCSim_DEBUG_COMPILE_FLAG=ON is defined in compilation
+//#define WCSIM_SAVE_PHOTON_HISTORY
+
 // Simple example of reading a generated Root file
 int sample_readfile(const char *filename="../wcsim.root", bool verbose=false)
 {
@@ -180,7 +183,10 @@ int sample_readfile(const char *filename="../wcsim.root", bool verbose=false)
 
     // Grab the big arrays of times and parent IDs
     TClonesArray *timeArray = wcsimrootevent->GetCherenkovHitTimes();
-    
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
+    TClonesArray *historyArray = wcsimrootevent->GetCherenkovHitHistories(); // scattering and reflection history
+#endif
+
     int totalPe = 0;
     // Loop through elements in the TClonesArray of WCSimRootCherenkovHits
     for (int itruepmt=0; itruepmt < ncherenkovhits; itruepmt++)
@@ -253,6 +259,17 @@ int sample_readfile(const char *filename="../wcsim.root", bool verbose=false)
 		cout<<" HitTime index "<<thephotonsid<<", pre-smear time "<<thehittimeobject->GetTruetime()
 		    <<", parent TrackID: "<<thehittimeobject->GetParentID()<<";";
 	      }
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
+        // use the same index as WCSimRootCherenkovHitTime
+        WCSimRootCherenkovHitHistory *thehithistoryobject =  dynamic_cast<WCSimRootCherenkovHitHistory*>(historyArray->At(thephotonsid));
+	      if(thehithistoryobject)
+        {
+          // Number of scattering, and types of reflection surface (WCSimEnumerations)
+          cout<<" Scattering: "<<thehithistoryobject->GetScatter()<<", Reflection: ";
+          for (auto r: thehithistoryobject->GetReflection()) cout<<r<<" ";
+          cout<<";";
+	      }
+#endif
 	      cout<<endl;
 	      photonid++;
 	    } // end loop over photons in digit

--- a/src/WCSimEnumerations.cc
+++ b/src/WCSimEnumerations.cc
@@ -79,6 +79,28 @@ std::string WCSimEnumerations::EnumAsString(BoundaryType_t b)
   return "";
 }
 
+std::string WCSimEnumerations::EnumAsString(ReflectionSurface_t r)
+{
+  switch(r) {
+  case (kOtherS) :
+    return "Others";
+    break;
+  case (kBlackSheetS) :
+    return "Blacksheet";
+    break;
+  case (kReflectorS) :
+    return "Reflector";
+    break;
+  case (kPhotocathodeS) :
+    return "Photocathode";
+    break;
+  default:
+    return "";
+    break;
+  }
+  return "";
+}
+
 TriggerType_t WCSimEnumerations::TriggerTypeFromString(std::string s)
 {
   for(int i = int(kTriggerUndefined)+1; i <= kTriggerFailure; i++) {

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -366,7 +366,6 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 
       const G4ThreeVector &pos = detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getTranslation();
       (*WCHC)[hitIndex]->SetTubeID((*pmtIt)->Get_tubeid());
-      (*WCHC)[hitIndex]->SetTrackID(0);
       (*WCHC)[hitIndex]->SetEdep(0.);
       (*WCHC)[hitIndex]->SetPos(pos);
       (*WCHC)[hitIndex]->SetRot(detectorConstructor->GetTubeTransform((*pmtIt)->Get_tubeid()).getRotation());
@@ -376,6 +375,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 	G4float time = G4RandGauss::shoot(0.0,10.);
 	G4ThreeVector dir(0, 0, 0);
 	(*WCHC)[hitIndex]->AddPe(time);
+  (*WCHC)[hitIndex]->AddTrackID(0);
 	(*WCHC)[hitIndex]->AddParentID(0); // Make parent a geantino (whatever that is)
 	(*WCHC)[hitIndex]->AddPhotonStartPos(pos);
 	(*WCHC)[hitIndex]->AddPhotonEndPos(pos);

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1452,15 +1452,17 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
 #ifdef WCSIM_SAVE_PHOTON_HISTORY
         int trackID = (*WCDC_hits)[idigi]->GetTrackID(id);
-        int hit_photon_scatter = 0;
-        std::vector<int> hit_photon_reflection = std::vector<int>();
+        int hit_photon_RayScatter = 0;
+        int hit_photon_MieScatter = 0;
+        std::vector<ReflectionSurface_t> hit_photon_reflection = std::vector<ReflectionSurface_t>();
         if (trackID>0) // skip noise hit
         {
           WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
-          hit_photon_scatter = trj->GetPhotonScatter();
+          hit_photon_RayScatter = trj->GetPhotonRayScatter();
+          hit_photon_MieScatter = trj->GetPhotonMieScatter();
           hit_photon_reflection = trj->GetPhotonReflection();
         }
-        wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
+        wcsimrootevent->AddCherenkovHitHistory(hit_photon_RayScatter,hit_photon_MieScatter,hit_photon_reflection);
 #endif
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
@@ -1998,15 +2000,17 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
 #ifdef WCSIM_SAVE_PHOTON_HISTORY
         int trackID = (*WCDC_hits)[idigi]->GetTrackID(id);
-        int hit_photon_scatter = 0;
-        std::vector<int> hit_photon_reflection = std::vector<int>();
+        int hit_photon_RayScatter = 0;
+        int hit_photon_MieScatter = 0;
+        std::vector<ReflectionSurface_t> hit_photon_reflection = std::vector<ReflectionSurface_t>();
         if (trackID>0) // skip noise hit
         {
           WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
-          hit_photon_scatter = trj->GetPhotonScatter();
+          hit_photon_RayScatter = trj->GetPhotonRayScatter();
+          hit_photon_MieScatter = trj->GetPhotonMieScatter();
           hit_photon_reflection = trj->GetPhotonReflection();
         }
-        wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
+        wcsimrootevent->AddCherenkovHitHistory(hit_photon_RayScatter,hit_photon_MieScatter,hit_photon_reflection);
 #endif
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -106,6 +106,12 @@ WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
   WCSimWCAddDarkNoise* WCDNM_OD;
   WCDNM_OD = new WCSimWCAddDarkNoise("WCDarkNoise_OD", detectorConstructor, "OD");
   DMman->AddNewModule(WCDNM_OD);
+
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
+  G4cout<<"Save photon hisotry in ROOT file"<<G4endl;
+#else
+  G4cout<<"DO NOT Save photon hisotry in ROOT file"<<G4endl;
+#endif
 }
 
 WCSimEventAction::~WCSimEventAction()
@@ -1443,17 +1449,16 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     TVector3 hit_photon_endpos;
     TVector3 hit_photon_startdir;
     TVector3 hit_photon_enddir;
-    int hit_photon_scatter;
-    std::vector<int> hit_photon_reflection;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
       WCSimPmtInfo *pmt = ((WCSimPmtInfo*)fpmts->at(digi_tubeid -1));
 
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
         int trackID = (*WCDC_hits)[idigi]->GetTrackID(id);
-        hit_photon_scatter = 0;
-        hit_photon_reflection = std::vector<int>();
+        int hit_photon_scatter = 0;
+        std::vector<int> hit_photon_reflection = std::vector<int>();
         if (trackID>0) // skip noise hit
         {
           WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
@@ -1462,6 +1467,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
           //G4cout<<"Digi trackID = "<<trackID<<" "<<trajMap[trackID]<<" "<<trj->GetPhotonScatter()<<" "<<trj->GetPhotonReflection().size()<<G4endl;
         }
         wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
+#endif
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
 	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);
@@ -1990,17 +1996,16 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
     TVector3 hit_photon_endpos;
     TVector3 hit_photon_startdir;
     TVector3 hit_photon_enddir;
-    int hit_photon_scatter;
-    std::vector<int> hit_photon_reflection;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
       WCSimPmtInfo *pmt = ((WCSimPmtInfo*)fpmts->at(digi_tubeid -1));
 
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
         int trackID = (*WCDC_hits)[idigi]->GetTrackID(id);
-        hit_photon_scatter = 0;
-        hit_photon_reflection = std::vector<int>();
+        int hit_photon_scatter = 0;
+        std::vector<int> hit_photon_reflection = std::vector<int>();
         if (trackID>0) // skip noise hit
         {
           WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
@@ -2009,6 +2014,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
           //G4cout<<"Digi trackID = "<<trackID<<" "<<trajMap[trackID]<<" "<<trj->GetPhotonScatter()<<" "<<trj->GetPhotonReflection().size()<<G4endl;
         }
         wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
+#endif
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
 	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1248,6 +1248,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   //n_trajectories=50;    // existed in previous versions of the code.  It also
                           // makes the ROOT file smaller.
 
+  std::map<int,int> trajMap; // mapping of trackID and index
   for (int i=0; i <n_trajectories; i++)
   {
     WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[i];
@@ -1262,6 +1263,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     if ( trj->GetPDGEncoding() == -211 ) antipionList.insert(trj->GetTrackID());
     if ( trj->GetParentID() == 0 ) primaryList.insert(trj->GetTrackID());
 
+    trajMap[trj->GetTrackID()] = i;
 
     // Process primary tracks or the secondaries from pizero or muons...
 
@@ -1441,12 +1443,25 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
     TVector3 hit_photon_endpos;
     TVector3 hit_photon_startdir;
     TVector3 hit_photon_enddir;
+    int hit_photon_scatter;
+    std::vector<int> hit_photon_reflection;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
       WCSimPmtInfo *pmt = ((WCSimPmtInfo*)fpmts->at(digi_tubeid -1));
 
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
+        int trackID = (*WCDC_hits)[idigi]->GetTrackID(id);
+        hit_photon_scatter = 0;
+        hit_photon_reflection = std::vector<int>();
+        if (trackID>0) // skip noise hit
+        {
+          WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
+          hit_photon_scatter = trj->GetPhotonScatter();
+          hit_photon_reflection = trj->GetPhotonReflection();
+          //G4cout<<"Digi trackID = "<<trackID<<" "<<trajMap[trackID]<<" "<<trj->GetPhotonScatter()<<" "<<trj->GetPhotonReflection().size()<<G4endl;
+        }
+        wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
 	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);
@@ -1783,6 +1798,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
   //n_trajectories=50;    // existed in previous versions of the code.  It also
                           // makes the ROOT file smaller.
 
+  std::map<int,int> trajMap; // mapping of trackID and index
   for (int i=0; i <n_trajectories; i++)
   {
     WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[i];
@@ -1796,6 +1812,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
     if ( trj->GetPDGEncoding() == 211 ) pionList.insert(trj->GetTrackID());
     if ( trj->GetPDGEncoding() == -211 ) antipionList.insert(trj->GetTrackID());
 
+    trajMap[trj->GetTrackID()] = i;
 
     // Process primary tracks or the secondaries from pizero or muons...
 
@@ -1973,12 +1990,25 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
     TVector3 hit_photon_endpos;
     TVector3 hit_photon_startdir;
     TVector3 hit_photon_enddir;
+    int hit_photon_scatter;
+    std::vector<int> hit_photon_reflection;
     //loop over the DigitsCollection
     for(int idigi = 0; idigi < WCDC_hits->entries(); idigi++) {
       int digi_tubeid = (*WCDC_hits)[idigi]->GetTubeID();
       WCSimPmtInfo *pmt = ((WCSimPmtInfo*)fpmts->at(digi_tubeid -1));
 
       for(G4int id = 0; id < (*WCDC_hits)[idigi]->GetTotalPe(); id++){
+        int trackID = (*WCDC_hits)[idigi]->GetTrackID(id);
+        hit_photon_scatter = 0;
+        hit_photon_reflection = std::vector<int>();
+        if (trackID>0) // skip noise hit
+        {
+          WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
+          hit_photon_scatter = trj->GetPhotonScatter();
+          hit_photon_reflection = trj->GetPhotonReflection();
+          //G4cout<<"Digi trackID = "<<trackID<<" "<<trajMap[trackID]<<" "<<trj->GetPhotonScatter()<<" "<<trj->GetPhotonReflection().size()<<G4endl;
+        }
+        wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
 	hit_time_true  = (*WCDC_hits)[idigi]->GetPreSmearTime(id);
 	hit_parentid = (*WCDC_hits)[idigi]->GetParentID(id);
 	hit_photon_starttime = (*WCDC_hits)[idigi]->GetPhotonStartTime(id);
@@ -2331,7 +2361,7 @@ void WCSimEventAction::FillFlatTree(G4int event_id,
 	thisNtuple->mPMTid[totNumHits] = digi_tubeid/nMpmtID_pmts;
  	thisNtuple->mPMT_pmtid[totNumHits] = (digi_tubeid%nMpmtID_pmts == 0 ? nMpmtID_pmts : digi_tubeid%nMpmtID_pmts ); // No. 1 to nID
 
-	thisNtuple->trackid[totNumHits] = (*WCDC_hits)[idigi]->GetTrackID();
+	thisNtuple->trackid[totNumHits] = (*WCDC_hits)[idigi]->GetTrackID(id);
 	G4ThreeVector pos = (*WCDC_hits)[idigi]->GetPos();       // Can also grab it from theDetector also.
 	thisNtuple->tube_x[totNumHits] = pos[0];                 //already in CLHEP::cm
 	thisNtuple->tube_y[totNumHits] = pos[1];

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -106,7 +106,6 @@ WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
   WCSimWCAddDarkNoise* WCDNM_OD;
   WCDNM_OD = new WCSimWCAddDarkNoise("WCDarkNoise_OD", detectorConstructor, "OD");
   DMman->AddNewModule(WCDNM_OD);
-
 }
 
 WCSimEventAction::~WCSimEventAction()

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -107,11 +107,6 @@ WCSimEventAction::WCSimEventAction(WCSimRunAction* myRun,
   WCDNM_OD = new WCSimWCAddDarkNoise("WCDarkNoise_OD", detectorConstructor, "OD");
   DMman->AddNewModule(WCDNM_OD);
 
-#ifdef WCSIM_SAVE_PHOTON_HISTORY
-  G4cout<<"Save photon hisotry in ROOT file"<<G4endl;
-#else
-  G4cout<<"DO NOT Save photon hisotry in ROOT file"<<G4endl;
-#endif
 }
 
 WCSimEventAction::~WCSimEventAction()
@@ -1464,7 +1459,6 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
           WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
           hit_photon_scatter = trj->GetPhotonScatter();
           hit_photon_reflection = trj->GetPhotonReflection();
-          //G4cout<<"Digi trackID = "<<trackID<<" "<<trajMap[trackID]<<" "<<trj->GetPhotonScatter()<<" "<<trj->GetPhotonReflection().size()<<G4endl;
         }
         wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
 #endif
@@ -2011,7 +2005,6 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
           WCSimTrajectory* trj = (WCSimTrajectory*)(*TC)[trajMap[trackID]];
           hit_photon_scatter = trj->GetPhotonScatter();
           hit_photon_reflection = trj->GetPhotonReflection();
-          //G4cout<<"Digi trackID = "<<trackID<<" "<<trajMap[trackID]<<" "<<trj->GetPhotonScatter()<<" "<<trj->GetPhotonReflection().size()<<G4endl;
         }
         wcsimrootevent->AddCherenkovHitHistory(hit_photon_scatter,hit_photon_reflection);
 #endif

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -612,12 +612,13 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
 
 //_____________________________________________________________________________
 
-WCSimRootCherenkovHitHistory *WCSimRootTrigger::AddCherenkovHitHistory(Int_t scat,
-					   std::vector<Int_t> reflec)
+WCSimRootCherenkovHitHistory *WCSimRootTrigger::AddCherenkovHitHistory(Int_t nRayScat,
+             Int_t nMieScat,
+					   std::vector<ReflectionSurface_t> reflec)
 {
   // Add a new Cherenkov hit history to the list of Cherenkov hit histories
   TClonesArray &cherenkovhithistories = *fCherenkovHitHistories;
-  WCSimRootCherenkovHitHistory* cherenkovhithistory = new(cherenkovhithistories[fNcherenkovhithistories++]) WCSimRootCherenkovHitHistory(scat,reflec);
+  WCSimRootCherenkovHitHistory* cherenkovhithistory = new(cherenkovhithistories[fNcherenkovhithistories++]) WCSimRootCherenkovHitHistory(nRayScat,nMieScat,reflec);
   return cherenkovhithistory;
 }
 
@@ -669,10 +670,11 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
   }
 }
 
-WCSimRootCherenkovHitHistory::WCSimRootCherenkovHitHistory(Int_t scat, std::vector<Int_t> refle)
+WCSimRootCherenkovHitHistory::WCSimRootCherenkovHitHistory(Int_t nRayScat, Int_t nMieScat, std::vector<ReflectionSurface_t> refle)
 {
   // Create a WCSimRootCherenkovHitHistory object and fill it with stuff
-  fScat = scat;
+  fNRayScat = nRayScat;
+  fNMieScat = nMieScat;
   fReflec = refle;
 }
 
@@ -898,8 +900,9 @@ bool WCSimRootCherenkovHitHistory::CompareAllVariables(const WCSimRootCherenkovH
 {
   bool failed = false;
 
-  failed = (!ComparisonPassed(fScat, c->GetScatter(), typeid(*this).name(), __func__, "Scattering")) || failed;
-  failed = (!ComparisonPassedVec(fReflec, c->GetReflection(), typeid(*this).name(), __func__, "Reflection")) || failed;
+  failed = (!ComparisonPassed(fNRayScat, c->GetNRayScatters(), typeid(*this).name(), __func__, "RayleighScattering")) || failed;
+  failed = (!ComparisonPassed(fNMieScat, c->GetNMieScatters(), typeid(*this).name(), __func__, "MieScattering")) || failed;
+  failed = (!ComparisonPassedVec(std::vector<int>(fReflec.begin(),fReflec.end()), std::vector<int>(c->GetReflectionSurfaces().begin(),c->GetReflectionSurfaces().end()), typeid(*this).name(), __func__, "Reflection")) || failed;
 
   return !failed;
 }

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -23,6 +23,7 @@ using std::vector;
 ClassImp(WCSimRootCherenkovDigiHit)
 ClassImp(WCSimRootCherenkovHit)
 ClassImp(WCSimRootCherenkovHitTime)
+ClassImp(WCSimRootCherenkovHitHistory)
 ClassImp(WCSimRootTrack)
 ClassImp(WCSimRootPi0)
 ClassImp(WCSimRootEventHeader)
@@ -60,8 +61,10 @@ WCSimRootTrigger::WCSimRootTrigger()
   // TClonesArray of WCSimRootCherenkovHits
   fCherenkovHits = 0;
   fCherenkovHitTimes = 0;
+  fCherenkovHitHistories = 0;
   fNcherenkovhits = 0;
   fNcherenkovhittimes = 0;
+  fNcherenkovhithistories = 0;
 
   // TClonesArray of WCSimRootCherenkovDigiHits
   fCherenkovDigiHits = 0;
@@ -106,10 +109,14 @@ void WCSimRootTrigger::Initialize() //actually allocate memory for things in her
 				    10000);
   fCherenkovHitTimes = new TClonesArray("WCSimRootCherenkovHitTime", 
 					10000);
+  fCherenkovHitHistories = new TClonesArray("WCSimRootCherenkovHitHistory", 
+					10000);
   fCherenkovHits->BypassStreamer(kFALSE); // use the member Streamer
   fCherenkovHitTimes->BypassStreamer(kFALSE); // use the member Streamer
+  fCherenkovHitHistories->BypassStreamer(kFALSE); // use the member Streamer
   fNcherenkovhits = 0;
   fNcherenkovhittimes = 0;
+  fNcherenkovhithistories = 0;
 
   // TClonesArray of WCSimRootCherenkovDigiHits
   fCherenkovDigiHits = new TClonesArray("WCSimRootCherenkovDigiHit", 
@@ -150,12 +157,14 @@ WCSimRootTrigger::~WCSimRootTrigger()
     fTracks->Delete();            
     fCherenkovHits->Delete();      
     fCherenkovHitTimes->Delete();   
+    fCherenkovHitHistories->Delete();   
     fCherenkovDigiHits->Delete();
     fCaptures->Delete();
     
     delete   fTracks;            
     delete   fCherenkovHits;      
     delete   fCherenkovHitTimes;   
+    delete   fCherenkovHitHistories;   
     delete   fCherenkovDigiHits;
     delete   fCaptures;
   }
@@ -200,6 +209,8 @@ WCSimRootTrigger & WCSimRootTrigger::operator=(const WCSimRootTrigger & in)
   fCherenkovHitCounter = in.fCherenkovHitCounter;
   fNcherenkovhittimes = in.fNcherenkovhittimes;
   fCherenkovHitTimes = (TClonesArray*)in.fCherenkovHitTimes->Clone();
+  fNcherenkovhithistories = in.fNcherenkovhithistories;
+  fCherenkovHitHistories = (TClonesArray*)in.fCherenkovHitHistories->Clone();
   fNumDigitizedTubes = in.fNumDigitizedTubes;
   fNcherenkovdigihits = in.fNcherenkovdigihits;
   fSumQ = in.fSumQ;
@@ -223,6 +234,7 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   // TClonesArray of WCSimRootCherenkovHits
   fNcherenkovhits = 0;
   fNcherenkovhittimes = 0;
+  fNcherenkovhithistories = 0;
 
   // TClonesArray of WCSimRootCherenkovDigiHits
   fNcherenkovdigihits = 0;
@@ -238,6 +250,7 @@ void WCSimRootTrigger::Clear(Option_t */*option*/)
   fTracks->Delete();
   fCherenkovHits->Delete();
   fCherenkovHitTimes->Delete();
+  fCherenkovHitHistories->Delete();
   fCherenkovDigiHits->Delete();
   fCaptures->Delete();
 
@@ -596,6 +609,18 @@ WCSimRootCherenkovHit *WCSimRootTrigger::AddCherenkovHit(Int_t tubeID,
 
   return cherenkovhit;
 }
+
+//_____________________________________________________________________________
+
+WCSimRootCherenkovHitHistory *WCSimRootTrigger::AddCherenkovHitHistory(Int_t scat,
+					   std::vector<Int_t> reflec)
+{
+  // Add a new Cherenkov hit history to the list of Cherenkov hit histories
+  TClonesArray &cherenkovhithistories = *fCherenkovHitHistories;
+  WCSimRootCherenkovHitHistory* cherenkovhithistory = new(cherenkovhithistories[fNcherenkovhithistories++]) WCSimRootCherenkovHitHistory(scat,reflec);
+  return cherenkovhithistory;
+}
+
 //_____________________________________________________________________________
 
 WCSimRootCherenkovHit::WCSimRootCherenkovHit(Int_t tubeID,
@@ -642,6 +667,13 @@ WCSimRootCherenkovHitTime::WCSimRootCherenkovHitTime(Double_t truetime,
     fPhotonStartDir[i] = photonStartDir[i];
     fPhotonEndDir[i] = photonEndDir[i];
   }
+}
+
+WCSimRootCherenkovHitHistory::WCSimRootCherenkovHitHistory(Int_t scat, std::vector<Int_t> refle)
+{
+  // Create a WCSimRootCherenkovHitHistory object and fill it with stuff
+  fScat = scat;
+  fReflec = refle;
 }
 
 //_____________________________________________________________________________
@@ -862,6 +894,17 @@ bool WCSimRootCherenkovHitTime::CompareAllVariables(const WCSimRootCherenkovHitT
 }
 
 //_____________________________________________________________________________
+bool WCSimRootCherenkovHitHistory::CompareAllVariables(const WCSimRootCherenkovHitHistory * c) const
+{
+  bool failed = false;
+
+  failed = (!ComparisonPassed(fScat, c->GetScatter(), typeid(*this).name(), __func__, "Scattering")) || failed;
+  failed = (!ComparisonPassedVec(fReflec, c->GetReflection(), typeid(*this).name(), __func__, "Reflection")) || failed;
+
+  return !failed;
+}
+
+//_____________________________________________________________________________
 bool WCSimRootCherenkovDigiHit::CompareAllVariables(const WCSimRootCherenkovDigiHit * c) const
 {
   bool failed = false;
@@ -1033,6 +1076,7 @@ bool WCSimRootTrigger::CompareAllVariables(const WCSimRootTrigger * c, bool deep
 	cout << "Hit Time " << j << endl;
 #endif
 	failed = !((WCSimRootCherenkovHitTime *)this->GetCherenkovHitTimes()->At(i))->CompareAllVariables((WCSimRootCherenkovHitTime *)c->GetCherenkovHitTimes()->At(i)) || failed;
+  failed = !((WCSimRootCherenkovHitHistory *)this->GetCherenkovHitHistories()->At(i))->CompareAllVariables((WCSimRootCherenkovHitHistory *)c->GetCherenkovHitHistories()->At(i)) || failed;
       }//j (WCSimRootCherenkovHitTime)
     }
   }//i (WCSimRootCherenkovHit)
@@ -1133,6 +1177,7 @@ bool WCSimRootTrigger::CompareAllVariables(const WCSimRootTrigger * c, bool deep
   ComparisonPassed(fNtrack_slots, c->GetNtrack_slots(), typeid(*this).name(), __func__, "Ntrack_slots (shouldn't necessarily be equal)");
   failed = (!ComparisonPassed(fNcherenkovhits, c->GetNcherenkovhits(), typeid(*this).name(), __func__, "Ncherenkovhits")) || failed;
   failed = (!ComparisonPassed(fNcherenkovhittimes, c->GetNcherenkovhittimes(), typeid(*this).name(), __func__, "Ncherenkovhittimes")) || failed;
+  failed = (!ComparisonPassed(fNcherenkovhithistories, c->GetNcherenkovhittimes(), typeid(*this).name(), __func__, "Ncherenkovhithistories")) || failed;
   failed = (!ComparisonPassed(fNcherenkovdigihits, c->GetNcherenkovdigihits(), typeid(*this).name(), __func__, "Ncherenkovdigihits")) || failed;
   //don't expect this to pass in general, so don't affect failed
   ComparisonPassed(fNcherenkovdigihits_slots, c->GetNcherenkovdigihits_slots(), typeid(*this).name(), __func__, "Ncherenkovdigihits_slots (shouldn't necessarily be equal)");

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -137,7 +137,9 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
       )
     {
       // if so the track is worth saving
-      anInfo->WillBeSaved(true);
+      if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
+        anInfo->WillBeSaved(true);
+      else anInfo->WillBeSaved(false);
     }
   else {
     anInfo->WillBeSaved(false);
@@ -149,11 +151,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
 
   // pass parent trajectory to children
   G4TrackVector* secondaries = fpTrackingManager->GimmeSecondaries();
-  WCSimTrajectory *currentTrajectory = 0;
-  // Do not pass photon trajectory to children at all when SAVE_PHOTON_HISTORY is on
-  // Otherwise photon tracks with e.g. WLS in OD PMT will be saved in root output
-  if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
-    currentTrajectory = (WCSimTrajectory*)fpTrackingManager->GimmeTrajectory();
+  WCSimTrajectory *currentTrajectory = (WCSimTrajectory*)fpTrackin0gManager->GimmeTrajectory();
   if(currentTrajectory && !anInfo->GetMyTrajectory())
     anInfo->SetMyTrajectory(currentTrajectory);
   if(secondaries)
@@ -174,7 +172,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
   if (anInfo->GetProducesHit() && saveHitProducingTracks){
       WCSimTrajectory* parentTrajectory = anInfo->GetParentTrajectory();
       while(parentTrajectory != 0 && !parentTrajectory->GetProducesHit()){
-          parentTrajectory->SetProducesHit(true);
+          if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())  parentTrajectory->SetProducesHit(true);
           parentTrajectory = parentTrajectory->GetParentTrajectory();
       }
   }

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -149,7 +149,11 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
 
   // pass parent trajectory to children
   G4TrackVector* secondaries = fpTrackingManager->GimmeSecondaries();
-  WCSimTrajectory *currentTrajectory = (WCSimTrajectory*)fpTrackingManager->GimmeTrajectory();
+  WCSimTrajectory *currentTrajectory = NULL;
+  // Do not pass photon trajectory to children at all when SAVE_PHOTON_HISTORY is on
+  // Otherwise photon tracks with e.g. WLS in OD PMT will be saved in root output
+  if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
+    currentTrajectory = (WCSimTrajectory*)fpTrackingManager->GimmeTrajectory();
   if(currentTrajectory && !anInfo->GetMyTrajectory())
     anInfo->SetMyTrajectory(currentTrajectory);
   if(secondaries)

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -69,6 +69,7 @@ void WCSimTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
   // if larger than zero, will keep trajectories of many secondaries as well
   // and store them in output file. Difficult to control them all, so best only
   // use for visualization, not for storing in ROOT.
+
   if ( aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()
        || G4UniformRand() < percentageOfCherenkovPhotonsToDraw/100. )
     {
@@ -202,8 +203,8 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
       // optical photon tracks can still be saved if wanted by explicitly adding appropriate entries to the ParticleList or ProcessList via mac file commands
       currentTrajectory->SetProducesHit(anInfo->GetProducesHit());
     }
-    else if (currentTrajectory->GetSavePhotonTrack())
-      currentTrajectory->SetSaveFlag(anInfo->isSaved()); // only save the wanted photon tracks
+    else if (currentTrajectory->GetSavePhotonTrack()) // only save the wanted photon tracks
+      currentTrajectory->SetSaveFlag(anInfo->isSaved()); 
     else 
       currentTrajectory->SetSaveFlag(false);
   }

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -64,16 +64,19 @@ void WCSimTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
   // if larger than zero, will keep trajectories of many secondaries as well
   // and store them in output file. Difficult to control them all, so best only
   // use for visualization, not for storing in ROOT.
-
+#ifndef WCSIM_SAVE_PHOTON_HISTORY
   if ( aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()
        || G4UniformRand() < percentageOfCherenkovPhotonsToDraw/100. )
     {
+#endif
       WCSimTrajectory* thisTrajectory = new WCSimTrajectory(aTrack);
       fpTrackingManager->SetTrajectory(thisTrajectory);
       fpTrackingManager->SetStoreTrajectory(true);
+#ifndef WCSIM_SAVE_PHOTON_HISTORY
     }
   else 
     fpTrackingManager->SetStoreTrajectory(false);
+#endif
 	
   WCSimPrimaryGeneratorAction *primaryGenerator = (WCSimPrimaryGeneratorAction *) (G4RunManager::GetRunManager()->GetUserPrimaryGeneratorAction());
   if(!primaryGenerator->IsConversionFound()) {

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -172,7 +172,8 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
   if (anInfo->GetProducesHit() && saveHitProducingTracks){
       WCSimTrajectory* parentTrajectory = anInfo->GetParentTrajectory();
       while(parentTrajectory != 0 && !parentTrajectory->GetProducesHit()){
-          if (!SAVE_PHOTON_HISTORY || parentTrajectory->GetPDGEncoding()!=0 )  parentTrajectory->SetProducesHit(true);
+          if (SAVE_PHOTON_HISTORY && parentTrajectory->GetPDGEncoding()==0 ) break;
+          parentTrajectory->SetProducesHit(true);
           parentTrajectory = parentTrajectory->GetParentTrajectory();
       }
   }

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -185,7 +185,11 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
     currentTrajectory->SetStoppingPoint(currentPosition);
     currentTrajectory->SetStoppingVolume(currentVolume);
 
-    currentTrajectory->SetSaveFlag(anInfo->isSaved());// mark it for WCSimEventAction ;
+    // Do not save photon tracks in root output when SAVE_PHOTON_HISTORY is on
+    if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()) 
+      currentTrajectory->SetSaveFlag(anInfo->isSaved());// mark it for WCSimEventAction ;
+    else 
+      currentTrajectory->SetSaveFlag(false);
     if (aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
       // don't save the optical photon tracks themselves simply when they produce a hit, since that info is already saved in WCSimRootCherenkovHitTime
       // optical photon tracks can still be saved if wanted by explicitly adding appropriate entries to the ParticleList or ProcessList via mac file commands

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -172,7 +172,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
   if (anInfo->GetProducesHit() && saveHitProducingTracks){
       WCSimTrajectory* parentTrajectory = anInfo->GetParentTrajectory();
       while(parentTrajectory != 0 && !parentTrajectory->GetProducesHit()){
-          if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())  parentTrajectory->SetProducesHit(true);
+          if (!SAVE_PHOTON_HISTORY || parentTrajectory->GetPDGEncoding()!=0 )  parentTrajectory->SetProducesHit(true);
           parentTrajectory = parentTrajectory->GetParentTrajectory();
       }
   }

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -149,7 +149,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
 
   // pass parent trajectory to children
   G4TrackVector* secondaries = fpTrackingManager->GimmeSecondaries();
-  WCSimTrajectory *currentTrajectory = NULL;
+  WCSimTrajectory *currentTrajectory = 0;
   // Do not pass photon trajectory to children at all when SAVE_PHOTON_HISTORY is on
   // Otherwise photon tracks with e.g. WLS in OD PMT will be saved in root output
   if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -65,18 +65,23 @@ void WCSimTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
   // and store them in output file. Difficult to control them all, so best only
   // use for visualization, not for storing in ROOT.
 #ifndef WCSIM_SAVE_PHOTON_HISTORY
-  if ( aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()
-       || G4UniformRand() < percentageOfCherenkovPhotonsToDraw/100. )
-    {
+  bool SAVE_PHOTON_HISTORY = false;
+#else
+  bool SAVE_PHOTON_HISTORY = true;
 #endif
+//#ifndef WCSIM_SAVE_PHOTON_HISTORY
+  if ( aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()
+       || G4UniformRand() < percentageOfCherenkovPhotonsToDraw/100. || SAVE_PHOTON_HISTORY )
+    {
+//#endif
       WCSimTrajectory* thisTrajectory = new WCSimTrajectory(aTrack);
       fpTrackingManager->SetTrajectory(thisTrajectory);
       fpTrackingManager->SetStoreTrajectory(true);
-#ifndef WCSIM_SAVE_PHOTON_HISTORY
+//#ifndef WCSIM_SAVE_PHOTON_HISTORY
     }
   else 
     fpTrackingManager->SetStoreTrajectory(false);
-#endif
+//#endif
 	
   WCSimPrimaryGeneratorAction *primaryGenerator = (WCSimPrimaryGeneratorAction *) (G4RunManager::GetRunManager()->GetUserPrimaryGeneratorAction());
   if(!primaryGenerator->IsConversionFound()) {

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -47,6 +47,11 @@ WCSimTrackingAction::WCSimTrackingAction()
   ParticleList.insert(2112);
 
   percentageOfCherenkovPhotonsToDraw = 0.0;
+#ifndef WCSIM_SAVE_PHOTON_HISTORY
+  SAVE_PHOTON_HISTORY = false;
+#else
+  SAVE_PHOTON_HISTORY = true;
+#endif
 
   messenger = new WCSimTrackingMessenger(this);
 
@@ -64,24 +69,15 @@ void WCSimTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
   // if larger than zero, will keep trajectories of many secondaries as well
   // and store them in output file. Difficult to control them all, so best only
   // use for visualization, not for storing in ROOT.
-#ifndef WCSIM_SAVE_PHOTON_HISTORY
-  bool SAVE_PHOTON_HISTORY = false;
-#else
-  bool SAVE_PHOTON_HISTORY = true;
-#endif
-//#ifndef WCSIM_SAVE_PHOTON_HISTORY
   if ( aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()
        || G4UniformRand() < percentageOfCherenkovPhotonsToDraw/100. || SAVE_PHOTON_HISTORY )
     {
-//#endif
       WCSimTrajectory* thisTrajectory = new WCSimTrajectory(aTrack);
       fpTrackingManager->SetTrajectory(thisTrajectory);
       fpTrackingManager->SetStoreTrajectory(true);
-//#ifndef WCSIM_SAVE_PHOTON_HISTORY
     }
   else 
     fpTrackingManager->SetStoreTrajectory(false);
-//#endif
 	
   WCSimPrimaryGeneratorAction *primaryGenerator = (WCSimPrimaryGeneratorAction *) (G4RunManager::GetRunManager()->GetUserPrimaryGeneratorAction());
   if(!primaryGenerator->IsConversionFound()) {

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -151,7 +151,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
 
   // pass parent trajectory to children
   G4TrackVector* secondaries = fpTrackingManager->GimmeSecondaries();
-  WCSimTrajectory *currentTrajectory = (WCSimTrajectory*)fpTrackin0gManager->GimmeTrajectory();
+  WCSimTrajectory *currentTrajectory = (WCSimTrajectory*)fpTrackingManager->GimmeTrajectory();
   if(currentTrajectory && !anInfo->GetMyTrajectory())
     anInfo->SetMyTrajectory(currentTrajectory);
   if(secondaries)

--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -185,11 +185,7 @@ void WCSimTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
     currentTrajectory->SetStoppingPoint(currentPosition);
     currentTrajectory->SetStoppingVolume(currentVolume);
 
-    // Do not save photon tracks in root output when SAVE_PHOTON_HISTORY is on
-    if (!SAVE_PHOTON_HISTORY || aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()) 
-      currentTrajectory->SetSaveFlag(anInfo->isSaved());// mark it for WCSimEventAction ;
-    else 
-      currentTrajectory->SetSaveFlag(false);
+    currentTrajectory->SetSaveFlag(anInfo->isSaved());// mark it for WCSimEventAction ;
     if (aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
       // don't save the optical photon tracks themselves simply when they produce a hit, since that info is already saved in WCSimRootCherenkovHitTime
       // optical photon tracks can still be saved if wanted by explicitly adding appropriate entries to the ParticleList or ProcessList via mac file commands

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -77,6 +77,7 @@ WCSimTrajectory::WCSimTrajectory(const G4Track* aTrack)
   pScatter = 0;
   pReflec.clear();
   fBoundary = NULL;
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
   // Only do search for optical photon
   if (PDGEncoding==0)
   {
@@ -90,6 +91,7 @@ WCSimTrajectory::WCSimTrajectory(const G4Track* aTrack)
       }
     }
   }
+#endif
 }
 
 WCSimTrajectory::WCSimTrajectory(WCSimTrajectory & right):G4VTrajectory()
@@ -122,9 +124,11 @@ WCSimTrajectory::WCSimTrajectory(WCSimTrajectory & right):G4VTrajectory()
   boundaryTimes = right.boundaryTimes;
   boundaryTypes = right.boundaryTypes;
 
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
   pScatter = right.pScatter;
   pReflec = right.pReflec;
   fBoundary = right.fBoundary;
+#endif
 }
 
 WCSimTrajectory::~WCSimTrajectory()
@@ -262,6 +266,7 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
     }
   }
 
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
   // Add photon history
   if (PDGEncoding==0)
   {
@@ -293,6 +298,7 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
       }
     }
   }
+#endif
 }
 
 G4ParticleDefinition* WCSimTrajectory::GetParticleDefinition()
@@ -329,8 +335,10 @@ void WCSimTrajectory::MergeTrajectory(G4VTrajectory* secondTrajectory)
                      (seco->GetBoundaryTypes()).at(i));
   }
 
+#ifdef WCSIM_SAVE_PHOTON_HISTORY
   AddPhotonScatter(seco->GetPhotonScatter());
   for (auto i: seco->GetPhotonReflection()) AddPhotonReflection(i);
+#endif
 }
 
 

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -261,8 +261,6 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
       std::vector<G4float> bPs(3);
       bPs[0] = track->GetPosition().x(); bPs[1] = track->GetPosition().y(); bPs[2] = track->GetPosition().z();
       AddBoundaryPoint(bPs, track->GetKineticEnergy(), track->GetGlobalTime(), ty);
-      // G4cout<<"Step point "<<track->GetCurrentStepNumber () <<" "<<track->GetPosition().x()<<" "<<track->GetPosition().y()<<" "<<track->GetPosition().z()<<
-      //    " "<<track->GetKineticEnergy()<<" "<<thePrePV->GetName()<<" "<<thePostPV->GetName()<<G4endl;
     }
   }
 
@@ -282,7 +280,6 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
     }
     else
     {
-      //G4cout<<"Having optical boundary process "<<fBoundary->GetStatus()<<" "<<thePrePV->GetName()<<" "<<thePostPV->GetName()<<G4endl;
       if((fBoundary->GetStatus() >= FresnelReflection && fBoundary->GetStatus() <=BackScattering) || 
           (fBoundary->GetStatus() >= PolishedLumirrorAirReflection && fBoundary->GetStatus() <=GroundVM2000GlueReflection) ||
           fBoundary->GetStatus() == CoatedDielectricReflection
@@ -293,7 +290,6 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
         if (thePostPVName.contains("BlackSheet")) rType = 1;
         else if (thePostPVName.contains("reflector")) rType = 2;
         else if (thePostPVName.contains("InteriorWCPMT")) rType = 3;
-        //G4cout<<"Having optical reflection "<<thePrePV->GetName()<<" "<<thePostPV->GetName()<<" "<<rType<<G4endl;
         AddPhotonReflection(rType);
       }
     }

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -23,7 +23,7 @@ WCSimTrajectory::WCSimTrajectory()
   :  positionRecord(0), fTrackID(0), fParentID(0),
      PDGEncoding( 0 ), PDGCharge(0.0), ParticleName(""),
      initialMomentum( G4ThreeVector() ),SaveIt(false), producesHit(false),
-     creatorProcess(""), globalTime(0.0), parentTrajectory(0)
+     creatorProcess(""), globalTime(0.0), savePhotonTrack(false), parentTrajectory(0)
 {
   boundaryPoints.clear();
   boundaryKEs.clear();
@@ -69,6 +69,7 @@ WCSimTrajectory::WCSimTrajectory(const G4Track* aTrack)
     }
   else 
     creatorProcess = "";
+  savePhotonTrack = false;
 
   boundaryPoints.clear();
   boundaryKEs.clear();
@@ -110,6 +111,7 @@ WCSimTrajectory::WCSimTrajectory(WCSimTrajectory & right):G4VTrajectory()
   stoppingVolume = right.stoppingVolume;
   SaveIt = right.SaveIt;
   creatorProcess = right.creatorProcess;
+  savePhotonTrack = right.savePhotonTrack;
 
   producesHit = right.producesHit;
   parentTrajectory = right.parentTrajectory;

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -30,7 +30,8 @@ WCSimTrajectory::WCSimTrajectory()
   boundaryTimes.clear();
   boundaryTypes.clear();
 
-  pScatter = 0;
+  pRayScatter = 0;
+  pMieScatter = 0;
   pReflec.clear();
 
   fBoundary = NULL;
@@ -74,7 +75,8 @@ WCSimTrajectory::WCSimTrajectory(const G4Track* aTrack)
   boundaryTimes.clear();
   boundaryTypes.clear();
 
-  pScatter = 0;
+  pRayScatter = 0;
+  pMieScatter = 0;
   pReflec.clear();
   fBoundary = NULL;
 #ifdef WCSIM_SAVE_PHOTON_HISTORY
@@ -125,7 +127,8 @@ WCSimTrajectory::WCSimTrajectory(WCSimTrajectory & right):G4VTrajectory()
   boundaryTypes = right.boundaryTypes;
 
 #ifdef WCSIM_SAVE_PHOTON_HISTORY
-  pScatter = right.pScatter;
+  pRayScatter = right.pRayScatter;
+  pMieScatter = right.pMieScatter;
   pReflec = right.pReflec;
   fBoundary = right.fBoundary;
 #endif
@@ -272,11 +275,14 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
     //G4cout<<"Having optical photon in AppendStep "<<pds->GetProcessName()<<G4endl;
     if ( pds->GetProcessType() == fOptical )
     {
-      if ( pds->GetProcessSubType() == fOpRayleigh || pds->GetProcessSubType() == fOpMieHG )
+      if ( pds->GetProcessSubType() == fOpRayleigh )
       {
-        AddPhotonScatter(1);
+        AddPhotonRayScatter(1);
       }
-  
+      else if ( pds->GetProcessSubType() == fOpMieHG )
+      {
+        AddPhotonMieScatter(1);
+      }
     }
     else
     {
@@ -290,7 +296,7 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
         if (thePostPVName.contains("BlackSheet")) rType = kBlackSheetS;
         else if (thePostPVName.contains("reflector")) rType = kReflectorS;
         else if (thePostPVName.contains("InteriorWCPMT")) rType = kPhotocathodeS;
-        AddPhotonReflection((int)rType);
+        AddPhotonReflection(rType);
       }
     }
   }
@@ -332,7 +338,8 @@ void WCSimTrajectory::MergeTrajectory(G4VTrajectory* secondTrajectory)
   }
 
 #ifdef WCSIM_SAVE_PHOTON_HISTORY
-  AddPhotonScatter(seco->GetPhotonScatter());
+  AddPhotonRayScatter(seco->GetPhotonRayScatter());
+  AddPhotonMieScatter(seco->GetPhotonMieScatter());
   for (auto i: seco->GetPhotonReflection()) AddPhotonReflection(i);
 #endif
 }

--- a/src/WCSimTrajectory.cc
+++ b/src/WCSimTrajectory.cc
@@ -286,11 +286,11 @@ void WCSimTrajectory::AppendStep(const G4Step* aStep)
         )
       {
         G4String thePostPVName = thePostPV->GetName();
-        G4int rType = 0;
-        if (thePostPVName.contains("BlackSheet")) rType = 1;
-        else if (thePostPVName.contains("reflector")) rType = 2;
-        else if (thePostPVName.contains("InteriorWCPMT")) rType = 3;
-        AddPhotonReflection(rType);
+        ReflectionSurface_t rType = kOtherS;
+        if (thePostPVName.contains("BlackSheet")) rType = kBlackSheetS;
+        else if (thePostPVName.contains("reflector")) rType = kReflectorS;
+        else if (thePostPVName.contains("InteriorWCPMT")) rType = kPhotocathodeS;
+        AddPhotonReflection((int)rType);
       }
     }
   }

--- a/src/WCSimWCAddDarkNoise.cc
+++ b/src/WCSimWCAddDarkNoise.cc
@@ -270,7 +270,7 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	    
 	    //G4cout<<"1 "<<(G4LogicalVolumeStore::GetInstance()->GetVolume("glassFaceWCPMT"))->GetName()<<"\n";
 	    //G4cout<<"2 "<<(*WCHCPMT)[0]->GetLogicalVolume()->GetName()<<"\n";
-	    ahit->SetTrackID(-1);
+	    ahit->SetTrackID(PMTindex[noise_pmt],-1);
 	    ahit->SetParentID(PMTindex[noise_pmt], -1);
 
 	    // Set the position and rotation of the pmt
@@ -316,7 +316,8 @@ void WCSimWCAddDarkNoise::AddDarkNoiseBeforeDigi(WCSimWCDigitsCollection* WCHCPM
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPe(PMTindex[noise_pmt],pe);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPreSmearTime(PMTindex[noise_pmt],current_time); //presmear==postsmear for dark noise
-	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
+	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetTrackID(PMTindex[noise_pmt],-1);
+    (*WCHCPMT)[ list[noise_pmt]-1 ]->SetParentID(PMTindex[noise_pmt],-1);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartTime(PMTindex[noise_pmt],current_time);
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonStartPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());
 	  (*WCHCPMT)[ list[noise_pmt]-1 ]->SetPhotonEndPos(PMTindex[noise_pmt],(*WCHCPMT)[ list[noise_pmt]-1 ]->GetPos());

--- a/src/WCSimWCHit.cc
+++ b/src/WCSimWCHit.cc
@@ -108,7 +108,14 @@ void WCSimWCHit::Print()
 
   G4cout << " Tube:"  << std::setw(4) << tubeID
 	 << " Tube type:"  << tubeType 
-	 << " Track:" << std::setw(6) << trackID 
+	 << " Track:" << std::setw(6); 
+  for (int i = 0; i < totalPe; i++) 
+  {
+    G4cout << trackID[i] << " ";
+    if ( i%10 == 0 && i != 0) 
+      G4cout << G4endl << "\t";
+  }
+  G4cout
 	 << " Pe:"    << totalPe
 	 << " Pos:"   << pos/cm << G4endl
 	 << "\tTime: "; 

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -185,7 +185,6 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
       G4int   tube         = (*WCHC)[i]->GetTubeID();
       G4double peSmeared = 0.0;
       G4double time_PMT, time_true;
-      //G4int  track_id      = (*WCHC)[i]->GetTrackID();
 
       // Set the position and rotation of the pmt (from WCSimWCAddDarkNoise.cc)
       Double_t hit_pos[3];

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -185,7 +185,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
       G4int   tube         = (*WCHC)[i]->GetTubeID();
       G4double peSmeared = 0.0;
       G4double time_PMT, time_true;
-      G4int  track_id      = (*WCHC)[i]->GetTrackID();
+      //G4int  track_id      = (*WCHC)[i]->GetTrackID();
 
       // Set the position and rotation of the pmt (from WCSimWCAddDarkNoise.cc)
       Double_t hit_pos[3];
@@ -231,6 +231,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 #ifdef DEBUG
 	    G4cout << "tube : " << i << " (ID=" << tube << ")" << " hit in tube : "<< ip << " (time=" << time_true << "ns)"  << " pe value : " << peSmeared << G4endl; //TD debug
 #endif
+      int track_id = (*WCHC)[i]->GetTrackID(ip);
 	    int parent_id = (*WCHC)[i]->GetParentID(ip);
 
 	    float photon_starttime = (*WCHC)[i]->GetPhotonStartTime(ip);
@@ -249,7 +250,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      Digi->SetOrientation(pmt_orientation);
 	      Digi->SetPe(ip,peSmeared);
 	      Digi->SetTime(ip,time_PMT);
-	      Digi->SetTrackID(track_id);
+	      Digi->SetTrackID(ip,track_id);
 	      Digi->SetPreSmearTime(ip,time_true);
 	      Digi->SetParentID(ip,parent_id);
 	      Digi->SetPhotonStartTime(ip,photon_starttime);
@@ -269,7 +270,7 @@ void WCSimWCPMT::MakePeCorrection(WCSimWCHitsCollection* WCHC)
 	      //(*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTubeType((*WCHC)[0]->GetTubeType()); 
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPos(pmt_position);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetOrientation(pmt_orientation);
-	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTrackID(track_id);
+	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetTrackID(ip,track_id);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPreSmearTime(ip,time_true);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetParentID(ip,parent_id);
 	      (*DigitsCollection)[DigiHitMapPMT[tube]-1]->SetPhotonStartTime(ip,photon_starttime);

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -257,6 +257,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	 }
        else {
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
+   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->SetTrackID(trackID);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(parentSavedTrackID);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);

--- a/src/WCSimWCSD.cc
+++ b/src/WCSimWCSD.cc
@@ -232,7 +232,6 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   WCSimWCHit* newHit = new WCSimWCHit();
 	   newHit->SetTubeID(replicaNumber);
 	   //newHit->SetTubeType(volumeName);//B. Quilain
-	   newHit->SetTrackID(trackID);
 	   newHit->SetEdep(energyDeposition); 
 	   newHit->SetLogicalVolume(thePhysical->GetLogicalVolume());
 	   
@@ -244,6 +243,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	   // Set the hitMap value to the collection hit number
 	   PMTHitMap[replicaNumber] = hitsCollection->insert( newHit );
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
+     (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddTrackID(trackID);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(parentSavedTrackID);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);
@@ -257,7 +257,7 @@ G4bool WCSimWCSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 	 }
        else {
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPe(hitTime);
-   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->SetTrackID(trackID);
+   (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddTrackID(trackID);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddParentID(parentSavedTrackID);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartTime(photonStartTime);
 	 (*hitsCollection)[PMTHitMap[replicaNumber]-1]->AddPhotonStartPos(photonStartPos);

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -274,6 +274,7 @@ void WCSimWCTriggerBase::AlgNDigits(WCSimWCDigitsCollection* WCDCPMT, bool remov
   window_start_time -= window_start_time % 5;
   long long window_end_time   = lasthit - ndigitsWindow + window_step_size;
   window_end_time += window_end_time % 5;
+  if (window_end_time<window_start_time) window_end_time = window_start_time;
 #ifdef WCSIMWCTRIGGER_VERBOSE
   G4cout << "WCSimWCTriggerBase::AlgNDigits. Found first/last hits. Looping from "
 	 << window_start_time


### PR DESCRIPTION
Toggle WCSim to save photon scattering and reflection history when `-DWCSIM_SAVE_PHOTON_HISTORY_FLAG=ON` is set in `cmake` configuration. This feature is mostly for calibration studies when we want to know the photon propagation histories with respect to different water qualities and surface reflectivity.

Major changes include:
1. Save `trackID` per photon in `WCSimWCHit` and `WCSimWCDigi`
2. Save the number of scattering and reflection experienced by a photon in `WCSimTrajectory`. In `WCSimTrajectory::AppendStep()`, check whether a Rayleigh/Mie scattering happens, or whether a boundary reflection occurs and save the boundary surface type (`kOtherS,kBlackSheetS,kReflectorS, kPhotocathodeS` defined in `WCSimEnumerations`)
3. Construct new `WCSimRootCherenkovHitHistory` class to save the photon scattering and reflection histories. Users can access this class in a way similar to `WCSimRootCherenkovHitTime`, thus get the scattering and reflection histories per Cherenkov photon. An example usage is also documented in `sample-root-scripts/sample_readfile.C`.
4. In `WCSimEventAction::EndOfEventAction()`, retrieve photon histories from `WCSimTrajectory` container and save in output root file.
5. The photon process check and photon histories saving only occur when `-DWCSIM_SAVE_PHOTON_HISTORY_FLAG=ON` is set in `cmake` configuration. This will enforce `WCSimTrajectory` to be stored in `WCSimTrackingAction::fpTrackingManager` for every photon, overriding setup from `/Tracking/fractionOpticalPhotonsToDraw`.

Bug fix:
1. In `WCSimWCTriggerBase::AlgNDigits`, if the digi hit time range is smaller than trigger window, the find trigger loop is invalid. Pushed a fix to enforce `window_start_time<=window_end_time` in all case