### PR TITLE
Add option to select WCSimRoot only installation

### DIFF
--- a/.github/workflows/build_wcsimroot.yml
+++ b/.github/workflows/build_wcsimroot.yml
@@ -1,0 +1,82 @@
+name: Build WCSimRoot
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request_target: #runs on the PR branch, rather than the merge branch. But is required for access to secrets
+    branches: [ develop ]
+  release:
+  
+concurrency:
+  #When a PR is pushed too multiple times in a short period, this would usually trigger multiple CI runs
+  #This setting cancels any in-progress CI when a new push is performed
+  #But we can have multiple jobs testing different things
+  # It should be that
+  # * Each push to a PR cancels any in progress PR CI
+  # * Each push to develop cancels any in progress develop push-triggered CI
+  # * It seems that PR merges to develop don't get cancelled. This is actually a good thing
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    #This should mean that only one "build" job runs at a time
+    # Meaning there should be no webpage clashes if multiple CI runs are triggered
+    # in a short period
+    concurrency:
+      group: wcsim_build_wcsimroot
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: /opt/
+    #run inside a container that has the prerequisites already installed
+    container:
+      image: docker://ghcr.io/hyperk/wcsimroot
+      credentials:
+           username: ${{ github.actor }}
+           password: ${{ secrets.CONTAINER_REPO }}
+      env:
+        #GIT_COMMIT: ${{ github.sha }}
+        GIT_PULL_REQUEST: ${{ github.event.number }}
+        GIT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+        GIT_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        GitHubToken: ${{ secrets.VALIDATION_PR }}
+        ValidationPath: /opt/Validation/
+    steps:
+      # Print all the info about the action
+      - name: Logging
+        run: |
+          echo "Test print"
+        #echo "${{toJSON(github)}}"
+    
+      - name: Get repo to checkout
+        id: checkout_repo
+        uses: haya14busa/action-cond@v1
+        with:
+          cond: ${{ github.event_name == 'pull_request_target' }}
+          if_true: ${{ github.event.pull_request.head.repo.full_name }}
+          if_false: ${{ github.repository }}
+          
+      - name: Get SHA to checkout
+        id: checkout_sha
+        uses: haya14busa/action-cond@v1
+        with:
+          cond: ${{ github.event_name == 'pull_request_target' }}
+          if_true: ${{ github.event.pull_request.head.sha }}
+          if_false: ${{ github.sha }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout WCSim
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout_sha.outputs.value }}
+          repository: ${{ steps.checkout_repo.outputs.value }}
+
+      - name: Build
+        run: |
+          source /usr/local/hk/hk-pilot/setup.sh
+          pwd
+          hkp install .
+

--- a/.github/workflows/build_wcsimroot.yml
+++ b/.github/workflows/build_wcsimroot.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
 
-  build:
+  build_wcsim:
     runs-on: ubuntu-latest
     #This should mean that only one "build" job runs at a time
     # Meaning there should be no webpage clashes if multiple CI runs are triggered

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,15 @@ pbuilder_prepare_project()
 
 set(CMAKE_CXX_STANDARD 14) # Enable c++14 standard
 
-
+# Add a WCSimRoot library installation (simpler dependencies, used in fitqun)
+option (WCSim_WCSimRoot_only
+        "Allows to only install the WCSimROOT library (file format); no need for G4!"
+        OFF
+)
+MESSAGE(STATUS "WCSim_WCSimRoot_only: ${WCSim_WCSimRoot_only}")
+if (${WCSim_WCSimRoot_only})
+    MESSAGE(STATUS "Will install only WCSimRoot library; disabling Geant4 package search!")
+endif ()
 
 ######
 # ROOT
@@ -50,24 +58,27 @@ include_directories (${ROOT_INCLUDE_DIR})
 LIST(APPEND PUBLIC_EXT_LIBS ${ROOT_LIBRARIES})
 
 
