### PR TITLE
Doxygen the output file classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Useful cmake commands:
 #### WCSim cmake build options
 * `-DWCSim_Geometry_Overlaps_CHECK=<ON|OFF>` If ON, turns on geometry overlap checking (slow, but important when setting new detector geometry options). Default: OFF
 * `-DWCSim_DEBUG_COMPILE_FLAG=<ON|OFF>` If ON, turns on the gcc debug compiler flag `-g`. Default: OFF
-* `-DWCSim_DEBUG_COMPILE_FLAG=<ON|OFF>` If ON, turns on photon scattering/reflection history saving. The data class `WCSimRootCherenkovHitHistory` is used in a similar way as `WCSimRootCherenkovHitTime`. Default: OFF
+* `-DWCSIM_SAVE_PHOTON_HISTORY_FLAG=<ON|OFF>` If ON, turns on photon scattering/reflection history saving. The data class `WCSimRootCherenkovHitHistory` is used in a similar way as `WCSimRootCherenkovHitTime`. Default: OFF
 
 #### Build with CMake on sukap:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can follow issues/requests etc by watching the GitHub respository.
 
 ## Validation Webpage
 
-WCSim uses Travis CI to perform build and physics tests for each pull request and commit.
+WCSim uses GitHub Actions CI to perform build and physics tests for each pull request and commit.
 The scripts it runs can be found at https://github.com/WCSim/Validation
 
 The output can be found at: https://wcsim.github.io/Validation/
@@ -33,9 +33,26 @@ The output can be found at: https://wcsim.github.io/Validation/
 More detailed information about the simulation is available in
 `doc/DetectorDocumentation.pdf`
 
