### PR TITLE
Update where yum gets its info from

### DIFF
--- a/.github/workflows/build_and_physics_test.yml
+++ b/.github/workflows/build_and_physics_test.yml
@@ -98,6 +98,9 @@ jobs:
 
       - name: Install HepMC3
         run: |
+          cd /etc/yum.repos.d/
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum install -y HepMC3 HepMC3-devel HepMC3-search HepMC3-search-devel HepMC3-interfaces-devel HepMC3-doc
   
       - name: Print environment
@@ -195,6 +198,9 @@ jobs:
 
       - name: Install HepMC3
         run: |
+          cd /etc/yum.repos.d/
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum install -y HepMC3 HepMC3-devel HepMC3-search HepMC3-search-devel HepMC3-interfaces-devel HepMC3-doc
 
       - name: Build, with added geometry checks

--- a/.github/workflows/build_wcsimroot.yml
+++ b/.github/workflows/build_wcsimroot.yml
@@ -76,6 +76,9 @@ jobs:
 
       - name: Install HepMC3
         run: |
+          cd /etc/yum.repos.d/
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum install -y HepMC3 HepMC3-devel HepMC3-search HepMC3-search-devel HepMC3-interfaces-devel HepMC3-doc
 
       - name: Link WCSim directory

--- a/.github/workflows/on_tag.yml
+++ b/.github/workflows/on_tag.yml
@@ -84,6 +84,9 @@ jobs:
 
       - name: Install HepMC3
         run: |
+          cd /etc/yum.repos.d/
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum install -y HepMC3 HepMC3-devel HepMC3-search HepMC3-search-devel HepMC3-interfaces-devel HepMC3-doc
 
       - name: Print environment
@@ -179,6 +182,9 @@ jobs:
 
       - name: Install HepMC3
         run: |
+          cd /etc/yum.repos.d/
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum install -y HepMC3 HepMC3-devel HepMC3-search HepMC3-search-devel HepMC3-interfaces-devel HepMC3-doc
 
       - name: Build


### PR DESCRIPTION
CI is currently failing at the `yum install` stage

This seems to because CentOS Stream 8 (the CI OS) [became EOL on 31 May 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/)

Trying [this stackoverflow fix](https://stackoverflow.com/a/71309215)