### PR TITLE
Allow multiple runs

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -409,5 +409,20 @@
 ##################
 # NUMBER OF EVENTS TO RUN
 ##################
+# It is possible to perform multiple runs of WCSim in a single process
+# The benefit of this is to reduce the time spent on WCSim initialisation
+# in a use case e.g. simulating events at multiple source positions
+# In order to do this, you can repeat the /run/beamOn command e.g.
+# /gun/direction -1 0 0
+# /run/beamOn 2
+# /gun/direction 1 0 0
+# /run/beamOn 3
+# However, be warned that you cannot change all options between runs
+# - All parameters in tuning_parameters.mac and jobOptions.mac changed will have no effect
+# - Some parameters in WCSim.mac may not have an effect (e.g. geometry)
+# - It is up to you to perform the bookkeeping of which events were run with which options, but to help with this:
+# -- The options tree will be filled with one entry for each run
+# -- The EventHeader has a run number that specifies the run (and corresponding options tree entry) for a given event
+# It is therefore your responsibility to confirm that the options you are changing work as expected in multi-run mode
 /run/beamOn 10
 #exit

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -133,6 +133,9 @@ public:
 
   void SetUseTimer(bool use) { useTimer = use; }
 
+  int GetRunID() { return run; }
+  void SetRunID(int runID) { run = runID; }
+
  private:
   // MFechner : set by the messenger
   std::string RootFileName;

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1144,8 +1144,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       if (index >=1 ) {
 	wcsimrootsuperevent->AddSubEvent();
 	wcsimrootevent = wcsimrootsuperevent->GetTrigger(index);
-	wcsimrootevent->SetHeader(event_id,0,
-				  0,index+1); // date & # of subevent
+	wcsimrootevent->SetHeader(event_id, GetRunAction()->GetRunID(), 0, index+1); // date & # of subevent
 	wcsimrootevent->SetMode(injhfNtuple.mode[0]);
       }
       //wcsimrootevent->SetTriggerInfo(WCTM->GetTriggerType(index),
@@ -1160,9 +1159,9 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 
 
   // Fill the header
-  // Need to add run and date
+  // Need to add date
   wcsimrootevent = wcsimrootsuperevent->GetTrigger(0);
-  wcsimrootevent->SetHeader(event_id,0,0); // will be set later.
+  wcsimrootevent->SetHeader(event_id, GetRunAction()->GetRunID(), 0); // will be set later.
 
   // Fill other info for this event
 
@@ -1681,8 +1680,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
       if (index >=1 ) {
 	wcsimrootsuperevent->AddSubEvent();
 	wcsimrootevent = wcsimrootsuperevent->GetTrigger(index);
-	wcsimrootevent->SetHeader(event_id,0,
-				   0,index+1); // date & # of subevent
+	wcsimrootevent->SetHeader(event_id, GetRunAction()->GetRunID(), 0, index+1); // date & # of subevent
 	wcsimrootevent->SetMode(injhfNtuple.mode[0]);
       }
       //wcsimrootevent->SetTriggerInfo(WCTM->GetTriggerType(index),
@@ -1697,9 +1695,9 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 
 
   // Fill the header
-  // Need to add run and date
+  // Need to add date
   wcsimrootevent = wcsimrootsuperevent->GetTrigger(0);
-  wcsimrootevent->SetHeader(event_id,0,0); // will be set later.
+  wcsimrootevent->SetHeader(event_id, GetRunAction()->GetRunID(), 0); // will be set later.
 
   // Fill other info for this event
 