-doxygen documentation can be built by running
-`cd $WCSIMDIR/doc && make`
-Additionally, doxygen documentation is available at https://wcsim.github.io/WCSim/inherits.html
+Additionally, doxygen documentation is available at https://wcsim.github.io/WCSim/annotated.html
+Note that most of the code has no doxygen comments, but all output class member variables are documented. See the WCSimRoot* classes
+
+doxygen documentation can be built locally by running
+```bash
+cd $WCSIMDIR/ && doxygen WCSim_doxygen_config
+```
+
+For admin: A more featured doxygen build can be done & pushed using an alternative doxygen config file (requires `dot` from `graphviz`)
+```bash
+git clone -b gh-pages --single-branch git@github.com:WCSim/WCSim.git WCSim-dox
+cd WCSim-dox
+./get_dox.sh
+```
+You can also make this featured version locally by
+```bash
+cd $WCSIMDIR
+git clone -b gh-pages --single-branch git@github.com:WCSim/WCSim.git WCSim-dox
+doxygen WCSim-dox/WCSim_doxygen_config
+```
 
 ## Build Instructions
 

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -124,7 +124,7 @@ class WCSimRootCherenkovHit : public TObject {
 
 private:
   Int_t fTubeID; //!< PMT ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
-  Int_t fmPMTID; //!< The mPMT number this 3" PMT is in (Equivlaent to fTubeID for 20" & OD PMTs)
+  Int_t fmPMTID; //!< The mPMT number this 3" PMT is in (Equivalent to fTubeID for 20" & OD PMTs)
   Int_t fmPMT_PMTID; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
   Int_t fTotalPe[2]; //!< 0th element: position in the WCSimRootCherenkovHitTime array where this PMTs' true hits start in this event. 1st element: Number of true hits on this PMT in this event. 
 
@@ -236,9 +236,9 @@ private:
   // See jhfNtuple.h for the meaning of these data members:
   Float_t fQ; //!< Digitised charge
   Double_t fT; //!< Digitised time, relative to the digit time (date in the WCSimRootEventHeader) (unit: )
-  Int_t fTubeID; //!< PMT ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
-  Int_t fmPMTID; //!< The mPMT number this 3" PMT is in (Equivlaent to fTubeID for 20" & OD PMTs)
-  Int_t fmPMT_PMTID; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
+  Int_t fTubeId; //!< PMT ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
+  Int_t fmPMTId; //!< The mPMT number this 3" PMT is in (Equivalent to fTubeId for 20" & OD PMTs)
+  Int_t fmPMT_PMTId; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
   std::vector<int> fPhotonIds; //!< Truth matching. Position in the CherenkovHitTime array that contains the true hit(s) that created this digit
 
 public:

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -25,7 +25,8 @@ class TDirectory;
 
 
 /**
- * Class holding true track information.
+ * \class WCSimRootTrack
+ * \brief Class holding true track information.
  *
  * By default,
  * - No Cherenkov photons are saved in the output file
@@ -39,25 +40,25 @@ class WCSimRootTrack : public TObject {
 private:
 
   // See jhfNtuple.h for the meaning of these data members:
-  Int_t   fIpnu; //!< 
-  Int_t   fFlag; //!<
-  Float_t fM; //!< Particle mass (units: )
-  Float_t fP; //!< Particle momentum (units: )
-  Float_t fE; //!< Particle energy (units: )
+  Int_t   fIpnu; //!< Track PDG code
+  Int_t   fFlag; //!< -2: Neutrino target nucleus track. -1: Primary neutrino track. 0: Final state particle track
+  Float_t fM; //!< Particle mass (units: MeV/c2)
+  Float_t fP; //!< Particle initial momentum magnitude (units: MeV/c)
+  Float_t fE; //!< Particle initial total energy = sqrt(p^2 + m^2) (units: MeV)
   Int_t   fStartvol; //!< Particle starting volume
   Int_t   fStopvol; //!< Particle stopping volume
-  Float_t fDir[3]; //!< Particle direction. Unit vector in x,y,z
-  Float_t fPdir[3]; //!< Particle momentum. Vector in x,y,z
-  Float_t fStop[3]; //!< Particle stopping position. Vector in x,y,z
-  Float_t fStart[3]; //!< Particle starting position. Vector in x,y,z
-  Int_t fParenttype; //!< 
+  Float_t fDir[3]; //!< Particle initial direction. Unit vector in x,y,z
+  Float_t fPdir[3]; //!< Particle initial momentum. Vector in x,y,z (units: MeV). The magnitude of this vector is equivalent to fP.
+  Float_t fStop[3]; //!< Particle stopping position. Vector in x,y,z (units: cm)
+  Float_t fStart[3]; //!< Particle starting position. Vector in x,y,z (units: cm)
+  Int_t fParenttype; //!< PDG code of parent particle (0 for primary, 999 for parent PDG code not found in the specific logic used)
   ProcessType_t fCreatorProcess; //!< The physics process that created the track
   Double_t fTime; //!< Particle start time
-  Int_t fId; //!< 
-  Int_t fParentId; //!< 
-  std::vector<std::vector<float>> boundaryPoints; //!< The position (x,y,z) where the particle crossed the blacksheet/tyvek/cave
-  std::vector<float> boundaryKEs; //!< The particle kinetic energy as it crossed the blacksheet/tyvek/cave
-  std::vector<double> boundaryTimes; //!< The time as the particle crossed the blacksheet/tyvek/cave
+  Int_t fId; //!< Unique track ID for this particle track. This is the ID to use for particle history tracking (not position in the WCSimRootTrack array)
+  Int_t fParentId; //!< Unique track ID for the parent of this track. This is the ID to use for particle history tracking (not position in the WCSimRootTrack array)
+  std::vector<std::vector<float>> boundaryPoints; //!< The position (x,y,z) where the particle crossed the blacksheet/tyvek/cave (units: cm)
+  std::vector<float> boundaryKEs; //!< The particle kinetic energy as it crossed the blacksheet/tyvek/cave (units: MeV)
+  std::vector<double> boundaryTimes; //!< The time as the particle crossed the blacksheet/tyvek/cave (units: ns)
   std::vector<int> boundaryTypes; //!< The surface the particle has crossed. 1 = blacksheet, 2 = tyvek, 3 = cave. Note that all boundary* variables are in synch
 
 public:
@@ -114,7 +115,8 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Class holding true hit information.
+ * \class WCSimRootCherenkovHit
+ * \brief Class holding true (Cherenkov photon + dark noise) hit information.
  *
  * For each PMT that has at least 1 PMT hit,
  * this class specifies the position of the detailed
@@ -151,7 +153,8 @@ public:
 };
 
 /**
- * Class holding true (Cherenkov) hit information
+ * \class WCSimRootCherenkovHitTime
+ * \brief Class holding true (Cherenkov photon + dark noise) hit information
  *
  * There is one entry per hit.
  */
@@ -159,11 +162,11 @@ class WCSimRootCherenkovHitTime : public TObject {
 
 private:
   // See jhfNtuple.h for the meaning of these data members:
-  Double_t fTruetime; //!< True hit time (unit: )
+  Double_t fTruetime; //!< True hit time (unit: ns)
   Int_t   fParentSavedTrackID; //!< Truth matching. ID of the parent track that created the Cherenkov photon that created this hit. Note that this is not the position in the WCSimRootTrack array - you do need to loop and check the ID. Note that if you are running in non-default mode and you are saving photon tracks, this will be the ID of the photon track. Note: for dark noise, this number is -1
-  Float_t fPhotonStartTime; //!< Start time of the photon that created this hit (unit: )
-  Float_t fPhotonStartPos[3]; //!< Start position (x,y,z) of the photon that created this hit (unit: )
-  Float_t fPhotonEndPos[3]; //!< End position (x,y,z) of the photon that created this hit (unit: )
+  Float_t fPhotonStartTime; //!< Start time of the photon that created this hit (unit: ns)
+  Float_t fPhotonStartPos[3]; //!< Start position (x,y,z) of the photon that created this hit (unit: cm)
+  Float_t fPhotonEndPos[3]; //!< End position (x,y,z) of the photon that created this hit (unit: cm)
   Float_t fPhotonStartDir[3]; //< Start direction unit vector (x,y,z) of the photon that created this hit
   Float_t fPhotonEndDir[3]; //< End direction unit vector (x,y,z) of the photon that created this hit
   ProcessType_t fPhotonCreatorProcess; //!< Process that created the photon that created this hit
@@ -196,7 +199,8 @@ public:
 };
 
 /**
- * Class holding scattering and reflection history for each Cherenkov hit (photon)
+ * \class WCSimRootCherenkovHitHistory
+ * \brief Class holding scattering and reflection history for each true hit (Cherenkov photon; dark noise are all 0)
  *
  * There is one entry per hit.
  * Note that this information is not filled, unless WCSim is compiled with -DWCSIM_SAVE_PHOTON_HISTORY_FLAG=ON (default OFF)
@@ -226,7 +230,8 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Class holding scattering and reflection history for each digitised hit
+ * \class WCSimRootCherenkovDigiHit
+ * \brief Class holding digitised hit (aka digit or digi) information (after PMT & electronics simulation + triggering)
  *
  * There is one entry per digit
  */
@@ -234,12 +239,12 @@ class WCSimRootCherenkovDigiHit : public TObject {
 
 private:
   // See jhfNtuple.h for the meaning of these data members:
-  Float_t fQ; //!< Digitised charge
-  Double_t fT; //!< Digitised time, relative to the digit time (date in the WCSimRootEventHeader) (unit: )
+  Float_t fQ; //!< Digitised charge (unit: something like p.e.)
+  Double_t fT; //!< Digitised time, relative to the digit time (date in the WCSimRootEventHeader) (unit: ns)
   Int_t fTubeId; //!< PMT ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
   Int_t fmPMTId; //!< The mPMT number this 3" PMT is in (Equivalent to fTubeId for 20" & OD PMTs)
   Int_t fmPMT_PMTId; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
-  std::vector<int> fPhotonIds; //!< Truth matching. Position in the CherenkovHitTime array that contains the true hit(s) that created this digit
+  std::vector<int> fPhotonIds; //!< Truth matching. Position(s) in the CherenkovHitTime array that contains the true hit(s) that created this digit
 
 public:
   WCSimRootCherenkovDigiHit() {}
@@ -266,14 +271,15 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Class containing header information for this trigger
+ * \class WCSimRootEventHeader
+ * \brief Class containing header information for this trigger
  */
 class WCSimRootEventHeader {
 
 private:
   Int_t   fEvtNum; //!< Event number
   Int_t   fRun; //!< Run number. Should be 0 for the first call of /run/beamOn, and increment for each subsequent call of /run/beamOn
-  int64_t fDate; //!< Time 
+  int64_t fDate; //!< Time (ns)
   Int_t   fSubEvtNumber; //!< Trigger number. 0 for the first trigger (or if no trigger has been found), and increments for each subsequent trigger
 
 public:
@@ -294,7 +300,8 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Class storing information about pi0 decays TOCHECKALL
+ * \class WCSimRootPi0
+ * \brief Class storing information about pi0 decays
  */
 class WCSimRootPi0 : public TObject {
     // this is a class used specifically for Pi0 events
@@ -303,7 +310,7 @@ private:
   Float_t fPi0Vtx[3]; //!< pi0 vertex (x,y,z)
   Int_t   fGammaID[2]; //!< Truth matching. Track ID of each gamma
   Float_t fGammaE[2]; //!< Starting energy of each gamma
-  Float_t fGammaVtx[2][3]; //!< Starting position of each gamma?
+  Float_t fGammaVtx[2][3]; //!< Stopping position of each gamma (x,y,z)
 
 public:
   WCSimRootPi0() {}
@@ -328,13 +335,14 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Information about gammas released from neutron capture TOCHECKALL
+ * \class WCSimRootCaptureGamma
+ * \brief Class storing information about gammas released from neutron capture
  */
 class WCSimRootCaptureGamma : public TObject {
 
 private:
   Int_t   fID; //!<  Truth matching. Track ID of the gamma
-  Float_t fEnergy; //!< Energy of the gamma
+  Float_t fEnergy; //!< Energy of the gamma (unit: MeV)
   Float_t fDir[3]; //!< Direction unit vector (x,y,z) of the gamma
 
 public:
@@ -357,17 +365,18 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Class used specifically for neutron capture events TOCHECKALL
+ * \class WCSimRootCapture
+ * \brief Class used specifically for neutron capture events
  */
 class WCSimRootCapture : public TObject {
 
 
 private:
   Int_t   	   fCaptureParent; //!< Track ID of the parent neutron
-  Float_t 	   fCaptureVtx[3]; //!< Position of the neutron capture (x,y,z)
+  Float_t 	   fCaptureVtx[3]; //!< Position of the neutron capture (x,y,z) (unit: cm)
   Int_t   	   fNGamma; //!< Number of gammas produced by the neutron capture
-  Float_t 	   fTotalGammaE; //!< Total gamma energy produced by the neutron capture
-  Float_t 	   fCaptureT; //!< Time of the neutron capture
+  Float_t 	   fTotalGammaE; //!< Total gamma energy produced by the neutron capture (unit: MeV)
+  Float_t 	   fCaptureT; //!< Time of the neutron capture (unit: ns)
   Int_t          fCaptureNucleus; //!< Nucleus the neutron captured on
   TClonesArray * fGammas; //!< Array of WCSimRootCaptureGamma storing detailed information about individual gammas released from the neutron capture
   bool 	   IsZombie; //!< Will be true if unfilled, false if filled
@@ -406,7 +415,8 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 /**
- * Class storing trigger information
+ * \class WCSimRootTrigger
+ * \brief Class storing trigger information
  *
  * Digitised hit information will be put in the WCSimRootTrigger it is associated with
  * (if there are multiple overlapping trigger readout windows, digits will only be saved in the first
@@ -419,29 +429,29 @@ class WCSimRootTrigger : public TObject {
 private:
   WCSimRootEventHeader    fEvtHdr;  //!< The header
   // See jhfNtuple.h for the meaning of these data members:
-  Int_t                fMode[MAX_N_VERTICES]; //!<
+  Int_t                fMode[MAX_N_VERTICES]; //!< Interaction mode for each vertex. Only set for the muline generator
   Int_t                fNvtxs; //!< Number of true vertices in the event
-  Int_t                fVtxsvol[MAX_N_VERTICES]; //!< 
+  Int_t                fVtxsvol[MAX_N_VERTICES]; //!< The detector volume this vertex occured in
   Float_t              fVtxs[MAX_N_VERTICES][4]; //!< True 4-position (x,y,z,t) of the vertex
-  Int_t                fVecRecNumber;       //!< "info event" number in inputvectorfile 
-  Int_t                fJmu; //!< 
-  Int_t                fJp; //!< 
+  Int_t                fVecRecNumber;       //!< "info event" number in inputvectorfile. Only set for the muline generator
+  Int_t                fJmu; //!< LEGACY VARIABLE MAY BE INACCURATE IN SOME RUNNING SCENARIOS. Index of the muon
+  Int_t                fJp; //!< LEGACY VARIABLE MAY BE INACCURATE IN SOME RUNNING SCENARIOS. Index of the proton
 
   WCSimRootPi0         fPi0;                //!< Pi0 info (default = not used)
 
-  TClonesArray         *fCaptures;           //!< Neutron capture info (default = not used)
+  TClonesArray         *fCaptures;           //!< Neutron capture info
   Int_t                fNcaptures;           //!< Number of tracks in the neutron capture array
 
-  Int_t                fNpar;               //!< Number of particles ???
-  Int_t                fNtrack;             //!< Number of tracks in the WCSimRootTracks array
-  Int_t                fNtrack_slots;       //!< Number of slots in the WCSimRootTracks array. This is potentially more than fNtrack (i.e. if any tracks have been removed that aren't at the very start/end)
+  Int_t                fNpar;               //!< LEGACY VARIABLE MAY BE INACCURATE IN SOME RUNNING SCENARIOS. Index Number of tracks in the event (not all will be saved in the WCSimRootTrack array)
+  Int_t                fNtrack;             //!< Number of tracks in the WCSimRootTrack array
+  Int_t                fNtrack_slots;       //!< Number of slots in the WCSimRootTrack array. This is potentially more than fNtrack (i.e. if any tracks have been removed that aren't at the very start/end)
   TClonesArray         *fTracks;            //!< Array of WCSimRootTracks 
 
   Int_t                fNumTubesHit;         //!< Number of tubes hit
   Int_t                fNcherenkovhits;      //!< Number of hits in the array
   TClonesArray         *fCherenkovHits;      //!< Array of WCSimRootCherenkovHits
 
-  Int_t                fCherenkovHitCounter; //!< 
+  Int_t                fCherenkovHitCounter; //!< Incremented with every call of WCSimRootTrigger::AddCherenkovHit(). Not initialised to 0. Not used. Inaccessible publicly. Avoid
   Int_t                fNcherenkovhittimes;      //!< Number of hits in the WCSimRootCherenkovHits array
   TClonesArray         *fCherenkovHitTimes;      //!< Array of WCSimRootCherenkovHits
   Int_t                fNcherenkovhithistories;      //!< Number of hits in the WCSimRootCherenkovHitHistories array. Should be identical to fNcherenkovhittimes
@@ -454,7 +464,7 @@ private:
   TClonesArray         *fCherenkovDigiHits;  //!< Array of WCSimRootCherenkovDigiHit's
 
   TriggerType_t        fTriggerType;         //!< Trigger algorithm that created this trigger
-  std::vector<Double_t> fTriggerInfo;         //!< Information about how it passed the trigger (e.g. how many hits in the NDigits window)
+  std::vector<Double_t> fTriggerInfo;        //!< Information about how it passed the trigger (e.g. how many hits in the NDigits window)
 
   bool IsZombie; //!< Will be true if unfilled, false if filled 
 
@@ -593,10 +603,13 @@ public:
 };
 
 /**
- * Class containing event information
+ * \class WCSimRootEvent
+ * \brief Class containing event information
  *
  * Only events from a single PMT type (20" PMT OR 3" PMT in mPMT OR OD PMT) are available
  * in a single WCSimRootEvent
+ *
+ * See the macro sample-root-scripts/sample_readfile.C for an example of using this class
  */
 class WCSimRootEvent : public TObject {
 public:

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -23,31 +23,42 @@
 
 class TDirectory;
 
+
+/**
+ * Class holding true track information.
+ *
+ * By default,
+ * - No Cherenkov photons are saved in the output file
+ * (in fact no photons are stored at all. The exception
+ * is what Geant terms as gammas - basically high energy photons)
+ * - Everything that creates a photon that creates a true PMT hit is saved,
+ * along with all its ancestors
+ */
 class WCSimRootTrack : public TObject {
 
 private:
 
   // See jhfNtuple.h for the meaning of these data members:
-  Int_t   fIpnu;
-  Int_t   fFlag;
-  Float_t fM;
-  Float_t fP;
-  Float_t fE;
-  Int_t   fStartvol;
-  Int_t   fStopvol;
-  Float_t fDir[3];
-  Float_t fPdir[3];
-  Float_t fStop[3];
-  Float_t fStart[3];
-  Int_t fParenttype;
-  ProcessType_t fCreatorProcess;
-  Double_t fTime;
-  Int_t fId;
-  Int_t fParentId;
-  std::vector<std::vector<float>> boundaryPoints;
-  std::vector<float> boundaryKEs;
-  std::vector<double> boundaryTimes;
-  std::vector<int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
+  Int_t   fIpnu; //!< 
+  Int_t   fFlag; //!<
+  Float_t fM; //!< Particle mass (units: )
+  Float_t fP; //!< Particle momentum (units: )
+  Float_t fE; //!< Particle energy (units: )
+  Int_t   fStartvol; //!< Particle starting volume
+  Int_t   fStopvol; //!< Particle stopping volume
+  Float_t fDir[3]; //!< Particle direction. Unit vector in x,y,z
+  Float_t fPdir[3]; //!< Particle momentum. Vector in x,y,z
+  Float_t fStop[3]; //!< Particle stopping position. Vector in x,y,z
+  Float_t fStart[3]; //!< Particle starting position. Vector in x,y,z
+  Int_t fParenttype; //!< 
+  ProcessType_t fCreatorProcess; //!< The physics process that created the track
+  Double_t fTime; //!< Particle start time
+  Int_t fId; //!< 
+  Int_t fParentId; //!< 
+  std::vector<std::vector<float>> boundaryPoints; //!< The position (x,y,z) where the particle crossed the blacksheet/tyvek/cave
+  std::vector<float> boundaryKEs; //!< The particle kinetic energy as it crossed the blacksheet/tyvek/cave
+  std::vector<double> boundaryTimes; //!< The time as the particle crossed the blacksheet/tyvek/cave
+  std::vector<int> boundaryTypes; //!< The surface the particle has crossed. 1 = blacksheet, 2 = tyvek, 3 = cave. Note that all boundary* variables are in synch
 
 public:
   WCSimRootTrack() {}
@@ -102,14 +113,20 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
-
+/**
+ * Class holding true hit information.
+ *
+ * For each PMT that has at least 1 PMT hit,
+ * this class specifies the position of the detailed
+ * true hit information in the WCSimRootCherenkovHitTime array
+ */
 class WCSimRootCherenkovHit : public TObject {
 
 private:
-  Int_t fTubeID;
-  Int_t fmPMTID;
-  Int_t fmPMT_PMTID;
-  Int_t fTotalPe[2];
+  Int_t fTubeID; //!< PMT ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
+  Int_t fmPMTID; //!< The mPMT number this 3" PMT is in (Equivlaent to fTubeID for 20" & OD PMTs)
+  Int_t fmPMT_PMTID; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
+  Int_t fTotalPe[2]; //!< 0th element: position in the WCSimRootCherenkovHitTime array where this PMTs' true hits start in this event. 1st element: Number of true hits on this PMT in this event. 
 
 public:
   WCSimRootCherenkovHit() {}
@@ -133,18 +150,23 @@ public:
   ClassDef(WCSimRootCherenkovHit,2)  
 };
 
+/**
+ * Class holding true (Cherenkov) hit information
+ *
+ * There is one entry per hit.
+ */
 class WCSimRootCherenkovHitTime : public TObject {
 
 private:
   // See jhfNtuple.h for the meaning of these data members:
-  Double_t fTruetime;
-  Int_t   fParentSavedTrackID;
-  Float_t fPhotonStartTime;
-  Float_t fPhotonStartPos[3];
-  Float_t fPhotonEndPos[3];
-  Float_t fPhotonStartDir[3];
-  Float_t fPhotonEndDir[3];
-  ProcessType_t fPhotonCreatorProcess;
+  Double_t fTruetime; //!< True hit time (unit: )
+  Int_t   fParentSavedTrackID; //!< Truth matching. ID of the parent track that created the Cherenkov photon that created this hit. Note that this is not the position in the WCSimRootTrack array - you do need to loop and check the ID. Note that if you are running in non-default mode and you are saving photon tracks, this will be the ID of the photon track. Note: for dark noise, this number is -1
+  Float_t fPhotonStartTime; //!< Start time of the photon that created this hit (unit: )
+  Float_t fPhotonStartPos[3]; //!< Start position (x,y,z) of the photon that created this hit (unit: )
+  Float_t fPhotonEndPos[3]; //!< End position (x,y,z) of the photon that created this hit (unit: )
+  Float_t fPhotonStartDir[3]; //< Start direction unit vector (x,y,z) of the photon that created this hit
+  Float_t fPhotonEndDir[3]; //< End direction unit vector (x,y,z) of the photon that created this hit
+  ProcessType_t fPhotonCreatorProcess; //!< Process that created the photon that created this hit
 
 public:
   WCSimRootCherenkovHitTime() {}
@@ -173,14 +195,19 @@ public:
   ClassDef(WCSimRootCherenkovHitTime,2)
 };
 
-// Scattering and reflection history for each Cherenkov hit (photon)
+/**
+ * Class holding scattering and reflection history for each Cherenkov hit (photon)
+ *
+ * There is one entry per hit.
+ * Note that this information is not filled, unless WCSim is compiled with -DWCSIM_SAVE_PHOTON_HISTORY_FLAG=ON (default OFF)
+ */
 class WCSimRootCherenkovHitHistory : public TObject {
 
 private:
   
-  Int_t   fNRayScat;
-  Int_t   fNMieScat;
-  std::vector<ReflectionSurface_t> fReflec;
+  Int_t   fNRayScat; //!< Number of Rayliegh scatters the photon that created this hit underwent
+  Int_t   fNMieScat; //!< Number of Mie scatters the photon that created this hit underwent
+  std::vector<ReflectionSurface_t> fReflec; //!< Surfaces of reflections that the photon that created this hit underwent
 
 public:
   WCSimRootCherenkovHitHistory() {}
@@ -198,17 +225,21 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
-
+/**
+ * Class holding scattering and reflection history for each digitised hit
+ *
+ * There is one entry per digit
+ */
 class WCSimRootCherenkovDigiHit : public TObject {
 
 private:
   // See jhfNtuple.h for the meaning of these data members:
-  Float_t fQ;
-  Double_t fT;
-  Int_t fTubeId;
-  Int_t fmPMTId;
-  Int_t fmPMT_PMTId;
-  std::vector<int> fPhotonIds;
+  Float_t fQ; //!< Digitised charge
+  Double_t fT; //!< Digitised time, relative to the digit time (date in the WCSimRootEventHeader) (unit: )
+  Int_t fTubeID; //!< PMT ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
+  Int_t fmPMTID; //!< The mPMT number this 3" PMT is in (Equivlaent to fTubeID for 20" & OD PMTs)
+  Int_t fmPMT_PMTID; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
+  std::vector<int> fPhotonIds; //!< Truth matching. Position in the CherenkovHitTime array that contains the true hit(s) that created this digit
 
 public:
   WCSimRootCherenkovDigiHit() {}
@@ -234,13 +265,16 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+/**
+ * Class containing header information for this trigger
+ */
 class WCSimRootEventHeader {
 
 private:
-  Int_t   fEvtNum;
-  Int_t   fRun;
-  int64_t fDate;
-  Int_t   fSubEvtNumber;
+  Int_t   fEvtNum; //!< Event number
+  Int_t   fRun; //!< Run number. Should be 0 for the first call of /run/beamOn, and increment for each subsequent call of /run/beamOn
+  int64_t fDate; //!< Time 
+  Int_t   fSubEvtNumber; //!< Trigger number. 0 for the first trigger (or if no trigger has been found), and increments for each subsequent trigger
 
 public:
   WCSimRootEventHeader() : fEvtNum(0), fRun(0), fDate(0), fSubEvtNumber(1) { }
@@ -259,14 +293,17 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+/**
+ * Class storing information about pi0 decays TOCHECKALL
+ */
 class WCSimRootPi0 : public TObject {
     // this is a class used specifically for Pi0 events
 
 private:
-  Float_t fPi0Vtx[3];
-  Int_t   fGammaID[2];
-  Float_t fGammaE[2];
-  Float_t fGammaVtx[2][3];
+  Float_t fPi0Vtx[3]; //!< pi0 vertex (x,y,z)
+  Int_t   fGammaID[2]; //!< Truth matching. Track ID of each gamma
+  Float_t fGammaE[2]; //!< Starting energy of each gamma
+  Float_t fGammaVtx[2][3]; //!< Starting position of each gamma?
 
 public:
   WCSimRootPi0() {}
@@ -290,12 +327,15 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+/**
+ * Information about gammas released from neutron capture TOCHECKALL
+ */
 class WCSimRootCaptureGamma : public TObject {
 
 private:
-  Int_t   fID;
-  Float_t fEnergy;
-  Float_t fDir[3];
+  Int_t   fID; //!<  Truth matching. Track ID of the gamma
+  Float_t fEnergy; //!< Energy of the gamma
+  Float_t fDir[3]; //!< Direction unit vector (x,y,z) of the gamma
 
 public:
   WCSimRootCaptureGamma() {}
@@ -316,18 +356,21 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+/**
+ * Class used specifically for neutron capture events TOCHECKALL
+ */
 class WCSimRootCapture : public TObject {
-  // this is a class used specifically for neutron capture events
+
 
 private:
-  Int_t   	   fCaptureParent;
-  Float_t 	   fCaptureVtx[3];
-  Int_t   	   fNGamma;
-  Float_t 	   fTotalGammaE;
-  Float_t 	   fCaptureT;
-  Int_t          fCaptureNucleus;
-  TClonesArray * fGammas;
-  bool 	   IsZombie;
+  Int_t   	   fCaptureParent; //!< Track ID of the parent neutron
+  Float_t 	   fCaptureVtx[3]; //!< Position of the neutron capture (x,y,z)
+  Int_t   	   fNGamma; //!< Number of gammas produced by the neutron capture
+  Float_t 	   fTotalGammaE; //!< Total gamma energy produced by the neutron capture
+  Float_t 	   fCaptureT; //!< Time of the neutron capture
+  Int_t          fCaptureNucleus; //!< Nucleus the neutron captured on
+  TClonesArray * fGammas; //!< Array of WCSimRootCaptureGamma storing detailed information about individual gammas released from the neutron capture
+  bool 	   IsZombie; //!< Will be true if unfilled, false if filled
 
 public:
   WCSimRootCapture() {
@@ -362,49 +405,58 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+/**
+ * Class storing trigger information
+ *
+ * Digitised hit information will be put in the WCSimRootTrigger it is associated with
+ * (if there are multiple overlapping trigger readout windows, digits will only be saved in the first
+ * trigger window they are associated with, to avoid double counting)
+ *
+ * True information (vertices, tracks, hits) are mostly put in the 0th WCSimRootTrigger
+ */
 class WCSimRootTrigger : public TObject {
 
 private:
-  WCSimRootEventHeader    fEvtHdr;  // The header
+  WCSimRootEventHeader    fEvtHdr;  //!< The header
   // See jhfNtuple.h for the meaning of these data members:
-  Int_t                fMode[MAX_N_VERTICES];
-  Int_t                fNvtxs;
-  Int_t                fVtxsvol[MAX_N_VERTICES];
-  Float_t              fVtxs[MAX_N_VERTICES][4];
-  Int_t                fVecRecNumber;       // "info event" number in inputvectorfile 
-  Int_t                fJmu;
-  Int_t                fJp;
+  Int_t                fMode[MAX_N_VERTICES]; //!<
+  Int_t                fNvtxs; //!< Number of true vertices in the event
+  Int_t                fVtxsvol[MAX_N_VERTICES]; //!< 
+  Float_t              fVtxs[MAX_N_VERTICES][4]; //!< True 4-position (x,y,z,t) of the vertex
+  Int_t                fVecRecNumber;       //!< "info event" number in inputvectorfile 
+  Int_t                fJmu; //!< 
+  Int_t                fJp; //!< 
 
-  WCSimRootPi0         fPi0;                // Pi0 info (default = not used)
+  WCSimRootPi0         fPi0;                //!< Pi0 info (default = not used)
 
-  TClonesArray         *fCaptures;           // Neutron capture info (default = not used)
-  Int_t                fNcaptures;           // Number of tracks in the array
+  TClonesArray         *fCaptures;           //!< Neutron capture info (default = not used)
+  Int_t                fNcaptures;           //!< Number of tracks in the neutron capture array
 
-  Int_t                fNpar;               // Number of particles
-  Int_t                fNtrack;             // Number of tracks in the array
-  Int_t                fNtrack_slots;       // Number of slots in the tracks array. This is potentially more than fNtrack (i.e. if any tracks have been removed that aren't at the very start/end)
-  TClonesArray         *fTracks;            //-> Array of WCSimRootTracks 
+  Int_t                fNpar;               //!< Number of particles ???
+  Int_t                fNtrack;             //!< Number of tracks in the WCSimRootTracks array
+  Int_t                fNtrack_slots;       //!< Number of slots in the WCSimRootTracks array. This is potentially more than fNtrack (i.e. if any tracks have been removed that aren't at the very start/end)
+  TClonesArray         *fTracks;            //!< Array of WCSimRootTracks 
 
-  Int_t                fNumTubesHit;         // Number of tubes hit
-  Int_t                fNcherenkovhits;      // Number of hits in the array
-  TClonesArray         *fCherenkovHits;      //-> Array of WCSimRootCherenkovHits
+  Int_t                fNumTubesHit;         //!< Number of tubes hit
+  Int_t                fNcherenkovhits;      //!< Number of hits in the array
+  TClonesArray         *fCherenkovHits;      //!< Array of WCSimRootCherenkovHits
 
-  Int_t                fCherenkovHitCounter;
-  Int_t                fNcherenkovhittimes;      // Number of hits in the array
-  TClonesArray         *fCherenkovHitTimes;      //-> Array of WCSimRootCherenkovHits
-  Int_t                fNcherenkovhithistories;      // Number of hits in the array
-  TClonesArray         *fCherenkovHitHistories;  //-> Array of WCSimRootCherenkovHitHistories
+  Int_t                fCherenkovHitCounter; //!< 
+  Int_t                fNcherenkovhittimes;      //!< Number of hits in the WCSimRootCherenkovHits array
+  TClonesArray         *fCherenkovHitTimes;      //!< Array of WCSimRootCherenkovHits
+  Int_t                fNcherenkovhithistories;      //!< Number of hits in the WCSimRootCherenkovHitHistories array. Should be identical to fNcherenkovhittimes
+  TClonesArray         *fCherenkovHitHistories;  //!< Array of WCSimRootCherenkovHitHistories
 
-  Int_t                fNumDigitizedTubes;  // Number of digitized tubes
-  Int_t                fNcherenkovdigihits;  // Number of digihits in the array
-  Int_t                fNcherenkovdigihits_slots;  // Number of slots in the digihits array. This is potentially more than fNcherenkovdigihits (i.e. if any digihits have been removed that aren't at the very start/end)
-  Float_t              fSumQ;
-  TClonesArray         *fCherenkovDigiHits;  //-> Array of WCSimRootCherenkovDigiHit's
+  Int_t                fNumDigitizedTubes;  //!< Number of digitized tubes
+  Int_t                fNcherenkovdigihits;  //!< Number of digihits in the WCSimRootCherenkovDigiHit array
+  Int_t                fNcherenkovdigihits_slots;  //!< Number of slots in the WCSimRootCherenkovDigiHit array. This is potentially more than fNcherenkovdigihits (i.e. if any digihits have been removed that aren't at the very start/end)
+  Float_t              fSumQ; //!< Sum of digitised hit charge in this trigger
+  TClonesArray         *fCherenkovDigiHits;  //!< Array of WCSimRootCherenkovDigiHit's
 
-  TriggerType_t        fTriggerType;         // Trigger algorithm that created this trigger
-  std::vector<Double_t> fTriggerInfo;         // Information about how it passed the trigger (e.g. how many hits in the NDigits window)
+  TriggerType_t        fTriggerType;         //!< Trigger algorithm that created this trigger
+  std::vector<Double_t> fTriggerInfo;         //!< Information about how it passed the trigger (e.g. how many hits in the NDigits window)
 
-  bool IsZombie;
+  bool IsZombie; //!< Will be true if unfilled, false if filled 
 
 public:
   WCSimRootTrigger();
@@ -540,7 +592,12 @@ public:
   ClassDef(WCSimRootTrigger,6) //WCSimRootEvent structure
 };
 
-
+/**
+ * Class containing event information
+ *
+ * Only events from a single PMT type (20" PMT OR 3" PMT in mPMT OR OD PMT) are available
+ * in a single WCSimRootEvent
+ */
 class WCSimRootEvent : public TObject {
 public:
   WCSimRootEvent();
@@ -600,7 +657,7 @@ public:
 
 private:
   //std::vector<WCSimRootTrigger*> fEventList;
-  TObjArray* fEventList;
+  TObjArray* fEventList; //!< Array of WCSimRootTrigger
   Int_t Current;                      //!               means transient, not writable to file
   ClassDef(WCSimRootEvent,3)
 

--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -15,17 +15,19 @@
 
 class TDirectory;
 
-//////////////////////////////////////////////////////////////////////////
+/** \class WCSimRootPMT
+ *  \brief PMT geometry information
+ */
 
 class WCSimRootPMT : public TObject {
 
 private:
-  Int_t fTubeNo;
-  Int_t fmPMTNo;
-  Int_t fmPMT_PMTNo;
-  Int_t fCylLoc;  // endcap1, wall, endcap2
-  Float_t fOrientation[3];
-  Float_t fPosition[3];
+  Int_t fTubeNo; //!< PMT tube ID. Unique number across all PMT types (i.e. runs from 0 to NPMTs, where NPMTs = N20" + NOD + N3"inMPMT)
+  Int_t fmPMTNo; //!< The mPMT number this 3" PMT is in (Equivalent to fTubeID for 20" & OD PMTs)
+  Int_t fmPMT_PMTNo; //!< The 3" PMT position ID inside this mPMT (runs from 1-19 for 3" PMTs inside mPMTs. Is 0 for 20" & OD PMTs)
+  Int_t fCylLoc;  //!< Distinguishes between PMT position p (top cap = 0, wall = 1, bottom cap = 2) & PMT type t (20" PMT in FD or 3" in mPMT in IWCD = 0, mPMT in FD = 2 / OD = 1). CylLoc = 3 * t + p
+  Float_t fOrientation[3]; //!< PMT direction unit vector pointing out of the glass into the detector volume
+  Float_t fPosition[3]; //!< PMT position vector. The position is defined as the ??? part of the PMT. Units: cm
 
 public:
   WCSimRootPMT();
@@ -55,28 +57,37 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+/** \class WCSimRootGeom
+ *  \brief Detector geometry information (also containing PMT information arrays)
+ *
+ * PMT information is stored based on the PMT type
+ * - ID PMTs of the first type are 20" (HK FD) or 3" PMTs inside mPMTs (IWCD)
+ * - ID PMTs of the second type are 3" PMTs inside mPMTs (HK FD)
+ * - OD PMTs are OD PMTs
+ */
+
 class WCSimRootGeom : public TObject {
 
 private:
 
-  Float_t                fWCCylRadius;  // Radius of WC tank
-  Float_t                fWCCylLength;  // Length of WC tank
+  Float_t                fWCCylRadius;  //!< Radius of WC tank. Units: cm
+  Float_t                fWCCylLength;  //!< Length of WC tank. Units: cm
 
-  Int_t                  fgeo_type;  // mailbox or cylinder?
+  Int_t                  fgeo_type;  //!< UNUSED mailbox or cylinder?
 
-  Float_t                fWCPMTRadius; // Radius of PMT
-  Float_t                fWCPMTRadius2; // Radius of PMT, hybrid case
-  Int_t                  fWCNumPMT;   // Number of PMTs
-  Int_t                  fWCNumPMT2;   // Number of PMTs, hybrid case
-  Float_t                fODWCPMTRadius; // Radius of OD PMT
+  Float_t                fWCPMTRadius; //!< Radius of ID PMT of the first type. Units: cm
+  Float_t                fWCPMTRadius2; // Radius of ID PMT of the second type. Units: cm
+  Int_t                  fWCNumPMT;   // Number of ID PMTs of the first type
+  Int_t                  fWCNumPMT2;   // Number of ID PMTs of the second type
+  Float_t                fODWCPMTRadius; // Radius of OD PMT. Units: cm
   Int_t                  fODWCNumPMT; // Number of OD PMTs
   Float_t                fWCOffset[3]; // Offset of barrel center in global coords
 
-  Int_t                  fOrientation; //Orientation o detector, 0 is 2km horizontal, 1 is Upright
+  Int_t                  fOrientation; //!< UNUSED Orientation of detector, 0 is 2km horizontal, 1 is Upright
 
-  TClonesArray           *fPMTArray;
-  TClonesArray           *fPMTArray2;
-  TClonesArray           *fODPMTArray;
+  TClonesArray           *fPMTArray; //!< Array of ID PMTs of the first type
+  TClonesArray           *fPMTArray2; //!< Array of ID PMTs of the second type
+  TClonesArray           *fODPMTArray; //!< Array of OD PMTs
 
 public:
 

--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -17,6 +17,8 @@ class TDirectory;
 
 /** \class WCSimRootPMT
  *  \brief PMT geometry information
+ *
+ * See the macro sample-root-scripts/read_number_of_PMTs.C for an example of using this class
  */
 
 class WCSimRootPMT : public TObject {
@@ -64,6 +66,8 @@ public:
  * - ID PMTs of the first type are 20" (HK FD) or 3" PMTs inside mPMTs (IWCD)
  * - ID PMTs of the second type are 3" PMTs inside mPMTs (HK FD)
  * - OD PMTs are OD PMTs
+ *
+ * See the macro sample-root-scripts/read_number_of_PMTs.C for an example of using this class
  */
 
 class WCSimRootGeom : public TObject {

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -23,7 +23,8 @@ using std::map;
 
 /**
  * \struct WCSimDarkNoiseOptions
- * Class to hold information about the chosen dark noise options.
+ * \brief Class to hold information about the chosen dark noise options.
+ *
  * There will be one copy of this class for each active PMT type in the output file.
  */
 struct WCSimDarkNoiseOptions {
@@ -43,8 +44,12 @@ struct WCSimDarkNoiseOptions {
 
 /** 
  * \class WCSimRootOptions
- * List of WCSim running options.
- * Note that not all options are currently included in this class
+ * \brief List of WCSim running options.
+ *
+ * Note that not all options are currently included in this class.
+ *
+ * When looking up the values, it is recommended to use the Print() function (examples in multiple macros).
+ * Values can also be accessed progammatically with the getters
  */
 class WCSimRootOptions : public TObject {
 

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -21,13 +21,18 @@ using std::map;
 
 //////////////////////////////////////////////////////////////////////////
 
+/**
+ * \struct WCSimDarkNoiseOptions
+ * Class to hold information about the chosen dark noise options.
+ * There will be one copy of this class for each active PMT type in the output file.
+ */
 struct WCSimDarkNoiseOptions {
-  double PMTDarkRate; // kHz
-  double ConvRate; // kHz
-  double DarkHigh; // ns
-  double DarkLow; // ns
-  double DarkWindow; // ns
-  int    DarkMode;  
+  double PMTDarkRate; //!< Dark rate for this PMT type (unit: kHz)
+  double ConvRate; //!< Conversion factor used to ensure that the dark rate is as requested. More true dark hits are generated, such that the final digitised dark noise rate is correct (hits are reduced due to thresholds, integration, etc. in the PMT & electronics simulation)
+  double DarkHigh; //!< In dark mode 0, the end time of the fixed dark noise window (unit: ns)
+  double DarkLow; //!< In dark mode 0, the start time of the fixed dark noise window (unit: ns)
+  double DarkWindow; //!< In dark mode 1, dark hits are added to a window of size ±DarkWindow/2 around true physics hits (unit: ns)
+  int    DarkMode;  //!< Mode 0: add dark noise in a fixed window. Mode 1: add dark noise around true physics hits
   WCSimDarkNoiseOptions() :
     PMTDarkRate(-999), ConvRate(-999), DarkHigh(-999), DarkLow(-999),
     DarkWindow(-999), DarkMode(-999)
@@ -36,6 +41,11 @@ struct WCSimDarkNoiseOptions {
 
 //////////////////////////////////////////////////////////////////////////
 
+/** 
+ * \class WCSimRootOptions
+ * List of WCSim running options.
+ * Note that not all options are currently included in this class
+ */
 class WCSimRootOptions : public TObject {
 
 public:
@@ -156,61 +166,61 @@ public:
 
 private:
   //WCSimDetector*
-  string DetectorName;
-  bool   GeomHasOD;
-  bool   SavePi0;
-  int    PMTQEMethod;
-  int    PMTCollEff;
+  string DetectorName; //!< Name of the detector geometry
+  bool   GeomHasOD; //!< Does the detector contain active OD PMTs?
+  bool   SavePi0; //!< Is more information about Pi0 decays saved?
+  int    PMTQEMethod; //!< 
+  int    PMTCollEff; //!< Is the PMT collection efficiency turned on?
   
   //WCSimWCAddDarkNoise
-  map<string, WCSimDarkNoiseOptions> DarkOptMap;
+  map<string, WCSimDarkNoiseOptions> DarkOptMap; //!< Maps active PMT types (string) with information on that PMT types' dark noise running options (WCSimDarkNoiseOptions)
 
   //WCSimWCDigitizer*
-  string DigitizerClassName;
-  int    DigitizerDeadTime; // ns
-  int    DigitizerIntegrationWindow; // ns
-  int    DigitizerTimingPrecision; // 
-  int    DigitizerPEPrecision; // 
+  string DigitizerClassName; //!< The active digitiser
+  int    DigitizerDeadTime; //!< The digitiser dead time (digitiser cannot integrate hits for this duration after a hit) (unit: ns)
+  int    DigitizerIntegrationWindow; //!< The digitiser integration time (unit: ns)
+  int    DigitizerTimingPrecision; //!< The digitiser timing precision. Hit times are truncated to this level (unit: ns)
+  int    DigitizerPEPrecision; //!< The digitiser charge precision. Hit charges are truncated to this level (unit: same as digitised charge (p.e.?))
 
   //WCSimWCTrigger*
-  string TriggerClassName;
-  bool   MultiDigitsPerTrigger;
+  string TriggerClassName; //!< The active trigger
+  bool   MultiDigitsPerTrigger; //!< Are multiple digits from the same PMT allowed to be read out in the same trigger readout window?
+  double TriggerOffset; //!< Triggered digit time = digit time - trigger time + this offset (unit: ns)
   //ndigits
-  int    NDigitsThreshold; // digitized hits
-  int    NDigitsWindow; // ns
-  bool   NDigitsAdjustForNoise;
-  int    NDigitsPreTriggerWindow; // ns
-  int    NDigitsPostTriggerWindow; // ns
-  double TriggerOffset; //ns
+  int    NDigitsThreshold; //!< For the NDigits trigger, how many digitised hits in the trigger decision window will make the trigger fire?
+  int    NDigitsWindow; //!< For the NDigits trigger, what is the length of the sliding trigger decision window? (unit: ns)
+  bool   NDigitsAdjustForNoise; //!< Should the NDigits threshold be automatically increased based on the average dark noise contribution in the trigger decision window?
+  int    NDigitsPreTriggerWindow; //!< For a positive trigger, how long before the issued trigger time should be read out? (unit: ns)
+  int    NDigitsPostTriggerWindow; //!< For a positive trigger, how long after the issued trigger time should be read out? (unit: ns)
   //savefailures
-  int    SaveFailuresMode;
-  double SaveFailuresTime; // ns
-  int    SaveFailuresPreTriggerWindow; // ns
-  int    SaveFailuresPostTriggerWindow; // ns
+  int    SaveFailuresMode; //!< 0: Digits that are part of a trigger readout window are saved, those that aren't are lost. 1: Both are saved. 2: Only triggers that are not part of a trigger readout window (but are in the special SaveFailures trigger window) are saved.
+  double SaveFailuresTime; //!< Trigger time for the special SaveFailures trigger (unit: ns)
+  int    SaveFailuresPreTriggerWindow; //!< How long before the special SaveFailures trigger time should digitised hits not associated with a real trigger be read out? (unit: ns)
+  int    SaveFailuresPostTriggerWindow; //!< How long after the special SaveFailures trigger time should digitised hits not associated with a real trigger be read out? (unit: ns)
 
   //WCSimTuningParameters
-  double Rayff;
-  double Bsrff;
-  double Abwff;
-  double Rgcff;
-  double Qeff;
-  double Mieff;
-  double Ttsff;
-  // double Qoiff; //TD 2019.6.26
-  double PmtSatur; //TD 2019.07.16
-  double Tvspacing;
-  bool   Topveto;
+  double Rayff; //!< Rayleigh scattering parameter
+  double Bsrff; //!< Blacksheet reflection parameter
+  double Abwff; //!< Water attenuation parameter
+  double Rgcff; //!< Cathode reflectivity parameter
+  double Qeff;  //!< Correction to cathode quantum efficiency parameter
+  double Mieff; //!< Mie scattering parameter
+  double Ttsff; //!< Transit time smearing for PMTs
+  // double Qoiff; //!< Uncertainty on amount of charge created in a PMT
+  double PmtSatur; //!< p.e. threshold where saturation starts to occur
+  double Tvspacing; //!< Top veto PMT spacing
+  bool   Topveto; //!< Is the top veto defined in the simulation?
 
   //WCSimPhysicsListFactory
-  string PhysicsListName;
+  string PhysicsListName; //!< The active physics list
 
   //WCSimPrimaryGeneratorAction
-  string VectorFileName;
-  string GeneratorType;
+  string VectorFileName; //!< The name of the input vector file (used for some generators e.g. muline, rootracker, datatable, ...)
+  string GeneratorType; //!< The active generator type
 
   //WCSimRandomParameters
-  int                    RandomSeed;
-  WCSimRandomGenerator_t RandomGenerator;
+  int                    RandomSeed; //!< The initial seed for one of the random number generators
+  WCSimRandomGenerator_t RandomGenerator; //!< The random number generator type
   
   ClassDef(WCSimRootOptions,5)
 };

--- a/sample-root-scripts/read_number_of_PMTs.C
+++ b/sample-root-scripts/read_number_of_PMTs.C
@@ -24,9 +24,23 @@ int read_number_of_PMTs(const char *filename="../wcsim.root")
   TBranch *gb = tree->GetBranch("wcsimrootgeom");
   gb->SetAddress(&geom);
   tree->GetEntry(0);
-  Printf("Number of 20\" PMTs: %d", geom->GetWCNumPMT());
+  Printf("Number of ID PMTs of the first type (e.g. 20\" PMTs in HK FD, 3\" PMTs in mPMTs in IWCD): %d", geom->GetWCNumPMT());
   Printf("Number of OD PMTs: %d", geom->GetODWCNumPMT());
-  Printf("Number of mPMTs: %d", geom->GetWCNumPMT(true));
+  Printf("Number of ID PMTs of the second type (e.g. 3\" PMTs in mPMTs in HK FD): %d", geom->GetWCNumPMT(true));
+
+  cout << "Tank radius & height: "
+       << geom->GetWCCylRadius() << "\t"
+       << geom->GetWCCylLength() << endl;
+
+  //printout of the first few PMTs of the first type
+  // See WCSimRootGeom.hh for how to get more PMT information,
+  // and for how to get information about other PMT types
+  cout << "PMT radius " << geom->GetWCPMTRadius(false) << endl;
+  for(int i = 0; i < 10; i++)
+    cout << "PMT " << i << "\tX, Y, Z: "
+	 << geom->GetPMT(i).GetPosition(0) << ",\t"
+	 << geom->GetPMT(i).GetPosition(1) << ",\t"
+	 << geom->GetPMT(i).GetPosition(2) << endl;
 
   return 0;
 }

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -149,7 +149,8 @@ int sample_readfile(const char *filename="../wcsim.root", TString events_tree_na
         else if(trackflag==-2) cout<<"Neutrino target nucleus track"<<endl;
         else cout<<"Final state particle track"<<endl;
         printf("  Track ipnu (PDG code): %d\n",wcsimroottrack->GetIpnu());
-        printf("  PDG code of parent particle (0 for primary): %d\n",wcsimroottrack->GetParenttype());
+        printf("  PDG code of parent particle (0 for primary, 999 for parent PDG code not found in the specific logic used): %d\n",wcsimroottrack->GetParenttype());
+	printf("  Track ID of parent particle (0 for primary): %d\n",wcsimroottrack->GetParentId());
             
         cout<<"  Track initial dir [unit 3-vector]: ("
             <<wcsimroottrack->GetDir(0)<<", "

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1568,7 +1568,7 @@ G4String WCSimPrimaryGeneratorAction::GetGeneratorTypeString()
 {
   if(useMulineEvt)
     return "muline";
-  if(useAmBeEvt)
+  else if(useAmBeEvt)
     return "ambeevt";
   else if(useGunEvt)
     return "gun";
@@ -1584,6 +1584,18 @@ G4String WCSimPrimaryGeneratorAction::GetGeneratorTypeString()
     return "cosmics";
   else if (useMPMTledEvt)
     return "mPMT-LED";
+  else if(useIBDEvt)
+    return "IBD";
+  else if(useDataTableEvt)
+    return "data-table";
+  else if(useCosmics)
+    return "cosmics";
+  else if(useRadioactiveEvt)
+    return "radioactivity";
+  else if(useRadonEvt)
+    return "radon";
+  else if(useLightInjectorEvt)
+    return "light-injector";
   return "";
 }
 

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -56,7 +56,7 @@ void WCSimRootOptions::Print(Option_t *) const
       
 	 << "Trigger options:" << endl
 	 << "\tTriggerClassName: " << TriggerClassName << endl
-	 << "\tTriggerOffset: " << TriggerOffset << endl
+	 << "\tTriggerOffset: " << TriggerOffset << " ns" << endl
 	 << "\tMultiDigitsPerTrigger: " << MultiDigitsPerTrigger << endl
 	 << "NDigits-style trigger options:" << endl
 	 << "\tNDigitsThreshold: " << NDigitsThreshold << " digitized hits" << endl


### PR DESCRIPTION
Work in progress to doxygen-ify the classes & data members of `WCSimRoot*` classes (basically everything saved in the output file). Useful so that everyone understands what information is available, exactly what it all means, what the units are, etc.

See https://wcsim.github.io/WCSim/annotated.html for the current doxygen build