### PR TITLE
Fix comsic muon position and direction for NuPrism type detector

### DIFF
--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1160,6 +1160,12 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     posInCyl.setY(posInCylR*sin(posInCylPhi));
     posInCyl.setZ(posInCylZ);
 
+    if (myDetector->GetIsNuPrism())
+    {
+      dir.rotateX(-90.*deg);
+      posInCyl.rotateX(-90.*deg);
+    }
+
     // generate muon at the intersection
     // between an sphere with radius = altComics
     // and a line made with the muon direction


### PR DESCRIPTION
For NuPrsim type geometry, the detector is rotated such that y-axis is the vertical axis of the cylinder. This makes the cosmic muon generator not working properly, i.e. muons are coming from the side of the detector instead of the top. 

This PR makes a quick fix for the muon direction and position. However, we still need the properly flux files for non-HK detector sites (IWCD, WCTE).