@@ -2466,7 +2464,7 @@ void WCSimEventAction::FillFlatTree(G4int event_id,
 
   // nGates == 0: I still want to keep untriggered event
   if(ngates == 0){
-    GetRunAction()->SetEventHeaderNew(0,event_id+1,1);   //ToDo: run
+    GetRunAction()->SetEventHeaderNew(GetRunAction()->GetRunID(), event_id+1, 1);   //ToDo: run
     //G4cout << event_id << G4endl; //TF debug
     //General case for a vector triggerInfo:
     //GetRunAction()->SetTriggerInfoNew(kTriggerUndefined, std::vector<G4double>(),0.,0.);
@@ -2492,7 +2490,7 @@ void WCSimEventAction::FillFlatTree(G4int event_id,
   for (int index = 0 ; index < ngates ; index++) {
     //WCSim (FillRootEvent) counts its sub-events from 1 to nGate, while counting events from 0 to n-1
     //Be consistent and start both from 1 here:
-    GetRunAction()->SetEventHeaderNew(0,event_id+1,index+1);   //ToDo: run
+    GetRunAction()->SetEventHeaderNew(GetRunAction()->GetRunID(), event_id+1, index+1);   //ToDo: run
     G4cout << event_id << G4endl;
 
     //First Trigger details of THIS subevent (index+1)

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -983,7 +983,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     G4cout << "B.Q: open the tree" << G4endl;
 #endif
     TTree* tree = GetRunAction()->GetTree();
-    tree->SetEntries(GetRunAction()->GetNumberOfEventsGenerated());
+    tree->SetEntries(tree->GetEntries() + GetRunAction()->GetNumberOfEventsGenerated());
   }
 
   //save DAQ options here. This ensures that when the user selects a default option

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -983,7 +983,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     G4cout << "B.Q: open the tree" << G4endl;
 #endif
     TTree* tree = GetRunAction()->GetTree();
-    tree->SetEntries(tree->GetEntries() + GetRunAction()->GetNumberOfEventsGenerated());
+    tree->SetEntries(tree->GetEntries() + 1);
   }
 
   //save DAQ options here. This ensures that when the user selects a default option

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -983,7 +983,7 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     G4cout << "B.Q: open the tree" << G4endl;
 #endif
     TTree* tree = GetRunAction()->GetTree();
-    tree->SetEntries(tree->GetEntries() + 1);
+    tree->Fill();
   }
 
   //save DAQ options here. This ensures that when the user selects a default option
@@ -1117,6 +1117,7 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   // Fill up a Root event with stuff from the ntuple
 
   WCSimRootEvent* wcsimrootsuperevent = GetRunAction()->GetRootEvent(detectorElement);
+  wcsimrootsuperevent->ReInitialize();
 
   // start with the first "sub-event"
   // if the WC digitization requires it, we will add another subevent
@@ -1634,11 +1635,6 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   //G4cout <<"WCFV digi sumQ:"<<std::setw(4)<<wcsimrootevent->GetSumQ()<<"  ";
   //  }
 
-  //TTree* tree = GetRunAction()->GetTree();
-  TBranch* branch = GetRunAction()->GetBranch(detectorElement);
-  //tree->Fill();
-  branch->Fill();
-
   /*
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
@@ -1649,17 +1645,6 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   }
   */
 
-  /*
-  TFile* hfile = tree->GetCurrentFile();
-  hfile->cd();                    // make sure tree is ONLY written to CurrentFile and not to all files!
-  // MF : overwrite the trees -- otherwise we have as many copies of the tree
-  // as we have events. All the intermediate copies are incomplete, only the
-  // last one is useful --> huge waste of disk space.
-  tree->Write("",TObject::kOverwrite);
-  */
-
-  // M Fechner : reinitialize the super event after the writing is over
-  wcsimrootsuperevent->ReInitialize();
 }
 
 void WCSimEventAction::FillRootEventHybrid(G4int event_id,
@@ -1671,6 +1656,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 				       WCSimRootEvent * wcsimrootsuperevent,
 				       WCSimRootTrigger * wcsimrootevent)
  {
+  wcsimrootsuperevent->ReInitialize();
   // start with the first "sub-event"
   // if the WC digitization requires it, we will add another subevent
   // for the WC.
@@ -2177,11 +2163,6 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
   //G4cout <<"WCFV digi sumQ:"<<std::setw(4)<<wcsimrootevent->GetSumQ()<<"  ";
   //  }
 
-  //TTree* tree = GetRunAction()->GetTree();
-  TBranch* branch = GetRunAction()->GetBranch(detectorElement);
-  //tree->Fill();
-  branch->Fill();
-
   /*
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
@@ -2190,18 +2171,7 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
       generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex()); //will increment NVtx
       GetRunAction()->FillRootrackerVertexTree();
   }
-
-
-  TFile* hfile = tree->GetCurrentFile();
-  hfile->cd();                    // make sure tree is ONLY written to CurrentFile and not to all files!
-  // MF : overwrite the trees -- otherwise we have as many copies of the tree
-  // as we have events. All the intermediate copies are incomplete, only the
-  // last one is useful --> huge waste of disk space.
-  tree->Write("",TObject::kOverwrite);
-
   */
-  // M Fechner : reinitialize the super event after the writing is over
-  wcsimrootsuperevent->ReInitialize();
 }
 
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -168,7 +168,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
       }
       else{
           TFile *hfile = new TFile(rootname.c_str(), "UPDATE");
-          WCSimTree = (*TTree) hfile->Get("wcsimT");
+          WCSimTree = (TTree*) hfile->Get("wcsimT");
           wcsimrooteventbranch = WCSimTree->GetBranch("wcsimrootevent");
           wcsimrooteventbranch2 = WCSimTree->GetBranch("wcsimrootevent2");
           wcsimrooteventbranch_OD = WCSimTree->GetBranch("wcsimrootevent_OD");

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -49,7 +49,7 @@ WCSimRunAction::~WCSimRunAction()
 
 void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
 {
-  run = aRun->GetRunID()
+  run = aRun->GetRunID();
 
   fSettingsOutputTree = NULL;
   fSettingsInputTree = NULL;

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -49,6 +49,7 @@ WCSimRunAction::~WCSimRunAction()
 
 void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
 {
+  run = aRun->GetRunID()
 
   fSettingsOutputTree = NULL;
   fSettingsInputTree = NULL;
@@ -105,7 +106,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
       wcsimrootsuperevent2->Initialize(); // make at least one event
       wcsimrootsuperevent_OD->Initialize(); // make at least one event
 
-      if (aRun->GetRunID() == 0) {
+      if (run == 0) {
           TFile *hfile = new TFile(rootname.c_str(), "RECREATE", "WCSim ROOT file");
           hfile->SetCompressionLevel(2);
 
@@ -175,6 +176,8 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
           wcsimrooteventbranch->SetAddress(&wcsimrootsuperevent);
           wcsimrooteventbranch2->SetAddress(&wcsimrootsuperevent2);
           wcsimrooteventbranch_OD->SetAddress(&wcsimrootsuperevent_OD);
+          optionsTree = (TTree*) hfile->Get("wcsimRootOptionsT");
+          optionsTree->SetBranchAddress("wcsimrootoptions", &wcsimrootoptions);
       }
   }
 
@@ -475,7 +478,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
   */
 }
 
-void WCSimRunAction::EndOfRunAction(const G4Run* aRun)
+void WCSimRunAction::EndOfRunAction(const G4Run*)
 {
 //G4cout << "Number of Events Generated: "<< numberOfEventsGenerated << G4endl;
 //G4cout<<"Number of times waterTube hit: " << numberOfTimesWaterTubeHit<<G4endl;
@@ -527,10 +530,8 @@ void WCSimRunAction::EndOfRunAction(const G4Run* aRun)
     // Close the Root file at the end of the run
     TFile* hfile = WCSimTree->GetCurrentFile();
     hfile->cd();
-    if(aRun->GetRunID() == 0) {
-        optionsTree->Fill();
-        optionsTree->Write();
-    }
+    optionsTree->Fill();
+    optionsTree->Write();
     hfile->Write();
     hfile->Close();
   


### PR DESCRIPTION
Geant4 allows multiple runs with different generator settings by having multiple /run/beamOn commands and changing generator settings between them. This is useful if e.g. you want to simulate some events at one source position followed by a some events at another position, etc., without needing to execute WCSim once for each position. You can just set the mac file to do them sequentially.

But this doesn't work in WCSim because the EndOfRunAction recreates (overwrites) the output root file, so only the final run gets saved.
To fix this, the StartOfRunAction can check the run number and either (re)create the output file for the first run, or open it to append for subsequent runs. Also, when writing each event, the tree itself is filled rather than filling individual branches, because when filling branches it was then required to specify manually the number of events in the tree. It's better to just fill the tree so the number of events is automatically correct, rather than tracking it through multiple runs and specifying it manually.

Tested with a macro file ending with
```
/gps/direction -1 0 0
/run/beamOn 2
/gps/direction 1 0 0
/run/beamOn 3
```
Checked that the output had five events in total, the first two events simulated tracks with direction (-1, 0, 0) and the final three simulated tracks with directions (1, 0, 0).