### PR TITLE
And an attempt to make it mac compatible...

### DIFF
--- a/sample-root-scripts/Makefile
+++ b/sample-root-scripts/Makefile
@@ -6,7 +6,7 @@ ROOTLIBS     	:= $(shell root-config --libs)
 ROOTGLIBS    	:= $(shell root-config --glibs)
 CXXFLAGS	+= $(ROOTCFLAGS)
 
-LIBS 		= $(ROOTGLIBS) $(WCSIM_BUILD_DIR)/lib/libWCSimRoot.so -lMinuit
+LIBS 		= $(ROOTGLIBS) -L$(WCSIM_BUILD_DIR)/lib -lWCSimRoot -lMinuit
 
 INC = $(WCSIM_BUILD_DIR)/include/WCSim
 SRC= $(WCSIMDIR)/src


### PR DESCRIPTION
Instead of looking for the file path with an explicit `.so`, use gcc's `-L` and `-l` commands, so it will hopefully pickup a `.dylib` extension

Follow on from #447 