### PR TITLE
Bug fix for muline event beam information

### DIFF
--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -315,8 +315,6 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 	  beamdirs[iVertex] = G4ThreeVector(atof(token[3]),
 					    atof(token[4]),
 					    atof(token[5]));
-	  SetBeamEnergy(beamenergies[iVertex]);
-	  SetBeamDir(beamdirs[iVertex]);
 	  G4cout << "Neutrino generated is = "<< beampdgs[iVertex]<<", Enu = " << beamenergies[iVertex] << " and interacts through mode = " << mode[iVertex] << G4endl;
 
 	  // Now read the target line


### PR DESCRIPTION
When using a muline file with multiple vertices per event, the old logic for saving the beam direction & energy was
1. Set the beam energy & direction of the ith vertex correctly
2. Set the beam energy & direction of the 0th vertex to the values from the ith vertex

This means that the 0th vertex beam energy & direction was always incorrect (in the case you're running with multiple vertices)

This fix removes the 2nd step, meaning the beam energy & direction is now correct for all vertices

Note that beam PDG is not effected by this bug