### PR TITLE
Update G4MultiUnion and G4Voxelizer

### DIFF
--- a/include/G4MultiUnion_v1072.hh
+++ b/include/G4MultiUnion_v1072.hh
@@ -29,21 +29,20 @@
 // GEANT 4 class header file
 //
 // 
-// G4MultiUnion_v1051
+// G4MultiUnion_v1072
 //
 // Class description:
 //
-//   An instance of "G4MultiUnion_v1051" constitutes a grouping of several solids.
+//   An instance of "G4MultiUnion_v1072" constitutes a grouping of several solids.
 //   The constituent solids are stored with their respective location in an
-//   instance of "G4Node". An instance of "G4MultiUnion_v1051" is subsequently
+//   instance of "G4Node". An instance of "G4MultiUnion_v1072" is subsequently
 //   composed of one or several nodes.
 
-// History:
-// 06.04.17 G.Cosmo - Imported implementation in Geant4 for VecGeom migration
 // 19.10.12 M.Gayer - Original implementation from USolids module
+// 06.04.17 G.Cosmo - Adapted implementation in Geant4 for VecGeom migration
 // --------------------------------------------------------------------
-#ifndef G4MULTIUNION_V1051_HH
-#define G4MULTIUNION_V1051_HH
+#ifndef G4MULTIUNION_V1072_HH
+#define G4MULTIUNION_V1072_HH
 
 #include <vector>
 
@@ -53,25 +52,25 @@
 #include "G4Point3D.hh"
 #include "G4Vector3D.hh"
 #include "G4SurfBits.hh"
-#include "G4Voxelizer_v1051.hh"
+#include "G4Voxelizer_v1072.hh"
 
 class G4Polyhedron;
 
-class G4MultiUnion_v1051 : public G4VSolid
+class G4MultiUnion_v1072 : public G4VSolid
 {
-    friend class G4Voxelizer_v1051;
+    friend class G4Voxelizer_v1072;
 
   public:
 
-    G4MultiUnion_v1051() : G4VSolid("") {}
-    G4MultiUnion_v1051(const G4String& name);
-    ~G4MultiUnion_v1051();
+    G4MultiUnion_v1072() : G4VSolid("") {}
+    G4MultiUnion_v1072(const G4String& name);
+    ~G4MultiUnion_v1072();
 
     // Build the multiple union by adding nodes
     void AddNode(G4VSolid& solid, G4Transform3D& trans);
 
-    G4MultiUnion_v1051(const G4MultiUnion_v1051& rhs);
-    G4MultiUnion_v1051& operator=(const G4MultiUnion_v1051& rhs);
+    G4MultiUnion_v1072(const G4MultiUnion_v1072& rhs);
+    G4MultiUnion_v1072& operator=(const G4MultiUnion_v1072& rhs);
 
     // Accessors
     inline const G4Transform3D& GetTransformation(G4int index) const;
@@ -93,9 +92,9 @@ class G4MultiUnion_v1051 : public G4VSolid
                           const G4ThreeVector& aDirection) const;
     G4double DistanceToOut(const G4ThreeVector& aPoint,
                            const G4ThreeVector& aDirection,
-                           const G4bool calcNorm=false,
-                           G4bool *validNorm=0,
-                           G4ThreeVector *aNormalVector=0) const;
+                           const G4bool calcNorm = false,
+                           G4bool* validNorm = nullptr,
+                           G4ThreeVector* aNormalVector = nullptr) const;
 
     G4double DistanceToInNoVoxels(const G4ThreeVector& aPoint,
                                   const G4ThreeVector& aDirection) const;
@@ -124,14 +123,14 @@ class G4MultiUnion_v1051 : public G4VSolid
 
     G4VSolid* Clone() const ;
 
-    G4GeometryType GetEntityType() const { return "G4MultiUnion_v1051"; }
+    G4GeometryType GetEntityType() const { return "G4MultiUnion_v1072"; }
 
     void Voxelize();
       // Finalize and prepare for use. User MUST call it once before
       // navigation use.
 
     EInside InsideNoVoxels(const G4ThreeVector& aPoint) const;
-    inline G4Voxelizer_v1051& GetVoxels() const;
+    inline G4Voxelizer_v1072& GetVoxels() const;
 
     std::ostream& StreamInfo(std::ostream& os) const;
 
@@ -141,7 +140,7 @@ class G4MultiUnion_v1051 : public G4VSolid
     G4Polyhedron* CreatePolyhedron () const ;
     G4Polyhedron* GetPolyhedron () const;
 
-    G4MultiUnion_v1051(__void__&);
+    G4MultiUnion_v1072(__void__&);
       // Fake default constructor for usage restricted to direct object
       // persistency for clients requiring preallocation of memory for
       // persistifiable objects.
@@ -178,49 +177,49 @@ class G4MultiUnion_v1051 : public G4VSolid
 
     std::vector<G4VSolid*> fSolids;
     std::vector<G4Transform3D> fTransformObjs;
-    G4Voxelizer_v1051 fVoxels;           // Pointer to the vozelized solid
-    G4double       fCubicVolume;   // Cubic Volume
-    G4double       fSurfaceArea;   // Surface Area
-    G4double       kRadTolerance;  // Cached radial tolerance
-    mutable G4bool fAccurate;      // Accurate safety (off by default)
+    G4Voxelizer_v1072 fVoxels;              // Vozelizer for the solid
+    G4double fCubicVolume = 0.0;      // Cubic Volume
+    G4double fSurfaceArea = 0.0;      // Surface Area
+    G4double kRadTolerance;           // Cached radial tolerance
+    mutable G4bool fAccurate = false; // Accurate safety (off by default)
 
-    mutable G4bool fRebuildPolyhedron;
-    mutable G4Polyhedron* fpPolyhedron;
+    mutable G4bool fRebuildPolyhedron = false;
+    mutable G4Polyhedron* fpPolyhedron = nullptr;
 };
 
 //______________________________________________________________________________
-inline G4Voxelizer_v1051& G4MultiUnion_v1051::GetVoxels() const
+inline G4Voxelizer_v1072& G4MultiUnion_v1072::GetVoxels() const
 {
-  return (G4Voxelizer_v1051&)fVoxels;
+  return (G4Voxelizer_v1072&)fVoxels;
 }
 
 //______________________________________________________________________________
-inline const G4Transform3D& G4MultiUnion_v1051::GetTransformation(G4int index) const
+inline const G4Transform3D& G4MultiUnion_v1072::GetTransformation(G4int index) const
 {
   return fTransformObjs[index];
 }
 
 //______________________________________________________________________________
-inline G4VSolid* G4MultiUnion_v1051::GetSolid(G4int index) const
+inline G4VSolid* G4MultiUnion_v1072::GetSolid(G4int index) const
 {
   return fSolids[index];
 }
 
 //______________________________________________________________________________
-inline G4int G4MultiUnion_v1051::GetNumberOfSolids() const
+inline G4int G4MultiUnion_v1072::GetNumberOfSolids() const
 {
-  return fSolids.size();
+  return G4int(fSolids.size());
 }
 
 //______________________________________________________________________________
-inline void G4MultiUnion_v1051::SetAccurateSafety(G4bool flag)
+inline void G4MultiUnion_v1072::SetAccurateSafety(G4bool flag)
 {
   fAccurate = flag;
 }
 
 //______________________________________________________________________________
 inline
