### PR TITLE
Make the rootracker tree available to be passed through again

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -281,6 +281,11 @@
 # define units used for time in kin file
 #/mygen/time_unit ns
 
+## Or you can use a rootracker-formated generator file
+## (e.g. from NEUT)
+#/mygen/generator rootracker
+#/mygen/vecfile vector_neg_1e22_HK_Tochibora_LBL2019Mar_0099.root
+
 ## Or you can use the G4 Particle Gun
 ## for a full list of /gun/ commands see:
 ## http://geant4.web.cern.ch/geant4/G4UsersDocuments/UsersGuides/ForApplicationDeveloper/html/Control/UIcommands/_gun_.html

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1645,7 +1645,6 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   //G4cout <<"WCFV digi sumQ:"<<std::setw(4)<<wcsimrootevent->GetSumQ()<<"  ";
   //  }
 
-  /*
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
   if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
@@ -1653,7 +1652,6 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
       generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex()); //will increment NVtx
       GetRunAction()->FillRootrackerVertexTree();
   }
-  */
 
 }
 
@@ -2182,7 +2180,6 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
   //G4cout <<"WCFV digi sumQ:"<<std::setw(4)<<wcsimrootevent->GetSumQ()<<"  ";
   //  }
 
-  /*
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
   if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
@@ -2190,7 +2187,6 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
       generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex()); //will increment NVtx
       GetRunAction()->FillRootrackerVertexTree();
   }
-  */
 }
 
 


### PR DESCRIPTION
Not fully tested yet - need to get a rootracker file with the same format as in the WCSim version of `TNRooTrackerVtx.hh` (my hypothesis for why my tests seg fault)