-#----------------------------------------------------------------------------
-# Find Geant4 package, activating all available UI and Vis drivers by default
-# You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
-# to build a batch mode only executable
-#
-option(WITH_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
-if(WITH_GEANT4_UIVIS)
-    find_package(Geant4 REQUIRED ui_all vis_all)
-else()
-    find_package(Geant4 REQUIRED)
-endif()
-LIST(APPEND PUBLIC_EXT_LIBS ${Geant4_LIBRARIES})
 
-#----------------------------------------------------------------------------
-# Setup Geant4 include directories and compile definitions
-# Setup include directory for this project
-#
-include(${Geant4_USE_FILE})  ## NOT needed for Dict
+
+if (NOT ${WCSim_WCSimRoot_only}) # only looking for G4 if WCSim_WCSimRoot_only is false
+    #----------------------------------------------------------------------------
+    # Find Geant4 package, activating all available UI and Vis drivers by default
+    # You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
+    # to build a batch mode only executable
+    option(WITH_GEANT4_UIVIS "Build example with Geant4 UI and Vis drivers" ON)
+    if(WITH_GEANT4_UIVIS)
+        find_package(Geant4 REQUIRED ui_all vis_all)
+    else()
+        find_package(Geant4 REQUIRED)
+    endif()
+    LIST(APPEND PUBLIC_EXT_LIBS ${Geant4_LIBRARIES})
+    #----------------------------------------------------------------------------
+    # Setup Geant4 include directories and compile definitions
+    # Setup include directory for this project
+    #
+    include(${Geant4_USE_FILE})  ## NOT needed for Dict
+endif()
+
 
 #########
 # C++ Standard and flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,18 @@ cmake_minimum_required(VERSION 3.1)
 # ##############################################################################
 
 set(PROJECT_NAME WCSim)
+
+# Add a WCSimRoot library installation (simpler dependencies, used in fitqun)
+option (WCSim_WCSimRoot_only
+        "Allows to only install the WCSimROOT library (file format); no need for G4!"
+        OFF
+)
+MESSAGE(STATUS "WCSim_WCSimRoot_only: ${WCSim_WCSimRoot_only}")
+if (${WCSim_WCSimRoot_only})
+    MESSAGE(STATUS "Will install only WCSimRoot library; disabling Geant4 package search!")
+    set(PROJECT_NAME WCSimRoot)
+endif ()
+
 set(PROJECT_VERSION 1.12.12)
 
 project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
@@ -32,15 +44,6 @@ pbuilder_prepare_project()
 
 set(CMAKE_CXX_STANDARD 14) # Enable c++14 standard
 
-# Add a WCSimRoot library installation (simpler dependencies, used in fitqun)
-option (WCSim_WCSimRoot_only
-        "Allows to only install the WCSimROOT library (file format); no need for G4!"
-        OFF
-)
-MESSAGE(STATUS "WCSim_WCSimRoot_only: ${WCSim_WCSimRoot_only}")
-if (${WCSim_WCSimRoot_only})
-    MESSAGE(STATUS "Will install only WCSimRoot library; disabling Geant4 package search!")
-endif ()
 
 ######
 # ROOT
@@ -227,7 +230,11 @@ add_subdirectory (src)
 # Configure package and final installation files
 #########
 
+if (NOT ${WCSim_WCSimRoot_only})
 configure_file(${PROJECT_SOURCE_DIR}/cmake/WCSimConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/WCSimConfig.cmake @ONLY)
+else ()
+    configure_file(${PROJECT_SOURCE_DIR}/cmake/WCSimRootConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/WCSimRootConfig.cmake @ONLY)
+endif()
 pbuilder_do_package_config()
 
 configure_file(cmake/this_wcsim.sh.in this_wcsim.sh)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The automated building testing is currently performed inside the hk-software doc
 * gcc 8.5.0
 * cmake 3.20.2
 
+If you just need to read WCSim output files, you can do this without the G4 dependency using the `WCSim_WCSimRoot_only` CMake option (see [here](#wcsim-cmake-build-options)).
+
 And as such this is the most supported version of the software (it is guaranteed to work)
 
 Other versions of prerequisite software can be tried, but aren't guaranteed to work. 
@@ -140,6 +142,7 @@ Useful cmake commands:
 * `-DWCSim_Geometry_Overlaps_CHECK=<ON|OFF>` If ON, turns on geometry overlap checking (slow, but important when setting new detector geometry options). Default: OFF
 * `-DWCSim_DEBUG_COMPILE_FLAG=<ON|OFF>` If ON, turns on the gcc debug compiler flag `-g`. Default: OFF
 * `-DWCSIM_SAVE_PHOTON_HISTORY_FLAG=<ON|OFF>` If ON, turns on photon scattering/reflection history saving. The data class `WCSimRootCherenkovHitHistory` is used in a similar way as `WCSimRootCherenkovHitTime`. Default: OFF
+* `-DWCSim_WCSimRoot_only=<ON|OFF>` If ON, only builds the WCSimRoot library (ignoring the WCSimCore one). This is useful if one wants only to read the WCSim output files (for e.g. reconstruction) and not running any simulation.
 
 #### Build with CMake on sukap:
 

--- a/cmake/WCSimRootConfig.cmake.in
+++ b/cmake/WCSimRootConfig.cmake.in
@@ -1,0 +1,15 @@
+# WCSimRootConfig.cmake
+
+get_filename_component( WCSimRoot_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH )
+
+include( CMakeFindDependencyMacro )
+find_dependency( ROOT REQUIRED )
+
+include("${WCSimRoot_CMAKE_DIR}/WCSimRoot_Library_Targets.cmake")
+
+find_library(WCSimRoot_LIBRARIES REQUIRED
+        NAMES WCSimRoot
+        HINTS @CMAKE_INSTALL_PREFIX@/@LIB_INSTALL_SUBDIR@)
+
+list(APPEND WCSimRoot_LIBRARIES
+        ${WCSimRoot_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 # WCSimRoot library
 
 set (dict_headers
+		${PROJECT_SOURCE_DIR}/include/jhfNtuple.h
         ${PROJECT_SOURCE_DIR}/include/WCSimRootEvent.hh
         ${PROJECT_SOURCE_DIR}/include/WCSimRootGeom.hh
         ${PROJECT_SOURCE_DIR}/include/WCSimPmtInfo.hh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,24 +3,30 @@
 # Date: Jul 27, 2022
 
 # Core library
-
+#
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
-file(GLOB headers 
-        ${PROJECT_SOURCE_DIR}/include/*.hh 
+file(GLOB headers
+        ${PROJECT_SOURCE_DIR}/include/*.hh
         ${PROJECT_SOURCE_DIR}/include/*.h
         ${PROJECT_SOURCE_DIR}/include/*.hpp)
 
-# ###########
-# # Library #
-# ###########
+## ###########
+## # Library #
+## ###########
 
-pbuilder_library(
-        TARGET WCSimCore
-        SOURCES ${sources}
-        PROJECT_LIBRARIES WCSimRoot
-        PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
-        PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
-)
+set ( WCSIM_LIBS_TO_EXPORT )
+
+if (NOT ${WCSim_WCSimRoot_only})
+	pbuilder_library(
+			TARGET WCSimCore
+			SOURCES ${sources}
+			PROJECT_LIBRARIES WCSimRoot
+			PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
+			PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
+	)
+	LIST(APPEND WCSIM_LIBS_TO_EXPORT WCSimCore)
+
+endif()
 
 
 # WCSimRoot library
@@ -64,49 +70,56 @@ pbuilder_library(
         PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
         PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
 )
+LIST(APPEND WCSIM_LIBS_TO_EXPORT WCSimRoot)
 
 
 
 pbuilder_component_install_and_export(
         COMPONENT Library
-        LIBTARGETS WCSimCore WCSimRoot
+        LIBTARGETS  ${WCSIM_LIBS_TO_EXPORT}
 )
 
-pbuilder_install_headers(${headers})
+if (${WCSim_WCSimRoot_only})
+	pbuilder_install_headers(${dict_headers})
+else ()
+	pbuilder_install_headers(${headers})
+endif ()
 
 
-##############
-# Executable
-##############
+###############
+## Executable
+###############
 
-set (exe_sources
-        ${PROJECT_SOURCE_DIR}/WCSim.cc
-        )
-set(exe_libraries
-        WCSimCore WCSimRoot
-        )
+if (NOT ${WCSim_WCSimRoot_only})
+	set (exe_sources
+			${PROJECT_SOURCE_DIR}/WCSim.cc
+			)
+	set(exe_libraries
+			WCSimCore WCSimRoot
+			)
 
-MESSAGE(${PUBLIC_EXT_LIBS})
+	MESSAGE(${PUBLIC_EXT_LIBS})
 
-pbuilder_executables(
-        SOURCES ${exe_sources}
-        TARGETS_VAR programs
-        PROJECT_LIBRARIES ${exe_libraries}
-        PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
-        PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
-)
+	pbuilder_executables(
+			SOURCES ${exe_sources}
+			TARGETS_VAR programs
+			PROJECT_LIBRARIES ${exe_libraries}
+			PUBLIC_EXTERNAL_LIBRARIES ${PUBLIC_EXT_LIBS}
+			PRIVATE_EXTERNAL_LIBRARIES ${PRIVATE_EXT_LIBS}
+	)
 
-pbuilder_component_install_and_export(
-        COMPONENT Executables
-        EXETARGETS ${programs}
-)
-##############
-# WCSim compilation options
-##############
+	pbuilder_component_install_and_export(
+			COMPONENT Executables
+			EXETARGETS ${programs}
+	)
+	##############
+	# WCSim compilation options
+	##############
 
-target_compile_definitions(WCSimCore PRIVATE
-        WCSIM_CHECK_GEOMETRY_OVERLAPS=${WCSIM_CHECK_GEOMETRY_OVERLAPS}
-)
-target_compile_definitions(WCSim PRIVATE
-        WCSIM_CHECK_GEOMETRY_OVERLAPS=${WCSIM_CHECK_GEOMETRY_OVERLAPS}
-)
+	target_compile_definitions(WCSimCore PRIVATE
+			WCSIM_CHECK_GEOMETRY_OVERLAPS=${WCSIM_CHECK_GEOMETRY_OVERLAPS}
+	)
+	target_compile_definitions(WCSim PRIVATE
+			WCSIM_CHECK_GEOMETRY_OVERLAPS=${WCSIM_CHECK_GEOMETRY_OVERLAPS}
+	)
+endif()

--- a/src/WCSimEnumerations.cc
+++ b/src/WCSimEnumerations.cc
@@ -1,6 +1,5 @@
 #include <string>
 #include <iostream>
-#include "G4ios.hh"
 
 #include "WCSimEnumerations.hh"
 


### PR DESCRIPTION
This allows to only install WCSimRoot libraries using the `-D WCSim_WCSimRoot_only=ON` cmake option.
When doing so, all the G4 dependencies won't be looked for, only looking for ROOT

This allows for packages to be able to decode the file format, but not run the simulation itself, allowing a cleaner split between the simulation and the reconstruction.
For HK, this should take the form of a new package `hyperk/WCSimRoot` used by fiTQun (and others...) instead of the full WCSim package.
