### PR TITLE
Fix unique copyNo bug in pmt placement

### DIFF
--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -4461,11 +4461,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
 
   G4String pmtname = "WCMultiPMT";
 
+  // unique copy number for auto placement
+  G4int copyNo = 0;
   ///////////////   Barrel PMT placement
 
   if(placeBorderPMTs){
-
-    G4int copyNo = 0;
 
     if (readFromTable)
     {
@@ -4638,7 +4638,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
                     pmtname,             // its name
                     logicCapAssembly,         // its mother volume
                     false,                     // no boolean operations
-                    i*WCPMTperCellVertical+j,
+                    copyNo++,
                     checkOverlapsPMT);
 #endif
               // logicWCPMT->GetDaughter(0),physiCapPMT is the glass face. If you add more 
@@ -4752,7 +4752,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
                     pmtname, // its name 
                     logicCapAssembly,         // its mother volume
                     false,                 // no boolean os
-                    icopy,               // every PMT need a unique id.
+                    copyNo++,               // every PMT need a unique id.
                     checkOverlapsPMT);
 #endif          
 


### PR DESCRIPTION
When non-replica placement is used without the PMT position table, the copyNo in endcap PMT placement is not assigned properly and some are duplicated. This makes the hit registration problematic. Now the bug is fixed.

Note that the default WCTE macro already includes the PMT position table, so this change will not affect the default behavior.