-G4ThreeVector G4MultiUnion_v1051::GetLocalPoint(const G4Transform3D& trans,
+G4ThreeVector G4MultiUnion_v1072::GetLocalPoint(const G4Transform3D& trans,
                                           const G4ThreeVector& global) const
 {
   // Returns local point coordinates converted from the global frame defined
@@ -232,7 +231,7 @@ G4ThreeVector G4MultiUnion_v1051::GetLocalPoint(const G4Transform3D& trans,
 
 //______________________________________________________________________________
 inline
-G4ThreeVector G4MultiUnion_v1051::GetLocalVector(const G4Transform3D& trans,
+G4ThreeVector G4MultiUnion_v1072::GetLocalVector(const G4Transform3D& trans,
                                            const G4ThreeVector& global) const
 {
   // Returns local point coordinates converted from the global frame defined
@@ -249,7 +248,7 @@ G4ThreeVector G4MultiUnion_v1051::GetLocalVector(const G4Transform3D& trans,
 
 //______________________________________________________________________________
 inline
-G4ThreeVector G4MultiUnion_v1051::GetGlobalPoint(const G4Transform3D& trans,
+G4ThreeVector G4MultiUnion_v1072::GetGlobalPoint(const G4Transform3D& trans,
                                            const G4ThreeVector& local) const
 {
   // Returns global point coordinates converted from the local frame defined
@@ -261,7 +260,7 @@ G4ThreeVector G4MultiUnion_v1051::GetGlobalPoint(const G4Transform3D& trans,
 
 //______________________________________________________________________________
 inline
-G4ThreeVector G4MultiUnion_v1051::GetGlobalVector(const G4Transform3D& trans,
+G4ThreeVector G4MultiUnion_v1072::GetGlobalVector(const G4Transform3D& trans,
                                             const G4ThreeVector& local) const
 {
   // Returns vector components converted from the local frame defined by the

--- a/include/G4Voxelizer_v1072.hh
+++ b/include/G4Voxelizer_v1072.hh
@@ -28,19 +28,17 @@
 // --------------------------------------------------------------------
 // GEANT 4 class header file
 //
-// G4Voxelizer_v1051
+// G4Voxelizer_v1072
 //
 // Class description:
 //
 // Voxelizer for tessellated surfaces and solids positioning in 3D space,
 // used in G4TessellatedSolid and G4MultiUnion.
 
-// History:
 // 19.10.12 Marek Gayer, created
 // --------------------------------------------------------------------
-
-#ifndef G4Voxelizer_v1051_HH
-#define G4Voxelizer_v1051_HH
+#ifndef G4VOXELIZER_V1072_HH
+#define G4VOXELIZER_V1072_HH
 
 #include <vector>
 #include <string>
@@ -53,93 +51,93 @@
 #include "G4VFacet.hh"
 #include "G4VSolid.hh"
 
-struct G4VoxelBox_v1051
+struct G4VoxelBox_v1072
 {
   G4ThreeVector hlen; // half length of the box
   G4ThreeVector pos; // position of the box
 };
 
-struct G4VoxelInfo_v1051
+struct G4VoxelInfo_v1072
 {
   G4int count;
   G4int previous;
   G4int next;
 };
 
-class G4Voxelizer_v1051
+class G4Voxelizer_v1072
 {
   public:
 
     template <typename T> 
-    static inline G4int BinarySearch(const std::vector<T> &vec, T value);
+    static inline G4int BinarySearch(const std::vector<T>& vec, T value);
 
-    void Voxelize(std::vector<G4VSolid *> &solids,
+    void Voxelize(std::vector<G4VSolid*>& solids,
                   std::vector<G4Transform3D>& transforms);
-    void Voxelize(std::vector<G4VFacet *> &facets);
+    void Voxelize(std::vector<G4VFacet*>& facets);
 
     void DisplayVoxelLimits() const;
     void DisplayBoundaries();
     void DisplayListNodes() const;
 
-    G4Voxelizer_v1051();
-   ~G4Voxelizer_v1051();
+    G4Voxelizer_v1072();
+   ~G4Voxelizer_v1072();
 
-    void GetCandidatesVoxel(std::vector<G4int> &voxels);
+    void GetCandidatesVoxel(std::vector<G4int>& voxels);
       // Method displaying the nodes located in a voxel characterized
       // by its three indexes.
 
-    G4int GetCandidatesVoxelArray(const G4ThreeVector &point,
-                                        std::vector<G4int> &list,
-                                        G4SurfBits *crossed=0) const;
+    G4int GetCandidatesVoxelArray(const G4ThreeVector& point,
+                                        std::vector<G4int>& list,
+                                        G4SurfBits* crossed = nullptr) const;
       // Method returning in a vector container the nodes located in a voxel
       // characterized by its three indexes.
-    G4int GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
+    G4int GetCandidatesVoxelArray(const std::vector<G4int>& voxels,
                                   const G4SurfBits bitmasks[],
-                                        std::vector<G4int> &list,
-                                        G4SurfBits *crossed=0) const;
-    G4int GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
-                                        std::vector<G4int> &list,
-                                        G4SurfBits *crossed=0)const;
+                                        std::vector<G4int>& list,
+                                        G4SurfBits* crossed = nullptr) const;
+    G4int GetCandidatesVoxelArray(const std::vector<G4int>& voxels,
+                                        std::vector<G4int>& list,
+                                        G4SurfBits* crossed = nullptr)const;
 
-    inline const std::vector<G4VoxelBox_v1051> &GetBoxes() const;
+    inline const std::vector<G4VoxelBox_v1072>& GetBoxes() const;
       // Method returning the pointer to the array containing the
       // characteristics of each box.
 
-    inline const std::vector<G4double> &GetBoundary(G4int index) const;
+    inline const std::vector<G4double>& GetBoundary(G4int index) const;
 
-    G4bool UpdateCurrentVoxel(const G4ThreeVector &point,
-                              const G4ThreeVector &direction,
-                                    std::vector<G4int> &curVoxel) const;
+    G4bool UpdateCurrentVoxel(const G4ThreeVector& point,
+                              const G4ThreeVector& direction,
+                                    std::vector<G4int>& curVoxel) const;
 
-    inline void GetVoxel(std::vector<G4int> &curVoxel,
-                         const G4ThreeVector &point) const;
+    inline void GetVoxel(std::vector<G4int>& curVoxel,
+                         const G4ThreeVector& point) const;
 
     inline G4int GetBitsPerSlice () const;
 
-    G4bool Contains(const G4ThreeVector &point) const;
+    G4bool Contains(const G4ThreeVector& point) const;
 
-    G4double DistanceToNext(const G4ThreeVector &point,
-                            const G4ThreeVector &direction,
-                                  std::vector<G4int> &curVoxel) const;
+    G4double DistanceToNext(const G4ThreeVector& point,
+                            const G4ThreeVector& direction,
+                                  std::vector<G4int>& curVoxel) const;
 
-    G4double DistanceToFirst(const G4ThreeVector &point,
-                             const G4ThreeVector &direction) const;
+    G4double DistanceToFirst(const G4ThreeVector& point,
+                             const G4ThreeVector& direction) const;
 
-    G4double DistanceToBoundingBox(const G4ThreeVector &point) const;
+    G4double DistanceToBoundingBox(const G4ThreeVector& point) const;
 
     inline G4int GetVoxelsIndex(G4int x, G4int y, G4int z) const;
-    inline G4int GetVoxelsIndex(const std::vector<G4int> &voxels) const;
+    inline G4int GetVoxelsIndex(const std::vector<G4int>& voxels) const;
     inline G4bool GetPointVoxel(const G4ThreeVector& p,
                                 std::vector<G4int>& voxels) const;
-    inline G4int GetPointIndex(const G4ThreeVector &p) const;
+    inline G4int GetPointIndex(const G4ThreeVector& p) const;
 
-    inline const G4SurfBits &Empty() const;
+    inline const G4SurfBits& Empty() const;
     inline G4bool IsEmpty(G4int index) const;
 
     void SetMaxVoxels(G4int max);
-    void SetMaxVoxels(const G4ThreeVector &reductionRatio);
+    void SetMaxVoxels(const G4ThreeVector& reductionRatio);
 
-    inline G4int GetMaxVoxels(G4ThreeVector &ratioOfReduction);
+    inline G4int GetMaxVoxels(G4ThreeVector& ratioOfReduction);
 
     G4int AllocatedMemory();
 
@@ -147,19 +145,19 @@ class G4Voxelizer_v1051
 
     inline long long CountVoxels(std::vector<G4double> boundaries[]) const;
 
-    inline const std::vector<G4int> &
-                 GetCandidates(std::vector<G4int> &curVoxel) const;
+    inline const std::vector<G4int>&
+                 GetCandidates(std::vector<G4int>& curVoxel) const;
 
     inline G4int GetVoxelBoxesSize() const;
 
-    inline const G4VoxelBox_v1051 &GetVoxelBox(G4int i) const;
+    inline const G4VoxelBox_v1072 &GetVoxelBox(G4int i) const;
 
-    inline const std::vector<G4int> &GetVoxelBoxCandidates(G4int i) const;
+    inline const std::vector<G4int>& GetVoxelBoxCandidates(G4int i) const;
 
     inline G4int GetTotalCandidates() const;
 
-    static G4double MinDistanceToBox (const G4ThreeVector &aPoint,
-                                      const G4ThreeVector &f);
+    static G4double MinDistanceToBox (const G4ThreeVector& aPoint,
+                                      const G4ThreeVector& f);
 
     static void SetDefaultVoxelsCount(G4int count);
 
@@ -171,13 +169,13 @@ class G4Voxelizer_v1051
     {
       public:
 
-      std::vector<G4VoxelInfo_v1051> &fVoxels;
+      std::vector<G4VoxelInfo_v1072>& fVoxels;
 
-      G4VoxelComparator(std::vector<G4VoxelInfo_v1051> &voxels) : fVoxels(voxels) {}
+      G4VoxelComparator(std::vector<G4VoxelInfo_v1072>& voxels) : fVoxels(voxels) {}
 
       G4bool operator()(const G4int& l, const G4int& r) const
       {
-        G4VoxelInfo_v1051 &lv = fVoxels[l], &rv = fVoxels[r];
+        G4VoxelInfo_v1072 &lv = fVoxels[l], &rv = fVoxels[r];
         G4int left = lv.count +  fVoxels[lv.next].count;
         G4int right = rv.count + fVoxels[rv.next].count;
         return (left == right) ? l < r : left < right;
@@ -188,9 +186,9 @@ class G4Voxelizer_v1051
 
     void BuildEmpty ();
 
-    G4String GetCandidatesAsString(const G4SurfBits &bits) const;
+    G4String GetCandidatesAsString(const G4SurfBits& bits) const;
 
-    void CreateSortedBoundary(std::vector<G4double> &boundaryRaw, G4int axis);
+    void CreateSortedBoundary(std::vector<G4double>& boundaryRaw, G4int axis);
 
     void BuildBoundaries();
 
@@ -201,23 +199,23 @@ class G4Voxelizer_v1051
 
     void BuildVoxelLimits(std::vector<G4VSolid*>& solids,
                           std::vector<G4Transform3D>& transforms);
-    void BuildVoxelLimits(std::vector<G4VFacet *> &facets);
+    void BuildVoxelLimits(std::vector<G4VFacet*>& facets);
 
-    void DisplayBoundaries(std::vector<G4double> &fBoundaries);
+    void DisplayBoundaries(std::vector<G4double>& fBoundaries);
 
     void BuildBitmasks(std::vector<G4double> fBoundaries[],
-                       G4SurfBits bitmasks[], G4bool countsOnly=false);
+                       G4SurfBits bitmasks[], G4bool countsOnly = false);
 
     void BuildBoundingBox();
     void BuildBoundingBox(G4ThreeVector& amin, G4ThreeVector& amax,
-                          G4double tolerance = 0);
+                          G4double tolerance = 0.0);
 
-    void SetReductionRatio(G4int maxVoxels, G4ThreeVector &reductionRatio);
+    void SetReductionRatio(G4int maxVoxels, G4ThreeVector& reductionRatio);
 
     void CreateMiniVoxels(std::vector<G4double> fBoundaries[],
                           G4SurfBits bitmasks[]);
     static void FindComponentsFastest(unsigned int mask,
-                                      std::vector<G4int> &list, G4int i);
+                                      std::vector<G4int>& list, G4int i);
 
     inline G4ThreeVector GetGlobalPoint(const G4Transform3D& trans,
                                         const G4ThreeVector& lpoint) const;
@@ -228,7 +226,7 @@ class G4Voxelizer_v1051
 
     static G4ThreadLocal G4int fDefaultVoxelsCount;
 
-    std::vector<G4VoxelBox_v1051> fVoxelBoxes;
+    std::vector<G4VoxelBox_v1072> fVoxelBoxes;
     std::vector<std::vector<G4int> > fVoxelBoxesCandidates;
     mutable std::map<G4int, std::vector<G4int> > fCandidates;
 
@@ -238,7 +236,7 @@ class G4Voxelizer_v1051
 
     G4int fNPerSlice;
 
-    std::vector<G4VoxelBox_v1051> fBoxes;
+    std::vector<G4VoxelBox_v1072> fBoxes;
       // Array of box limits on the 3 cartesian axis
 
     std::vector<G4double> fBoundaries[3];
@@ -265,31 +263,36 @@ class G4Voxelizer_v1051
     G4SurfBits fEmpty;
 };
 
+//
+// G4Voxelizer_v1072 inline methods
+//
+// 19.10.12 Marek Gayer, created
+// --------------------------------------------------------------------
+
 template <typename T> inline
-G4int G4Voxelizer_v1051::BinarySearch(const std::vector<T> &vec, T value)
+G4int G4Voxelizer_v1072::BinarySearch(const std::vector<T>& vec, T value)
 {
-  typename std::vector<T>::const_iterator begin=vec.begin(), end=vec.end();
-  G4int res = std::upper_bound(begin, end, value) - begin - 1;
-  return res;
+  typename std::vector<T>::const_iterator begin=vec.cbegin(), end=vec.cend();
+  return G4int(std::upper_bound(begin, end, value) - begin - 1);
 }
 
 inline
-const std::vector<G4VoxelBox_v1051> &G4Voxelizer_v1051::GetBoxes() const
+const std::vector<G4VoxelBox_v1072>& G4Voxelizer_v1072::GetBoxes() const
 {
   return fBoxes;
 }
   
 inline
-const std::vector<G4double> &G4Voxelizer_v1051::GetBoundary(G4int index) const
+const std::vector<G4double>& G4Voxelizer_v1072::GetBoundary(G4int index) const
 {
   return fBoundaries[index];
 }
 
 inline
-void G4Voxelizer_v1051::GetVoxel(std::vector<G4int> &curVoxel,
-                                  const G4ThreeVector &point) const
+void G4Voxelizer_v1072::GetVoxel(std::vector<G4int>& curVoxel,
+                           const G4ThreeVector& point) const
 {
-  for (G4int i=0; i<=2; ++i)
+  for (auto i=0; i<=2; ++i)
   {
     const std::vector<double> &boundary = GetBoundary(i);
     G4int n = BinarySearch(boundary, point[i]);
@@ -302,40 +305,39 @@ void G4Voxelizer_v1051::GetVoxel(std::vector<G4int> &curVoxel,
 }
 
 inline
-G4int G4Voxelizer_v1051::GetBitsPerSlice () const
+G4int G4Voxelizer_v1072::GetBitsPerSlice () const
 {
   return fNPerSlice*8*sizeof(unsigned int);
 }
 
 inline
-G4int G4Voxelizer_v1051::GetVoxelsIndex(G4int x, G4int y, G4int z) const
+G4int G4Voxelizer_v1072::GetVoxelsIndex(G4int x, G4int y, G4int z) const
 {
   if (x < 0 || y < 0 || z < 0) { return -1; }
-  G4int maxX = fBoundaries[0].size();
-  G4int maxY = fBoundaries[1].size();
-  G4int index = x + y*maxX + z*maxX*maxY;
+  std::size_t maxX = fBoundaries[0].size();
+  std::size_t maxY = fBoundaries[1].size();
 
-  return index;
+  return G4int(x + y*maxX + z*maxX*maxY);
 }
 
 inline
-G4int G4Voxelizer_v1051::GetVoxelsIndex(const std::vector<G4int> &voxels) const
+G4int G4Voxelizer_v1072::GetVoxelsIndex(const std::vector<G4int>& voxels) const
 {
   return GetVoxelsIndex(voxels[0], voxels[1], voxels[2]);
 }
 
 inline
-G4bool G4Voxelizer_v1051::GetPointVoxel(const G4ThreeVector& p,
+G4bool G4Voxelizer_v1072::GetPointVoxel(const G4ThreeVector& p,
                                   std::vector<G4int>& voxels) const
 {
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     if (p[i] < *fBoundaries[i].begin() || p[i] > *fBoundaries[i].end())
     {
       return false;
     }
   }
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     voxels[i] = BinarySearch(fBoundaries[i], p[i]);
   }
@@ -344,45 +346,44 @@ G4bool G4Voxelizer_v1051::GetPointVoxel(const G4ThreeVector& p,
 }
 
 inline
-G4int G4Voxelizer_v1051::GetPointIndex(const G4ThreeVector &p) const
+G4int G4Voxelizer_v1072::GetPointIndex(const G4ThreeVector& p) const
 {
-  G4int maxX = fBoundaries[0].size();
-  G4int maxY = fBoundaries[1].size();
+  std::size_t maxX = fBoundaries[0].size();
+  std::size_t maxY = fBoundaries[1].size();
   G4int x = BinarySearch(fBoundaries[0], p[0]);
   G4int y = BinarySearch(fBoundaries[1], p[1]);
   G4int z = BinarySearch(fBoundaries[2], p[2]);
-  G4int index = x + y*maxX + z*maxX*maxY;
 
-  return index;
+  return G4int(x + y*maxX + z*maxX*maxY);
 }
 
 inline
-const G4SurfBits &G4Voxelizer_v1051::Empty() const
+const G4SurfBits& G4Voxelizer_v1072::Empty() const
 {
   return fEmpty;
 }
 
 inline
-G4bool G4Voxelizer_v1051::IsEmpty(G4int index) const
+G4bool G4Voxelizer_v1072::IsEmpty(G4int index) const
 {
   return fEmpty[index];
 }
 
 inline
-G4int G4Voxelizer_v1051::GetMaxVoxels(G4ThreeVector &ratioOfReduction)
+G4int G4Voxelizer_v1072::GetMaxVoxels(G4ThreeVector& ratioOfReduction)
 {
   ratioOfReduction = fReductionRatio;
   return fMaxVoxels;
 }
 
 inline
-long long G4Voxelizer_v1051::GetCountOfVoxels() const
+long long G4Voxelizer_v1072::GetCountOfVoxels() const
 {
   return fCountOfVoxels;
 }
 
 inline
-long long G4Voxelizer_v1051::CountVoxels(std::vector<G4double> boundaries[]) const
+long long G4Voxelizer_v1072::CountVoxels(std::vector<G4double> boundaries[]) const
 {
   long long sx = boundaries[0].size() - 1;
   long long sy = boundaries[1].size() - 1;
@@ -393,7 +394,7 @@ long long G4Voxelizer_v1051::CountVoxels(std::vector<G4double> boundaries[]) con
 
 inline
 const std::vector<G4int>&
-G4Voxelizer_v1051::GetCandidates(std::vector<G4int> &curVoxel) const
+G4Voxelizer_v1072::GetCandidates(std::vector<G4int>& curVoxel) const
 {
   G4int voxelsIndex = GetVoxelsIndex(curVoxel);
 
@@ -405,33 +406,33 @@ G4Voxelizer_v1051::GetCandidates(std::vector<G4int> &curVoxel) const
 }
 
 inline
-G4int G4Voxelizer_v1051::GetTotalCandidates() const
+G4int G4Voxelizer_v1072::GetTotalCandidates() const
 {
   return fTotalCandidates;
 }
 
 inline
-G4int G4Voxelizer_v1051::GetVoxelBoxesSize() const
+G4int G4Voxelizer_v1072::GetVoxelBoxesSize() const
 {
-  return fVoxelBoxes.size();
+  return G4int(fVoxelBoxes.size());
 }
 
 inline
-const G4VoxelBox_v1051 &G4Voxelizer_v1051::GetVoxelBox(G4int i) const
+const G4VoxelBox_v1072 &G4Voxelizer_v1072::GetVoxelBox(G4int i) const
 {
   return fVoxelBoxes[i];
 }
 
 inline
 const std::vector<G4int>&
-G4Voxelizer_v1051::GetVoxelBoxCandidates(G4int i) const
+G4Voxelizer_v1072::GetVoxelBoxCandidates(G4int i) const
 {
   return fVoxelBoxesCandidates[i];
 }
 
 inline
 G4ThreeVector
-G4Voxelizer_v1051::GetGlobalPoint(const G4Transform3D& trans,
+G4Voxelizer_v1072::GetGlobalPoint(const G4Transform3D& trans,
                             const G4ThreeVector& local) const
 {
   // Returns global point coordinates converted from the local frame defined

--- a/src/G4MultiUnion_v1072.cc
+++ b/src/G4MultiUnion_v1072.cc
@@ -25,18 +25,16 @@
 //
 // This product includes software developed by Members of the Geant4 Collaboration (http://cern.ch/geant4).
 //
-// Implementation for G4MultiUnion_v1051 class
+// Implementation of G4MultiUnion_v1072 class
 //
-// History:
-//
-// 06.04.17 G.Cosmo - Imported implementation in Geant4 for VecGeom migration
-// 19.10.12 Marek Gayer - Original implementation from USolids module
+// 19.10.12 M.Gayer - Original implementation from USolids module
+// 06.04.17 G.Cosmo - Adapted implementation in Geant4 for VecGeom migration
 // --------------------------------------------------------------------
 
 #include <iostream>
 #include <sstream>
 
-#include "G4MultiUnion_v1051.hh"
+#include "G4MultiUnion_v1072.hh"
 #include "Randomize.hh"
 #include "G4GeometryTolerance.hh"
 #include "G4BoundingEnvelope.hh"
@@ -56,57 +54,52 @@ namespace
 }
 
 //______________________________________________________________________________
-G4MultiUnion_v1051::G4MultiUnion_v1051(const G4String& name)
-  : G4VSolid(name), fAccurate(false),
-    fRebuildPolyhedron(false), fpPolyhedron(0)
+G4MultiUnion_v1072::G4MultiUnion_v1072(const G4String& name)
+  : G4VSolid(name)
 {
   SetName(name);
   fSolids.clear();
   fTransformObjs.clear();
-  fCubicVolume = 0;
-  fSurfaceArea = 0;
   kRadTolerance = G4GeometryTolerance::GetInstance()->GetRadialTolerance();
 }
 
 //______________________________________________________________________________
-G4MultiUnion_v1051::~G4MultiUnion_v1051()
+G4MultiUnion_v1072::~G4MultiUnion_v1072()
 {
 }
 
 //______________________________________________________________________________
-void G4MultiUnion_v1051::AddNode(G4VSolid& solid, G4Transform3D& trans)
+void G4MultiUnion_v1072::AddNode(G4VSolid& solid, G4Transform3D& trans)
 {
   fSolids.push_back(&solid);
   fTransformObjs.push_back(trans);  // Store a local copy of transformations
 }
 
 //______________________________________________________________________________
-G4VSolid* G4MultiUnion_v1051::Clone() const
+G4VSolid* G4MultiUnion_v1072::Clone() const
 {
-  return new G4MultiUnion_v1051(*this);
+  return new G4MultiUnion_v1072(*this);
 }
 
 // Copy constructor
 //______________________________________________________________________________
-G4MultiUnion_v1051::G4MultiUnion_v1051(const G4MultiUnion_v1051& rhs)
-  : G4VSolid(rhs),fCubicVolume (rhs.fCubicVolume),
-    fSurfaceArea (rhs.fSurfaceArea),
-    kRadTolerance(rhs.kRadTolerance), fAccurate(false),
-    fRebuildPolyhedron(false), fpPolyhedron(0)
+G4MultiUnion_v1072::G4MultiUnion_v1072(const G4MultiUnion_v1072& rhs)
+  : G4VSolid(rhs), fCubicVolume(rhs.fCubicVolume),
+    fSurfaceArea(rhs.fSurfaceArea),
+    kRadTolerance(rhs.kRadTolerance), fAccurate(rhs.fAccurate)
 {
 }
 
 // Fake default constructor for persistency
 //______________________________________________________________________________
-G4MultiUnion_v1051::G4MultiUnion_v1051( __void__& a )
-  : G4VSolid(a), fCubicVolume (0.), fSurfaceArea (0.), kRadTolerance(0.),
-    fAccurate(false), fRebuildPolyhedron(false), fpPolyhedron(0)
+G4MultiUnion_v1072::G4MultiUnion_v1072( __void__& a )
+  : G4VSolid(a)
 {
 }
 
 // Assignment operator
 //______________________________________________________________________________
-G4MultiUnion_v1051& G4MultiUnion_v1051::operator = (const G4MultiUnion_v1051& rhs)
+G4MultiUnion_v1072& G4MultiUnion_v1072::operator = (const G4MultiUnion_v1072& rhs)
 {
   // Check assignment to self
   //
@@ -123,9 +116,9 @@ G4MultiUnion_v1051& G4MultiUnion_v1051::operator = (const G4MultiUnion_v1051& rh
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::GetCubicVolume()
+G4double G4MultiUnion_v1072::GetCubicVolume()
 {
-  // Computes the cubic volume of the "G4MultiUnion_v1051" structure using
+  // Computes the cubic volume of the "G4MultiUnion_v1072" structure using
   // random points
 
   if (!fCubicVolume)
@@ -137,13 +130,13 @@ G4double G4MultiUnion_v1051::GetCubicVolume()
     p = (extentMax + extentMin) / 2.;
     G4ThreeVector left = p - d;
     G4ThreeVector length = d * 2;
-    for (generated = 0; generated < 10000; generated++)
+    for (generated = 0; generated < 10000; ++generated)
     {
       G4ThreeVector rvec(G4UniformRand(), G4UniformRand(), G4UniformRand());
       point = left + G4ThreeVector(length.x()*rvec.x(),
                                    length.y()*rvec.y(),
                                    length.z()*rvec.z());
-      if (Inside(point) != EInside::kOutside) inside++;
+      if (Inside(point) != EInside::kOutside) ++inside;
     }
     G4double vbox = (2 * d.x()) * (2 * d.y()) * (2 * d.z());
     fCubicVolume = inside * vbox / generated;
@@ -153,7 +146,7 @@ G4double G4MultiUnion_v1051::GetCubicVolume()
 
 //______________________________________________________________________________
 G4double
-G4MultiUnion_v1051::DistanceToInNoVoxels(const G4ThreeVector& aPoint,
+G4MultiUnion_v1072::DistanceToInNoVoxels(const G4ThreeVector& aPoint,
                                    const G4ThreeVector& aDirection) const
 {
   G4ThreeVector direction = aDirection.unit();
@@ -176,7 +169,7 @@ G4MultiUnion_v1051::DistanceToInNoVoxels(const G4ThreeVector& aPoint,
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToInCandidates(const G4ThreeVector& aPoint,
+G4double G4MultiUnion_v1072::DistanceToInCandidates(const G4ThreeVector& aPoint,
                                               const G4ThreeVector& direction,
                                               std::vector<G4int>& candidates,
                                               G4SurfBits& bits) const
@@ -212,7 +205,7 @@ G4double G4MultiUnion_v1051::DistanceToInCandidates(const G4ThreeVector& aPoint,
 // But if distance is smaller than the shift to next voxel, we can return
 // it immediately
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToIn(const G4ThreeVector& aPoint,
+G4double G4MultiUnion_v1072::DistanceToIn(const G4ThreeVector& aPoint,
                                     const G4ThreeVector& aDirection) const
 {
   G4double minDistance = kInfinity;
@@ -246,7 +239,7 @@ G4double G4MultiUnion_v1051::DistanceToIn(const G4ThreeVector& aPoint,
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToOutNoVoxels(const G4ThreeVector& aPoint,
+G4double G4MultiUnion_v1072::DistanceToOutNoVoxels(const G4ThreeVector& aPoint,
                                              const G4ThreeVector& aDirection,
                                              G4ThreeVector* aNormal) const
 {
@@ -297,7 +290,7 @@ G4double G4MultiUnion_v1051::DistanceToOutNoVoxels(const G4ThreeVector& aPoint,
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToOut(const G4ThreeVector& aPoint,
+G4double G4MultiUnion_v1072::DistanceToOut(const G4ThreeVector& aPoint,
                                      const G4ThreeVector& aDirection,
                                      const G4bool /* calcNorm */,
                                      G4bool* /* validNorm */,
@@ -307,7 +300,7 @@ G4double G4MultiUnion_v1051::DistanceToOut(const G4ThreeVector& aPoint,
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToOutVoxels(const G4ThreeVector& aPoint,
+G4double G4MultiUnion_v1072::DistanceToOutVoxels(const G4ThreeVector& aPoint,
                                            const G4ThreeVector& aDirection,
                                            G4ThreeVector* aNormal) const
 {
@@ -318,7 +311,7 @@ G4double G4MultiUnion_v1051::DistanceToOutVoxels(const G4ThreeVector& aPoint,
   // o The proposed step is ignored.
   // o The normal vector to the crossed surface is always filled.
 
-  // In the case the considered point is located inside the G4MultiUnion_v1051
+  // In the case the considered point is located inside the G4MultiUnion_v1072
   // structure, the treatments are as follows:
   //      - investigation of the candidates for the passed point
   //      - progressive moving of the point towards the surface, along the
@@ -394,7 +387,7 @@ G4double G4MultiUnion_v1051::DistanceToOutVoxels(const G4ThreeVector& aPoint,
 
         distance += maxDistance;
         currentPoint += maxDistance * direction;
-        if(maxDistance == 0.) count++;
+        if(maxDistance == 0.) ++count;
 
         // the current component will be ignored
         exclusion.SetBitNumber(maxCandidate);
@@ -429,7 +422,7 @@ G4double G4MultiUnion_v1051::DistanceToOutVoxels(const G4ThreeVector& aPoint,
 }
 
 //______________________________________________________________________________
-EInside G4MultiUnion_v1051::InsideWithExclusion(const G4ThreeVector& aPoint,
+EInside G4MultiUnion_v1072::InsideWithExclusion(const G4ThreeVector& aPoint,
                                           G4SurfBits* exclusion) const
 {
   // Classify point location with respect to solid:
@@ -503,7 +496,7 @@ EInside G4MultiUnion_v1051::InsideWithExclusion(const G4ThreeVector& aPoint,
 }
 
 //______________________________________________________________________________
-EInside G4MultiUnion_v1051::Inside(const G4ThreeVector& aPoint) const
+EInside G4MultiUnion_v1072::Inside(const G4ThreeVector& aPoint) const
 {
   // Classify point location with respect to solid:
   //  o eInside       - inside the solid
@@ -523,7 +516,7 @@ EInside G4MultiUnion_v1051::Inside(const G4ThreeVector& aPoint) const
 }
 
 //______________________________________________________________________________
-EInside G4MultiUnion_v1051::InsideNoVoxels(const G4ThreeVector& aPoint) const
+EInside G4MultiUnion_v1072::InsideNoVoxels(const G4ThreeVector& aPoint) const
 {
   G4ThreeVector localPoint;
   EInside location = EInside::kOutside;
@@ -542,7 +535,7 @@ EInside G4MultiUnion_v1051::InsideNoVoxels(const G4ThreeVector& aPoint) const
     location = solid.Inside(localPoint);
 
     if (location == EInside::kSurface)
-      countSurface++;
+      ++countSurface;
 
     if (location == EInside::kInside) return EInside::kInside;
   }
@@ -551,7 +544,7 @@ EInside G4MultiUnion_v1051::InsideNoVoxels(const G4ThreeVector& aPoint) const
 }
 
 //______________________________________________________________________________
-void G4MultiUnion_v1051::Extent(EAxis aAxis, G4double& aMin, G4double& aMax) const
+void G4MultiUnion_v1072::Extent(EAxis aAxis, G4double& aMin, G4double& aMax) const
 {
   // Determines the bounding box for the considered instance of "UMultipleUnion"
   G4ThreeVector min, max;
@@ -620,7 +613,7 @@ void G4MultiUnion_v1051::Extent(EAxis aAxis, G4double& aMin, G4double& aMax) con
 }
 
 //______________________________________________________________________________
-void G4MultiUnion_v1051::BoundingLimits(G4ThreeVector& aMin,
+void G4MultiUnion_v1072::BoundingLimits(G4ThreeVector& aMin,
                                   G4ThreeVector& aMax) const
 {
    Extent(kXAxis, aMin[0], aMax[0]);
@@ -630,7 +623,7 @@ void G4MultiUnion_v1051::BoundingLimits(G4ThreeVector& aMin,
 
 //______________________________________________________________________________
 G4bool
-G4MultiUnion_v1051::CalculateExtent(const EAxis pAxis,
+G4MultiUnion_v1072::CalculateExtent(const EAxis pAxis,
                               const G4VoxelLimits& pVoxelLimit,
                               const G4AffineTransform& pTransform,
                                     G4double& pMin, G4double& pMax) const
@@ -646,7 +639,7 @@ G4MultiUnion_v1051::CalculateExtent(const EAxis pAxis,
 }
 
 //______________________________________________________________________________
-G4ThreeVector G4MultiUnion_v1051::SurfaceNormal(const G4ThreeVector& aPoint) const
+G4ThreeVector G4MultiUnion_v1072::SurfaceNormal(const G4ThreeVector& aPoint) const
 {
   // Computes the localNormal on a surface and returns it as a unit vector.
   // Must return a valid vector. (even if the point is not on the surface).
@@ -727,7 +720,7 @@ G4ThreeVector G4MultiUnion_v1051::SurfaceNormal(const G4ThreeVector& aPoint) con
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToOut(const G4ThreeVector& point) const
+G4double G4MultiUnion_v1072::DistanceToOut(const G4ThreeVector& point) const
 {
   // Estimates isotropic distance to the surface of the solid. This must
   // be either accurate or an underestimate.
@@ -764,7 +757,7 @@ G4double G4MultiUnion_v1051::DistanceToOut(const G4ThreeVector& point) const
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::DistanceToIn(const G4ThreeVector& point) const
+G4double G4MultiUnion_v1072::DistanceToIn(const G4ThreeVector& point) const
 {
   // Estimates the isotropic safety from a point outside the current solid to
   // any of its surfaces. The algorithm may be accurate or should provide a fast
@@ -772,7 +765,7 @@ G4double G4MultiUnion_v1051::DistanceToIn(const G4ThreeVector& point) const
 
   if (!fAccurate)  { return fVoxels.DistanceToBoundingBox(point); }
 
-  const std::vector<G4VoxelBox_v1051>& boxes = fVoxels.GetBoxes();
+  const std::vector<G4VoxelBox_v1072>& boxes = fVoxels.GetBoxes();
   G4double safetyMin = kInfinity;
   G4ThreeVector localPoint;
 
@@ -784,14 +777,14 @@ G4double G4MultiUnion_v1051::DistanceToIn(const G4ThreeVector& point) const
     {
       const G4ThreeVector& pos = boxes[j].pos;
       const G4ThreeVector& hlen = boxes[j].hlen;
-      for (G4int i = 0; i <= 2; ++i)
+      for (auto i = 0; i <= 2; ++i)
         // distance to middle point - hlength => distance from point to border
         // of x,y,z
         if ((dxyz[i] = std::abs(point[i] - pos[i]) - hlen[i]) > safetyMin)
           continue;
 
       G4double d2xyz = 0.;
-      for (G4int i = 0; i <= 2; ++i)
+      for (auto i = 0; i <= 2; ++i)
         if (dxyz[i] > 0) d2xyz += dxyz[i] * dxyz[i];
 
       // minimal distance is at least this, but could be even higher. therefore,
@@ -815,7 +808,7 @@ G4double G4MultiUnion_v1051::DistanceToIn(const G4ThreeVector& point) const
 }
 
 //______________________________________________________________________________
-G4double G4MultiUnion_v1051::GetSurfaceArea()
+G4double G4MultiUnion_v1072::GetSurfaceArea()
 {
   if (!fSurfaceArea)
   {
@@ -825,20 +818,20 @@ G4double G4MultiUnion_v1051::GetSurfaceArea()
 }
 
 //______________________________________________________________________________
-void G4MultiUnion_v1051::Voxelize()
+void G4MultiUnion_v1072::Voxelize()
 {
   fVoxels.Voxelize(fSolids, fTransformObjs);
 }
 
 //______________________________________________________________________________
-G4int G4MultiUnion_v1051::SafetyFromOutsideNumberNode(const G4ThreeVector& aPoint,
+G4int G4MultiUnion_v1072::SafetyFromOutsideNumberNode(const G4ThreeVector& aPoint,
                                                 G4double& safetyMin) const
 {
   // Method returning the closest node from a point located outside a
-  // G4MultiUnion_v1051.
+  // G4MultiUnion_v1072.
   // This is used to compute the normal in the case no candidate has been found.
 
-  const std::vector<G4VoxelBox_v1051>& boxes = fVoxels.GetBoxes();
+  const std::vector<G4VoxelBox_v1072>& boxes = fVoxels.GetBoxes();
   safetyMin = kInfinity;
   G4int safetyNode = 0;
   G4ThreeVector localPoint;
@@ -875,7 +868,7 @@ G4int G4MultiUnion_v1051::SafetyFromOutsideNumberNode(const G4ThreeVector& aPoin
 }
 
 //______________________________________________________________________________
-void G4MultiUnion_v1051::TransformLimits(G4ThreeVector& min, G4ThreeVector& max,
+void G4MultiUnion_v1072::TransformLimits(G4ThreeVector& min, G4ThreeVector& max,
                                    const G4Transform3D& transformation) const
 {
   // The goal of this method is to convert the quantities min and max
@@ -919,13 +912,13 @@ void G4MultiUnion_v1051::TransformLimits(G4ThreeVector& min, G4ThreeVector& max,
 
 // Stream object contents to an output stream
 //______________________________________________________________________________
-std::ostream& G4MultiUnion_v1051::StreamInfo(std::ostream& os) const
+std::ostream& G4MultiUnion_v1072::StreamInfo(std::ostream& os) const
 {
   G4int oldprc = os.precision(16);
   os << "-----------------------------------------------------------\n"
      << "                *** Dump for solid - " << GetName() << " ***\n"
      << "                ===================================================\n"
-     << " Solid type: G4MultiUnion_v1051\n"
+     << " Solid type: G4MultiUnion_v1072\n"
      << " Parameters: \n";
      G4int numNodes = fSolids.size();
      for (G4int i = 0 ; i < numNodes ; ++i)
@@ -945,7 +938,7 @@ std::ostream& G4MultiUnion_v1051::StreamInfo(std::ostream& os) const
 }
 
 //______________________________________________________________________________
-G4ThreeVector G4MultiUnion_v1051::GetPointOnSurface() const
+G4ThreeVector G4MultiUnion_v1072::GetPointOnSurface() const
 {
   G4ThreeVector point;
 
@@ -966,13 +959,13 @@ G4ThreeVector G4MultiUnion_v1051::GetPointOnSurface() const
 
 //______________________________________________________________________________
 void 
-G4MultiUnion_v1051::DescribeYourselfTo ( G4VGraphicsScene& scene ) const 
+G4MultiUnion_v1072::DescribeYourselfTo ( G4VGraphicsScene& scene ) const 
 {
   scene.AddSolid (*this);
 }
 
 //______________________________________________________________________________
-G4Polyhedron* G4MultiUnion_v1051::CreatePolyhedron() const
+G4Polyhedron* G4MultiUnion_v1072::CreatePolyhedron() const
 {
   HepPolyhedronProcessor processor;
   HepPolyhedronProcessor::Operation operation = HepPolyhedronProcessor::UNION;
@@ -997,9 +990,9 @@ G4Polyhedron* G4MultiUnion_v1051::CreatePolyhedron() const
 }
 
 //______________________________________________________________________________
-G4Polyhedron* G4MultiUnion_v1051::GetPolyhedron() const
+G4Polyhedron* G4MultiUnion_v1072::GetPolyhedron() const
 {
-  if (!fpPolyhedron ||
+  if (fpPolyhedron == nullptr ||
       fRebuildPolyhedron ||
       fpPolyhedron->GetNumberOfRotationStepsAtTimeOfCreation() !=
       fpPolyhedron->GetNumberOfRotationSteps())

--- a/src/G4Voxelizer_v1072.cc
+++ b/src/G4Voxelizer_v1072.cc
@@ -28,9 +28,8 @@
 // --------------------------------------------------------------------
 // GEANT 4 class header file
 //
-// G4Voxelizer_v1051 implementation
+// G4Voxelizer_v1072 implementation
 //
-// History:
 // 19.10.12 Marek Gayer, created
 // --------------------------------------------------------------------
 
@@ -43,7 +42,7 @@
 #include "G4VSolid.hh" 
 
 #include "G4Orb.hh"
-#include "G4Voxelizer_v1051.hh"
+#include "G4Voxelizer_v1072.hh"
 #include "G4SolidStore.hh"
 #include "Randomize.hh"
 #include "G4PhysicalConstants.hh"
@@ -56,10 +55,10 @@
 
 using namespace std;
 
-G4ThreadLocal G4int G4Voxelizer_v1051::fDefaultVoxelsCount = -1;
+G4ThreadLocal G4int G4Voxelizer_v1072::fDefaultVoxelsCount = -1;
 
 //______________________________________________________________________________
-G4Voxelizer_v1051::G4Voxelizer_v1051()
+G4Voxelizer_v1072::G4Voxelizer_v1072()
   : fBoundingBox("VoxBBox", 1, 1, 1)
 {
   fCountOfVoxels = fNPerSlice = fTotalCandidates = 0;
@@ -72,12 +71,12 @@ G4Voxelizer_v1051::G4Voxelizer_v1051()
 }
 
 //______________________________________________________________________________
-G4Voxelizer_v1051::~G4Voxelizer_v1051()
+G4Voxelizer_v1072::~G4Voxelizer_v1072()
 {
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildEmpty()
+void G4Voxelizer_v1072::BuildEmpty()
 {
   // by reserving the size of candidates, we would avoid reallocation of 
   // the vector which could cause fragmentation
@@ -85,7 +84,7 @@ void G4Voxelizer_v1051::BuildEmpty()
   std::vector<G4int> xyz(3), max(3), candidates(fTotalCandidates);
   const std::vector<G4int> empty(0);
 
-  for (G4int i = 0; i <= 2; i++) max[i] = fBoundaries[i].size();
+  for (auto i = 0; i <= 2; ++i) max[i] = fBoundaries[i].size();
   unsigned int size = max[0] * max[1] * max[2];
 
   fEmpty.Clear();
@@ -120,13 +119,9 @@ void G4Voxelizer_v1051::BuildEmpty()
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildVoxelLimits(std::vector<G4VSolid*>& solids,
+void G4Voxelizer_v1072::BuildVoxelLimits(std::vector<G4VSolid*>& solids,
                                    std::vector<G4Transform3D>& transforms)
 {
-  G4Rotate3D rot;
-  G4Translate3D transl ;
-  G4Scale3D scale;
-
   // "BuildVoxelLimits"'s aim is to store the coordinates of the origin as
   // well as the half lengths related to the bounding box of each node.
   // These quantities are stored in the array "fBoxes" (6 different values per
@@ -168,16 +163,15 @@ void G4Voxelizer_v1051::BuildVoxelLimits(std::vector<G4VSolid*>& solids,
         max += toleranceVector;
       }
       TransformLimits(min, max, transform);
-      fBoxes[i].hlen = (max - min) / 2;
-      transform.getDecomposition(scale,rot,transl); 
-      fBoxes[i].pos = transl.getTranslation();
+      fBoxes[i].hlen = (max - min) / 2.;
+      fBoxes[i].pos =  (max + min) / 2.;
     }
     fTotalCandidates = fBoxes.size();
   }
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildVoxelLimits(std::vector<G4VFacet *> &facets)
+void G4Voxelizer_v1072::BuildVoxelLimits(std::vector<G4VFacet*>& facets)
 {
   // "BuildVoxelLimits"'s aim is to store the coordinates of the origin as well
   // as the half lengths related to the bounding box of each node.
@@ -210,7 +204,7 @@ void G4Voxelizer_v1051::BuildVoxelLimits(std::vector<G4VFacet *> &facets)
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::DisplayVoxelLimits() const
+void G4Voxelizer_v1072::DisplayVoxelLimits() const
 {
   // "DisplayVoxelLimits" displays the dX, dY, dZ, pX, pY and pZ for each node
 
@@ -227,7 +221,7 @@ void G4Voxelizer_v1051::DisplayVoxelLimits() const
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::CreateSortedBoundary(std::vector<G4double> &boundary,
+void G4Voxelizer_v1072::CreateSortedBoundary(std::vector<G4double>& boundary,
                                        G4int axis)
 {
   // "CreateBoundaries"'s aim is to determine the slices induced by the
@@ -257,7 +251,7 @@ void G4Voxelizer_v1051::CreateSortedBoundary(std::vector<G4double> &boundary,
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildBoundaries()
+void G4Voxelizer_v1072::BuildBoundaries()
 {
   // "SortBoundaries" orders the boundaries along each axis (increasing order)
   // and also does not take into account redundant boundaries, i.e. if two
@@ -278,7 +272,7 @@ void G4Voxelizer_v1051::BuildBoundaries()
 
     G4int considered;
 
-    for (G4int j = 0; j <= 2; ++j)
+    for (auto j = 0; j <= 2; ++j)
     {
       CreateSortedBoundary(sortedBoundary, j);
       std::vector<G4double> &boundary = fBoundaries[j];
@@ -337,10 +331,10 @@ void G4Voxelizer_v1051::BuildBoundaries()
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::DisplayBoundaries()
+void G4Voxelizer_v1072::DisplayBoundaries()
 {
   char axis[3] = {'X', 'Y', 'Z'};
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     G4cout << " * " << axis[i] << " axis:" << G4endl << "    | ";
     DisplayBoundaries(fBoundaries[i]);
@@ -348,7 +342,7 @@ void G4Voxelizer_v1051::DisplayBoundaries()
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::DisplayBoundaries(std::vector<G4double> &boundaries)
+void G4Voxelizer_v1072::DisplayBoundaries(std::vector<G4double> &boundaries)
 {
   // Prints the positions of the boundaries of the slices on the three axes
 
@@ -364,7 +358,7 @@ void G4Voxelizer_v1051::DisplayBoundaries(std::vector<G4double> &boundaries)
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildBitmasks(std::vector<G4double> boundaries[],
+void G4Voxelizer_v1072::BuildBitmasks(std::vector<G4double> boundaries[],
                                 G4SurfBits bitmasks[], G4bool countsOnly)
 {
   // "BuildListNodes" stores in the bitmasks solids present in each slice
@@ -373,12 +367,12 @@ void G4Voxelizer_v1051::BuildBitmasks(std::vector<G4double> boundaries[],
   G4int numNodes = fBoxes.size();
   G4int bitsPerSlice = GetBitsPerSlice();
 
-  for (G4int k = 0; k < 3; ++k)
+  for (auto k = 0; k < 3; ++k)
   {
     G4int total = 0;
-    std::vector<G4double> &boundary = boundaries[k];
+    std::vector<G4double>& boundary = boundaries[k];
     G4int voxelsCount = boundary.size() - 1;
-    G4SurfBits &bitmask = bitmasks[k];
+    G4SurfBits& bitmask = bitmasks[k];
 
     if (!countsOnly)
     {
@@ -390,7 +384,7 @@ void G4Voxelizer_v1051::BuildBitmasks(std::vector<G4double> boundaries[],
         // it is here so we can set the maximum number of bits. this line
         // will rellocate the memory and set all to zero
     }
-    std::vector<G4int> &candidatesCount = fCandidatesCounts[k];
+    std::vector<G4int>& candidatesCount = fCandidatesCounts[k];
     candidatesCount.resize(voxelsCount);
 
     for(G4int i = 0 ; i < voxelsCount; ++i) { candidatesCount[i] = 0; }
@@ -417,8 +411,8 @@ void G4Voxelizer_v1051::BuildBitmasks(std::vector<G4double> boundaries[],
           bitmask.SetBitNumber(i*bitsPerSlice+j);
         }
         candidatesCount[i]++;
-        total++;
-        i++;
+        ++total;
+        ++i;
       }
       while (max > boundary[i] && i < voxelsCount);
     }
@@ -429,7 +423,7 @@ void G4Voxelizer_v1051::BuildBitmasks(std::vector<G4double> boundaries[],
 }
 
 //______________________________________________________________________________
-G4String G4Voxelizer_v1051::GetCandidatesAsString(const G4SurfBits &bits) const
+G4String G4Voxelizer_v1072::GetCandidatesAsString(const G4SurfBits& bits) const
 {
   // Decodes the candidates in mask as G4String.
 
@@ -444,7 +438,7 @@ G4String G4Voxelizer_v1051::GetCandidatesAsString(const G4SurfBits &bits) const
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::DisplayListNodes() const
+void G4Voxelizer_v1072::DisplayListNodes() const
 {
   // Prints which solids are present in the slices previously elaborated.
 
@@ -452,7 +446,7 @@ void G4Voxelizer_v1051::DisplayListNodes() const
   G4int size=8*sizeof(G4int)*fNPerSlice;
   G4SurfBits bits(size);
 
-  for (G4int j = 0; j <= 2; ++j)
+  for (auto j = 0; j <= 2; ++j)
   {
     G4cout << " * " << axis[j] << " axis:" << G4endl;
     G4int count = fBoundaries[j].size();
@@ -469,7 +463,7 @@ void G4Voxelizer_v1051::DisplayListNodes() const
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildBoundingBox()
+void G4Voxelizer_v1072::BuildBoundingBox()
 {
   G4ThreeVector min(fBoundaries[0].front(),
                     fBoundaries[1].front(),
@@ -481,11 +475,11 @@ void G4Voxelizer_v1051::BuildBoundingBox()
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildBoundingBox(G4ThreeVector& amin,
+void G4Voxelizer_v1072::BuildBoundingBox(G4ThreeVector& amin,
                                    G4ThreeVector& amax,
                                    G4double tolerance)
 {
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     G4double min = amin[i];
     G4double max = amax[i];
@@ -512,8 +506,8 @@ void G4Voxelizer_v1051::BuildBoundingBox(G4ThreeVector& amin,
 // would be updated.
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::SetReductionRatio(G4int maxVoxels,
-                                    G4ThreeVector &reductionRatio)
+void G4Voxelizer_v1072::SetReductionRatio(G4int maxVoxels,
+                                    G4ThreeVector& reductionRatio)
 {
   G4double maxTotal = (G4double) fCandidatesCounts[0].size()
                     * fCandidatesCounts[1].size() * fCandidatesCounts[2].size();
@@ -528,21 +522,21 @@ void G4Voxelizer_v1051::SetReductionRatio(G4int maxVoxels,
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildReduceVoxels(std::vector<G4double> boundaries[],
+void G4Voxelizer_v1072::BuildReduceVoxels(std::vector<G4double> boundaries[],
                                     G4ThreeVector reductionRatio)
 {
-  for (G4int k = 0; k <= 2; ++k)
+  for (auto k = 0; k <= 2; ++k)
   {
     std::vector<G4int> &candidatesCount = fCandidatesCounts[k];
     G4int max = candidatesCount.size();
-    std::vector<G4VoxelInfo_v1051> voxels(max);
+    std::vector<G4VoxelInfo_v1072> voxels(max);
     G4VoxelComparator comp(voxels);
     std::set<G4int, G4VoxelComparator> voxelSet(comp);
     std::vector<G4int> mergings;
 
     for (G4int j = 0; j < max; ++j)
     {
-      G4VoxelInfo_v1051 &voxel = voxels[j];
+      G4VoxelInfo_v1072 &voxel = voxels[j];
       voxel.count = candidatesCount[j];
       voxel.previous = j - 1;
       voxel.next = j + 1;
@@ -564,8 +558,8 @@ void G4Voxelizer_v1051::BuildReduceVoxels(std::vector<G4double> boundaries[],
         const G4int pos = *voxelSet.begin();
         mergings.push_back(pos + 1);
 
-        G4VoxelInfo_v1051& voxel = voxels[pos];
-        G4VoxelInfo_v1051& nextVoxel = voxels[voxel.next];
+        G4VoxelInfo_v1072& voxel = voxels[pos];
+        G4VoxelInfo_v1072& nextVoxel = voxels[voxel.next];
 
         if (voxelSet.erase(pos) != 1)
         {
@@ -593,7 +587,7 @@ void G4Voxelizer_v1051::BuildReduceVoxels(std::vector<G4double> boundaries[],
           voxels[voxel.previous].next = voxel.next;
           voxelSet.insert(voxel.previous);
         }
-        count++;
+        ++count;
       }  // Loop checking, 13.08.2015, G.Cosmo
     }
 
@@ -635,8 +629,8 @@ void G4Voxelizer_v1051::BuildReduceVoxels(std::vector<G4double> boundaries[],
       const G4int pos = *voxelSet.begin();
       mergings.push_back(pos);
 
-      G4VoxelInfo_v1051 &voxel = voxels[pos];
-      G4VoxelInfo_v1051 &nextVoxel = voxels[voxel.next];
+      G4VoxelInfo_v1072 &voxel = voxels[pos];
+      G4VoxelInfo_v1072 &nextVoxel = voxels[voxel.next];
 
       voxelSet.erase(pos);
       if (voxel.next != max - 1) { voxelSet.erase(voxel.next); }
@@ -654,7 +648,7 @@ void G4Voxelizer_v1051::BuildReduceVoxels(std::vector<G4double> boundaries[],
         voxels[voxel.previous].next = voxel.next;
         voxelSet.insert(voxel.previous);
       }
-      count++;
+      ++count;
     }
 
     if (mergings.size())
@@ -683,10 +677,10 @@ void G4Voxelizer_v1051::BuildReduceVoxels(std::vector<G4double> boundaries[],
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::BuildReduceVoxels2(std::vector<G4double> boundaries[],
+void G4Voxelizer_v1072::BuildReduceVoxels2(std::vector<G4double> boundaries[],
                                      G4ThreeVector reductionRatio)
 {
-  for (G4int k = 0; k <= 2; ++k)
+  for (auto k = 0; k <= 2; ++k)
   {
     std::vector<G4int> &candidatesCount = fCandidatesCounts[k];
     G4int max = candidatesCount.size();
@@ -715,7 +709,7 @@ void G4Voxelizer_v1051::BuildReduceVoxels2(std::vector<G4double> boundaries[],
       {
         G4double val = boundary[i];
         reducedBoundary[cur] = val;
-        cur++;
+        ++cur;
         if (cur == destination)
           break;
       }
@@ -726,7 +720,7 @@ void G4Voxelizer_v1051::BuildReduceVoxels2(std::vector<G4double> boundaries[],
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::Voxelize(std::vector<G4VSolid*>& solids,
+void G4Voxelizer_v1072::Voxelize(std::vector<G4VSolid*>& solids,
                            std::vector<G4Transform3D>& transforms)
 {
   BuildVoxelLimits(solids, transforms);
@@ -737,18 +731,18 @@ void G4Voxelizer_v1051::Voxelize(std::vector<G4VSolid*>& solids,
                 // actually only makes performance slower,
                 // these are only pre-calculated but not used by multi-union
 
-  for (G4int i = 0; i < 3; ++i)
+  for (auto i = 0; i < 3; ++i)
   {
     fCandidatesCounts[i].resize(0);
   }
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::CreateMiniVoxels(std::vector<G4double> boundaries[],
+void G4Voxelizer_v1072::CreateMiniVoxels(std::vector<G4double> boundaries[],
                                    G4SurfBits bitmasks[])
 {
   std::vector<G4int> voxel(3), maxVoxels(3);
-  for (G4int i = 0; i <= 2; ++i) maxVoxels[i] = boundaries[i].size();
+  for (auto i = 0; i <= 2; ++i) maxVoxels[i] = boundaries[i].size();
 
   G4ThreeVector point;
   for (voxel[2] = 0; voxel[2] < maxVoxels[2] - 1; ++voxel[2])
@@ -761,8 +755,8 @@ void G4Voxelizer_v1051::CreateMiniVoxels(std::vector<G4double> boundaries[],
         if (GetCandidatesVoxelArray(voxel, bitmasks, candidates, 0))
         {
           // find a box for corresponding non-empty voxel
-          G4VoxelBox_v1051 box;
-          for (G4int i = 0; i <= 2; ++i)
+          G4VoxelBox_v1072 box;
+          for (auto i = 0; i <= 2; ++i)
           {
             G4int index = voxel[i];
             const std::vector<G4double> &boundary = boundaries[i];
@@ -780,7 +774,7 @@ void G4Voxelizer_v1051::CreateMiniVoxels(std::vector<G4double> boundaries[],
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::Voxelize(std::vector<G4VFacet*>& facets)
+void G4Voxelizer_v1072::Voxelize(std::vector<G4VFacet*>& facets)
 {
   G4int maxVoxels = fMaxVoxels;
   G4ThreeVector reductionRatio = fReductionRatio;
@@ -851,7 +845,7 @@ void G4Voxelizer_v1051::Voxelize(std::vector<G4VFacet*>& facets)
 
     std::vector<G4double> miniBoundaries[3];
 
-    for (G4int i = 0; i <= 2; ++i)  { miniBoundaries[i] = fBoundaries[i]; }
+    for (auto i = 0; i <= 2; ++i)  { miniBoundaries[i] = fBoundaries[i]; }
 
     G4int voxelsCountMini = (fCountOfVoxels >= 1000)
                           ? 100 : fCountOfVoxels / 10;
@@ -899,7 +893,7 @@ void G4Voxelizer_v1051::Voxelize(std::vector<G4VFacet*>& facets)
     // deallocate fields unnecessary during runtime
     //
     fBoxes.resize(0);
-    for (G4int i = 0; i < 3; ++i)
+    for (auto i = 0; i < 3; ++i)
     {
       fCandidatesCounts[i].resize(0);
       fBitmasks[i].Clear();
@@ -909,7 +903,7 @@ void G4Voxelizer_v1051::Voxelize(std::vector<G4VFacet*>& facets)
 
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::GetCandidatesVoxel(std::vector<G4int> &voxels)
+void G4Voxelizer_v1072::GetCandidatesVoxel(std::vector<G4int>& voxels)
 {
   // "GetCandidates" should compute which solids are possibly contained in
   // the voxel defined by the three slices characterized by the passed indexes.
@@ -924,14 +918,14 @@ void G4Voxelizer_v1051::GetCandidatesVoxel(std::vector<G4int> &voxels)
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::FindComponentsFastest(unsigned int mask,
-                                         std::vector<G4int> &list, G4int i)
+void G4Voxelizer_v1072::FindComponentsFastest(unsigned int mask,
+                                         std::vector<G4int>& list, G4int i)
 {
-  for (G4int byte = 0; byte < (G4int) (sizeof(unsigned int)); byte++)
+  for (G4int byte = 0; byte < (G4int) (sizeof(unsigned int)); ++byte)
   {
     if (G4int maskByte = mask & 0xFF)
     {
-      for (G4int bit = 0; bit < 8; bit++)
+      for (G4int bit = 0; bit < 8; ++bit)
       {
         if (maskByte & 1) 
           { list.push_back(8*(sizeof(unsigned int)*i+ byte) + bit); }
@@ -943,7 +937,7 @@ void G4Voxelizer_v1051::FindComponentsFastest(unsigned int mask,
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::TransformLimits(G4ThreeVector& min, G4ThreeVector& max,
+void G4Voxelizer_v1072::TransformLimits(G4ThreeVector& min, G4ThreeVector& max,
                                   const G4Transform3D& transformation) const
 {
   // The goal of this method is to convert the quantities min and max
@@ -986,14 +980,14 @@ void G4Voxelizer_v1051::TransformLimits(G4ThreeVector& min, G4ThreeVector& max,
 }
 
 //______________________________________________________________________________
-G4int G4Voxelizer_v1051::GetCandidatesVoxelArray(const G4ThreeVector &point,
+G4int G4Voxelizer_v1072::GetCandidatesVoxelArray(const G4ThreeVector &point,
                           std::vector<G4int> &list, G4SurfBits *crossed) const
 {
   // Method returning the candidates corresponding to the passed point
 
   list.clear();
 
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     if(point[i] < fBoundaries[i].front() || point[i] >= fBoundaries[i].back()) 
       return 0;
@@ -1036,7 +1030,7 @@ G4int G4Voxelizer_v1051::GetCandidatesVoxelArray(const G4ThreeVector &point,
     else
     {
       unsigned int* masks[3], mask; // masks for X,Y,Z axis
-      for (G4int i = 0; i <= 2; ++i)
+      for (auto i = 0; i <= 2; ++i)
       {
         G4int slice = BinarySearch(fBoundaries[i], point[i]);
         masks[i] = ((unsigned int*) fBitmasks[i].fAllBits)
@@ -1079,7 +1073,7 @@ G4int G4Voxelizer_v1051::GetCandidatesVoxelArray(const G4ThreeVector &point,
     else
     {
       unsigned int *masks[3], mask; // masks for X,Y,Z axis
-      for (G4int i = 0; i <= 2; ++i)
+      for (auto i = 0; i <= 2; ++i)
       {
         G4int slice = BinarySearch(fBoundaries[i], point[i]); 
         masks[i] = ((unsigned int *) fBitmasks[i].fAllBits) + slice*fNPerSlice;
@@ -1107,10 +1101,10 @@ G4int G4Voxelizer_v1051::GetCandidatesVoxelArray(const G4ThreeVector &point,
 
 //______________________________________________________________________________
 G4int
-G4Voxelizer_v1051::GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
+G4Voxelizer_v1072::GetCandidatesVoxelArray(const std::vector<G4int>& voxels,
                                      const G4SurfBits bitmasks[],
-                                     std::vector<G4int> &list,
-                                     G4SurfBits *crossed) const
+                                     std::vector<G4int>& list,
+                                     G4SurfBits* crossed) const
 {
   list.clear();
 
@@ -1138,12 +1132,12 @@ G4Voxelizer_v1051::GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
     else
     {
       unsigned int *masks[3], mask; // masks for X,Y,Z axis
-      for (G4int i = 0; i <= 2; ++i)
+      for (auto i = 0; i <= 2; ++i)
       {
         masks[i] = ((unsigned int *) bitmasks[i].fAllBits)
                  + voxels[i]*fNPerSlice;
       }
-      unsigned int *maskCrossed = crossed
+      unsigned int *maskCrossed = crossed != nullptr
                                 ? (unsigned int *)crossed->fAllBits : 0;
 
       for (G4int i = 0 ; i < fNPerSlice; ++i)
@@ -1165,8 +1159,8 @@ G4Voxelizer_v1051::GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
 
 //______________________________________________________________________________
 G4int
-G4Voxelizer_v1051::GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
-                          std::vector<G4int> &list, G4SurfBits *crossed) const
+G4Voxelizer_v1072::GetCandidatesVoxelArray(const std::vector<G4int>& voxels,
+                          std::vector<G4int>& list, G4SurfBits* crossed) const
 {
   // Method returning the candidates corresponding to the passed point
 
@@ -1174,9 +1168,9 @@ G4Voxelizer_v1051::GetCandidatesVoxelArray(const std::vector<G4int> &voxels,
 }
 
 //______________________________________________________________________________
-G4bool G4Voxelizer_v1051::Contains(const G4ThreeVector &point) const
+G4bool G4Voxelizer_v1072::Contains(const G4ThreeVector& point) const
 {
-  for (G4int i = 0; i < 3; ++i)
+  for (auto i = 0; i < 3; ++i)
   {
     if (point[i] < fBoundaries[i].front() || point[i] > fBoundaries[i].back())
       return false;
@@ -1186,8 +1180,8 @@ G4bool G4Voxelizer_v1051::Contains(const G4ThreeVector &point) const
 
 //______________________________________________________________________________
 G4double
-G4Voxelizer_v1051::DistanceToFirst(const G4ThreeVector &point,
-                             const G4ThreeVector &direction) const
+G4Voxelizer_v1072::DistanceToFirst(const G4ThreeVector& point,
+                             const G4ThreeVector& direction) const
 {
   G4ThreeVector pointShifted = point - fBoundingBoxCenter;
   G4double shift = fBoundingBox.DistanceToIn(pointShifted, direction);
@@ -1196,7 +1190,7 @@ G4Voxelizer_v1051::DistanceToFirst(const G4ThreeVector &point,
 
 //______________________________________________________________________________
 G4double
-G4Voxelizer_v1051::DistanceToBoundingBox(const G4ThreeVector &point) const
+G4Voxelizer_v1072::DistanceToBoundingBox(const G4ThreeVector& point) const
 {
   G4ThreeVector pointShifted = point - fBoundingBoxCenter;
   G4double shift = MinDistanceToBox(pointShifted, fBoundingBoxSize);
@@ -1205,8 +1199,8 @@ G4Voxelizer_v1051::DistanceToBoundingBox(const G4ThreeVector &point) const
 
 //______________________________________________________________________________
 G4double
-G4Voxelizer_v1051::MinDistanceToBox (const G4ThreeVector &aPoint,
-                               const G4ThreeVector &f)
+G4Voxelizer_v1072::MinDistanceToBox (const G4ThreeVector& aPoint,
+                               const G4ThreeVector& f)
 {
   // Estimates the isotropic safety from a point outside the current solid to
   // any of its surfaces. The algorithm may be accurate or should provide a
@@ -1222,23 +1216,23 @@ G4Voxelizer_v1051::MinDistanceToBox (const G4ThreeVector &aPoint,
 
   G4double safsq = 0.0;
   G4int count = 0;
-  if ( safx > 0 ) { safsq += safx*safx; count++; }
-  if ( safy > 0 ) { safsq += safy*safy; count++; }
-  if ( safz > 0 ) { safsq += safz*safz; count++; }
+  if ( safx > 0 ) { safsq += safx*safx; ++count; }
+  if ( safy > 0 ) { safsq += safy*safy; ++count; }
+  if ( safz > 0 ) { safsq += safz*safz; ++count; }
   if (count == 1) return safe;
   return std::sqrt(safsq);
 }
 
 //______________________________________________________________________________
 G4double
-G4Voxelizer_v1051::DistanceToNext(const G4ThreeVector &point,
-                            const G4ThreeVector &direction,
-                                  std::vector<G4int> &curVoxel) const
+G4Voxelizer_v1072::DistanceToNext(const G4ThreeVector& point,
+                            const G4ThreeVector& direction,
+                                  std::vector<G4int>& curVoxel) const
 {
   G4double shift = kInfinity;
 
   G4int cur = 0; // the smallest index, which would be than increased
-  for (int i = 0; i <= 2; ++i)
+  for (G4int i = 0; i <= 2; ++i)
   {
     // Looking for the next voxels on the considered direction X,Y,Z axis
     //
@@ -1281,7 +1275,7 @@ G4Voxelizer_v1051::DistanceToNext(const G4ThreeVector &point,
   }
 
 /*
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     // Looking for the next voxels on the considered direction X,Y,Z axis
     //
@@ -1316,11 +1310,11 @@ G4Voxelizer_v1051::DistanceToNext(const G4ThreeVector &point,
 
 //______________________________________________________________________________
 G4bool
-G4Voxelizer_v1051::UpdateCurrentVoxel(const G4ThreeVector &point,
-                                const G4ThreeVector &direction,
-                                std::vector<G4int> &curVoxel) const
+G4Voxelizer_v1072::UpdateCurrentVoxel(const G4ThreeVector& point,
+                                const G4ThreeVector& direction,
+                                std::vector<G4int>& curVoxel) const
 {
-  for (G4int i = 0; i <= 2; ++i)
+  for (auto i = 0; i <= 2; ++i)
   {
     G4int index = curVoxel[i];
     const std::vector<G4double> &boundary = fBoundaries[i];
@@ -1347,36 +1341,36 @@ G4Voxelizer_v1051::UpdateCurrentVoxel(const G4ThreeVector &point,
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::SetMaxVoxels(G4int max)
+void G4Voxelizer_v1072::SetMaxVoxels(G4int max)
 {
   fMaxVoxels = max;
   fReductionRatio.set(0,0,0);
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::SetMaxVoxels(const G4ThreeVector &ratioOfReduction)
+void G4Voxelizer_v1072::SetMaxVoxels(const G4ThreeVector& ratioOfReduction)
 {
   fMaxVoxels = -1;
   fReductionRatio = ratioOfReduction;
 }
 
 //______________________________________________________________________________
-void G4Voxelizer_v1051::SetDefaultVoxelsCount(G4int count)
+void G4Voxelizer_v1072::SetDefaultVoxelsCount(G4int count)
 {
   fDefaultVoxelsCount = count;
 }
 
 //______________________________________________________________________________
-G4int G4Voxelizer_v1051::GetDefaultVoxelsCount()
+G4int G4Voxelizer_v1072::GetDefaultVoxelsCount()
 {
   return fDefaultVoxelsCount;
 }
 
 //______________________________________________________________________________
-G4int G4Voxelizer_v1051::AllocatedMemory()
+G4int G4Voxelizer_v1072::AllocatedMemory()
 {
   G4int size = fEmpty.GetNbytes();
-  size += fBoxes.capacity() * sizeof(G4VoxelBox_v1051);
+  size += fBoxes.capacity() * sizeof(G4VoxelBox_v1072);
   size += sizeof(G4double) * (fBoundaries[0].capacity()
         + fBoundaries[1].capacity() + fBoundaries[2].capacity());
   size += sizeof(G4int) * (fCandidatesCounts[0].capacity()

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -29,8 +29,8 @@
 #include "G4GeometryTolerance.hh"
 #include "G4GeometryManager.hh"
 #include "G4Version.hh"
-#if G4VERSION_NUMBER < 1040
-#include "G4MultiUnion_v1051.hh" //old version does not support G4MultiUnion naively, so use custom class
+#if G4VERSION_NUMBER < 1072
+#include "G4MultiUnion_v1072.hh" //old version does not support G4MultiUnion naively or is buggy, so use custom class
 #else
 #include "G4MultiUnion.hh"
 #endif
@@ -3292,8 +3292,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
   //jl145------------------------------------------------
 
   // Union of PMT solids to resolve overlap
-#if G4VERSION_NUMBER < 1040
-  G4MultiUnion_v1051* pmt_solid = new G4MultiUnion_v1051("UnitedPMTs_Barrel");
+#if G4VERSION_NUMBER < 1072
+  G4MultiUnion_v1072* pmt_solid = new G4MultiUnion_v1072("UnitedPMTs_Barrel");
 #else
   G4MultiUnion* pmt_solid = new G4MultiUnion("UnitedPMTs_Barrel");
 #endif
@@ -4369,8 +4369,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
   G4String pmtname = "WCMultiPMT";
 
   // Union of PMT solids to resolve overlap
-#if G4VERSION_NUMBER < 1040
-  G4MultiUnion_v1051* pmt_solid = new G4MultiUnion_v1051("UnitedPMTs_Cap");
+#if G4VERSION_NUMBER < 1072
+  G4MultiUnion_v1072* pmt_solid = new G4MultiUnion_v1072("UnitedPMTs_Cap");
 #else
   G4MultiUnion* pmt_solid = new G4MultiUnion("UnitedPMTs_Cap");
 #endif


### PR DESCRIPTION
When testing the new mPMT model to be used in WCTE, there were unknown overlapping warnings related to `G4MultiUnion`. After some investigation, I was pointed to a [bug report](https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2301) which suggested the "coordinates of bounding box of each node" were calculated incorrectly. Only one line has to be fixed, but the bug fix was implemented in geant4 v10.7.2, so I updated the whole custom class anyway, and the warnings were gone. 

Again it shows a geant4 version update is probably favorable for picking up bug fixes and new functionalities, but manpower is always limited (；一_一)