### PR TITLE
Rationalise the default dark noise option for all PMT types

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,8 @@ This file contains the release notes for each version of WCSim. Release notes ca
 Recent updates
 *************************************************************
 
+Bug fix
+* Pull request #432 @tdealtry: Use the same default dark rate time option for all PMT types in WCSim.mac
 
 *************************************************************
 18/04/2024: Notes for v1.12.12

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -164,7 +164,7 @@
 ##################
 # AmBe CALIBRATION SOURCE
 ##################
-# - BGO Placement: Default in source code is false. If set to true, you'll place the BGO inside
+# - BGO Placement: Default in source code is false. If set to true, you'll place the BGO inside
 # the detector geometry at (0,0,0) position. This is only supported if you use ambeevt generator
 # so you can see the tag scintillation light for the AmBe source.
 #/WCSim/BGOPlacement
@@ -235,20 +235,20 @@
 /DarkRate/SetDarkMode 1
 /DarkRate/SetDarkWindow 4000
 
-#/DarkRate/SetDetectorElement OD
+/DarkRate/SetDetectorElement OD
 #/DarkRate/SetDarkRate 0 kHz
 #/DarkRate/SetDarkRate 1 kHz
 #/DarkRate/SetConvert 1.367 #for 8" PMTs in HK OD
-#/DarkRate/SetDarkMode 1
-#/DarkRate/SetDarkWindow 4000
+/DarkRate/SetDarkMode 1
+/DarkRate/SetDarkWindow 4000
 
-#/DarkRate/SetDetectorElement tankPMT2
+/DarkRate/SetDetectorElement tankPMT2
 #/DarkRate/SetDarkRate 0 kHz
 #/DarkRate/SetDarkRate 1 kHz
 #/DarkRate/SetConvert 1.110 #for PMT3inchR14374 PMTs in HK mPMT
 #/DarkRate/SetConvert 1.126 #for PMT3inchR12199_02 PMTs in HK mPMT. WARNING value needs checking!
-#/DarkRate/SetDarkMode 1
-#/DarkRate/SetDarkWindow 4000
+/DarkRate/SetDarkMode 1
+/DarkRate/SetDarkWindow 4000
 
 ##################
 # VISUALISATION
@@ -305,7 +305,7 @@
 ## This is similar to the nuance format option, though this uses datatable formatted files.
 ## Datatables are formatted as follows:
 ## | Index of particle in event | PDG code | Energy | X | Y | Z | Px | Py | Pz | Time |
-## Note that the column separators "|" are for clarity in describing the format, and should not be included in the file
+## Note that the column separators "|" are for clarity in describing the format, and should not be included in the file
 ## Note also that comments are allowed in the data table file by starting lines with a "#"
 #/mygen/generator datatable
 #/mygen/vecfile inputDataTableFile

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -101,6 +101,8 @@ int sample_readfile(const char *filename="../wcsim.root", TString events_tree_na
       printf("Event Number (from loop): %ld\n", ievent);
       printf("Event Number (from WCSimRootEventHeader): %d\n", wcsimrootevent->GetHeader()->GetEvtNum());
       printf("Trigger Time [ns]: %ld\n", wcsimrootevent->GetHeader()->GetDate());
+      cout << "Trigger Type: " << wcsimrootevent->GetTriggerType()
+           << " " << WCSimEnumerations::EnumAsString(wcsimrootevent->GetTriggerType()) << endl;
       printf("Interaction Nuance Code: %d\n", wcsimrootevent->GetMode());
       printf("Number of Delayed Triggers (sub events): %d\n",
        wcsimrootsuperevent->GetNumberOfSubEvents());


### PR DESCRIPTION
Currently the default dark rate when running WCSim.mac is
- For first-type ID, we have dark noise simulated around true physics hits, ±2000 ns
- For second-type ID & OD, we have dark noise simulated at absolute times [0, 100000] ns

which is very confusing when using HK FD or IWCD+OD geometries.

This PR sets the default to be ±2000 ns around true physics hits