### PR TITLE
Properly initialize odEdited variable

### DIFF
--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -94,6 +94,7 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,
 
   isODConstructed = false;
   isCombinedPMTCollectionDefined = false;
+  odEdited = false;
 
   isRealisticPlacement = false;
 


### PR DESCRIPTION
It is reported that sometime error happens when running the WCTE geometry
```
 *************************
 ** CreateCombinedPMTQE **
 *************************

### Recover PMT collection name NuPRISMBeamTest_16cShort_mPMT-glassFaceWCPMT
wavelength[300nm] : 0.107808
wavelength[320nm] : 0.251781
wavelength[340nm] : 0.328904
wavelength[360nm] : 0.345342
wavelength[380nm] : 0.369178
wavelength[400nm] : 0.366575
wavelength[420nm] : 0.355205
wavelength[440nm] : 0.33863
wavelength[460nm] : 0.311781
wavelength[480nm] : 0.269863
wavelength[500nm] : 0.243425
wavelength[520nm] : 0.211918
wavelength[540nm] : 0.141507
wavelength[560nm] : 0.099589
wavelength[580nm] : 0.080411
wavelength[600nm] : 0.0643836
wavelength[620nm] : 0.0509589
wavelength[640nm] : 0.0390411
wavelength[660nm] : 0.030137
wavelength[680nm] : 0.0178082
NuPRISMBeamTest_16cShort_mPMT-glassFaceWCPMT_OD is not a recognized hit collection. Exiting WCSim.
```
After some investigation, it seems that it is triggered by the `odEdited` being true when issuing `/WCSim/Construct`.
Since `odEdited` is not initialized in the class constructor, it might be set to true in unfortunate cases.