### PR TITLE
Rework photocathode parameter input method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,10 @@ pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/data
         ${PROJECT_SOURCE_DIR}/data/ground_state_spectrum.txt
         ${PROJECT_SOURCE_DIR}/data/first_excited_spectrum.txt
         ${PROJECT_SOURCE_DIR}/data/second_excited_spectrum.txt
+        ${PROJECT_SOURCE_DIR}/data/CathodeParameters.txt
+        ${PROJECT_SOURCE_DIR}/data/CathodeParameters_SK.txt
+        ${PROJECT_SOURCE_DIR}/data/CathodeParameters_KCsCb.txt
+        ${PROJECT_SOURCE_DIR}/data/CathodeParameters_RbCsCb.txt
 	)
 
 pbuilder_install_files(${CMAKE_INSTALL_PREFIX}/macros

--- a/data/CathodeParameters.txt
+++ b/data/CathodeParameters.txt
@@ -1,0 +1,5 @@
+# Default photocathode model in WCSim
+# For a description of the format of this file, see $WCSIMDIR/doc/CathodeParameterFormat.md
+
+#DATASTART
+0 0 0

--- a/data/CathodeParameters_KCsCb.txt
+++ b/data/CathodeParameters_KCsCb.txt
@@ -1,13 +1,5 @@
-# First line is: photocathode_model_choice cathode_thickness number_of_cathode_points
-# photocathode_model_choice: 0 = default model, 1 or 2 = new models
-# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
-# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
-# Cannot handle total internal reflection when n1<n2
-# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
-# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
-# cathode_thickness: unit = nm
-# number_of_cathode_points: number of points to read refractive indices (limited to <=100)
-# each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
+# Model 2 with parameters of alloy KCsCb in the paper
+# For a description of the format of this file, see $WCSIMDIR/doc/CathodeParameterFormat.md
 
 #DATASTART
 2 20.0 23

--- a/data/CathodeParameters_KCsCb.txt
+++ b/data/CathodeParameters_KCsCb.txt
@@ -1,0 +1,36 @@
+# First line is: photocathode_model_choice cathode_thickness number_of_cathode_points
+# photocathode_model_choice: 0 = default model, 1 or 2 = new models
+# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
+# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
+# Cannot handle total internal reflection when n1<n2
+# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
+# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
+# cathode_thickness: unit = nm
+# number_of_cathode_points: number of points to read refractive indices
+# each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
+
+#DATASTART
+2 20.0 23
+1.000 2.96 0.33
+1.823 2.96 0.33
+1.864 2.95 0.34
+1.907 2.95 0.34
+1.953 2.95 0.35
+2.000 2.96 0.37
+2.049 2.98 0.38
+2.101 3.01 0.42
+2.156 3.06 0.46
+2.214 3.12 0.53
+2.275 3.20 0.63
+2.339 3.26 0.86
+2.407 3.09 1.05
+2.480 3.00 1.06
+2.556 3.00 1.11
+2.638 3.00 1.34
+2.725 2.87 1.44
+2.818 2.70 1.50
+2.917 2.61 1.53
+3.024 2.38 1.71
+3.139 2.18 1.69
+3.263 1.92 1.69
+9.000 1.92 1.69

--- a/data/CathodeParameters_KCsCb.txt
+++ b/data/CathodeParameters_KCsCb.txt
@@ -6,7 +6,7 @@
 # "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
 # Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
 # cathode_thickness: unit = nm
-# number_of_cathode_points: number of points to read refractive indices
+# number_of_cathode_points: number of points to read refractive indices (limited to <=100)
 # each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
 
 #DATASTART

--- a/data/CathodeParameters_RbCsCb.txt
+++ b/data/CathodeParameters_RbCsCb.txt
@@ -1,13 +1,5 @@
-# First line is: photocathode_model_choice cathode_thickness number_of_cathode_points
-# photocathode_model_choice: 0 = default model, 1 or 2 = new models
-# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
-# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
-# Cannot handle total internal reflection when n1<n2
-# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
-# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
-# cathode_thickness: unit = nm
-# number_of_cathode_points: number of points to read refractive indices (limited to <=100)
-# each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
+# Model 2 with parameters of alloy RbCsCb in the paper
+# For a description of the format of this file, see $WCSIMDIR/doc/CathodeParameterFormat.md
 
 #DATASTART
 2 23.4 23

--- a/data/CathodeParameters_RbCsCb.txt
+++ b/data/CathodeParameters_RbCsCb.txt
@@ -1,0 +1,36 @@
+# First line is: photocathode_model_choice cathode_thickness number_of_cathode_points
+# photocathode_model_choice: 0 = default model, 1 or 2 = new models
+# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
+# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
+# Cannot handle total internal reflection when n1<n2
+# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
+# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
+# cathode_thickness: unit = nm
+# number_of_cathode_points: number of points to read refractive indices
+# each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
+
+#DATASTART
+2 23.4 23
+1.000 3.13 0.35
+1.823 3.13 0.35
+1.864 3.14 0.37
+1.907 3.14 0.37
+1.953 3.15 0.38
+2.000 3.18 0.40
+2.049 3.22 0.43
+2.101 3.28 0.46
+2.156 3.39 0.59
+2.214 3.32 0.76
+2.275 3.23 0.86
+2.339 3.21 0.90
+2.407 3.22 1.04
+2.480 3.16 1.21
+2.556 2.99 1.37
+2.638 2.81 1.41
+2.725 2.63 1.40
+2.818 2.50 1.35
+2.917 2.40 1.27
+3.024 2.30 1.21
+3.139 2.22 1.17
+3.263 2.07 1.22
+9.000 2.07 1.22

--- a/data/CathodeParameters_RbCsCb.txt
+++ b/data/CathodeParameters_RbCsCb.txt
@@ -6,7 +6,7 @@
 # "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
 # Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
 # cathode_thickness: unit = nm
-# number_of_cathode_points: number of points to read refractive indices
+# number_of_cathode_points: number of points to read refractive indices (limited to <=100)
 # each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
 
 #DATASTART

--- a/data/CathodeParameters_SK.txt
+++ b/data/CathodeParameters_SK.txt
@@ -1,0 +1,19 @@
+# First line is: photocathode_model_choice cathode_thickness number_of_cathode_points
+# photocathode_model_choice: 0 = default model, 1 or 2 = new models
+# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
+# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
+# Cannot handle total internal reflection when n1<n2
+# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
+# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
+# cathode_thickness: unit = nm
+# number_of_cathode_points: number of points to read refractive indices
+# each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
+
+#DATASTART
+2 11.5 6
+1.000 3.4 1.7
+2.786 3.4 1.7
+3.061 3.1 1.6
+3.306 2.8 1.5
+3.679 2.4 1.4
+9.000 2.4 1.4

--- a/data/CathodeParameters_SK.txt
+++ b/data/CathodeParameters_SK.txt
@@ -1,13 +1,5 @@
-# First line is: photocathode_model_choice cathode_thickness number_of_cathode_points
-# photocathode_model_choice: 0 = default model, 1 or 2 = new models
-# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
-# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
-# Cannot handle total internal reflection when n1<n2
-# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
-# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
-# cathode_thickness: unit = nm
-# number_of_cathode_points: number of points to read refractive indices (limited to <=100)
-# each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
+# Model 2 with SK-like parameters
+# For a description of the format of this file, see $WCSIMDIR/doc/CathodeParameterFormat.md
 
 #DATASTART
 2 11.5 6

--- a/data/CathodeParameters_SK.txt
+++ b/data/CathodeParameters_SK.txt
@@ -6,7 +6,7 @@
 # "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
 # Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
 # cathode_thickness: unit = nm
-# number_of_cathode_points: number of points to read refractive indices
+# number_of_cathode_points: number of points to read refractive indices (limited to <=100)
 # each subsequent line is: photon_energy_in_eV refractive_index_real refractive_index_imaginary
 
 #DATASTART

--- a/doc/CathodeParameterFormat.md
+++ b/doc/CathodeParameterFormat.md
@@ -1,0 +1,28 @@
+# Cathode Parameter format
+This describes the format for a file containing the cathode parameters, set by `/WCSim/tuning/PMTCathodePara`
+
+An example is shown below:
+```
+#DATASTART
+2 11.5 6
+1.000 3.4 1.7
+2.786 3.4 1.7
+3.061 3.1 1.6
+3.306 2.8 1.5
+3.679 2.4 1.4
+9.000 2.4 1.4
+```
+
+Each line represents the following:
+* `#DATASTART`
+  * Marks the start of the data.
+* `2 11.5 6`
+  * The first number is the choice of the photocathode model : 0 = default model, 1 or 2 = new models. \
+  If set to 0, all other parameters are irrelevant. \
+  Model 1 is copied from [geant4.11](https://ieeexplore.ieee.org/document/9875513), which models the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability, but it cannot handle total internal reflection when n1 < n2. \
+  Model 2 is implemented based on [this paper](https://arxiv.org/abs/physics/0408075v1), which models the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability.
+  * The second number sets the photocathode layer thickness in nm.
+  * The third sets the number of points of photon energy (rows below) to read refractive indices (limited to <=100)
+* `1.000 3.4 1.7` and all lines below
+  * The first number is the photon energy in eV.
+  * The second and third numbers are the real and imaginary refractive indices of the alloy at that point.

--- a/include/WCSimTuningMessenger.hh
+++ b/include/WCSimTuningMessenger.hh
@@ -13,6 +13,7 @@ class G4UIcommand;
 class G4UIcmdWithADouble;
 class G4UIcmdWithABool; //jl145
 class G4UIcmdWithAnInteger;
+class G4UIcmdWithAString;
 
 
 class WCSimTuningMessenger: public G4UImessenger
@@ -39,8 +40,7 @@ private:
   //G4UIcmdWithADouble* Qoiff; //TD 2019.6.26
   //G4UIcmdWithADouble* NLTinfo; //TD 2019.6.26
 
-  G4UIcmdWithAnInteger* PMTSurfType;
-  G4UIcmdWithAnInteger* CathodePara;
+  G4UIcmdWithAString* PMTCathodePara;
 
   //For Top Veto - jl145
   G4UIcmdWithADouble* TVSpacing;

--- a/include/WCSimTuningMessenger.hh
+++ b/include/WCSimTuningMessenger.hh
@@ -12,7 +12,6 @@ class G4UIdirectory;
 class G4UIcommand;
 class G4UIcmdWithADouble;
 class G4UIcmdWithABool; //jl145
-class G4UIcmdWithAnInteger;
 class G4UIcmdWithAString;
 
 

--- a/include/WCSimTuningParameters.hh
+++ b/include/WCSimTuningParameters.hh
@@ -34,8 +34,11 @@ public:
   G4int GetPMTSurfType() {return pmtsurftype;}
   void SetPMTSurfType(G4double rparam) {pmtsurftype=rparam;}
 
-  G4int GetCathodePara() {return cathodepara;}
-  void SetCathodePara(G4double rparam) {cathodepara=rparam;}
+  void ReadCathodeParaTable(std::string);
+  G4double GetCathodeThickness() {return cathodeThickness;}
+  G4int GetNCathodePara() {return nCathodePara;}
+  std::vector<std::vector<G4double>> GetCathodeParaTable() {return cathodeparaTable;}
+
   //Added by TD 2019/06/22
   G4double GetTtsff() {return ttsff;}
   void SetTtsff(G4double rparam) {ttsff=rparam;}
@@ -87,7 +90,9 @@ private:
 
   // PMT photocathode surface properties
   G4int pmtsurftype;
-  G4int cathodepara;
+  G4double cathodeThickness;
+  G4int nCathodePara;
+  std::vector<std::vector<G4double>>  cathodeparaTable;
 
   //For Top Veto - jl145
   G4double tvspacing;

--- a/macros/tuning_parameters.mac
+++ b/macros/tuning_parameters.mac
@@ -12,7 +12,7 @@
 /WCSim/tuning/tvspacing 100
 
 # Input file to set photocathode parameters
-#/WCSim/tuning/PMTCathodePara data/CathodeParameters_KCsCb.txt
+/WCSim/tuning/PMTCathodePara data/CathodeParameters.txt
 
 /WCSim/tuning/WCODWLSCladdingReflectivity 0.90
 /WCSim/tuning/WCODTyvekReflectivity 0.90

--- a/macros/tuning_parameters.mac
+++ b/macros/tuning_parameters.mac
@@ -11,18 +11,8 @@
 # Set top veto PMT spacing in cm.
 /WCSim/tuning/tvspacing 100
 
-
-# Paramater to set photocathode model
-# Set to "0" to use default model, "1" or "2" to use new models
-# "1" is copied from geant4.11, which is based on https://ieeexplore.ieee.org/document/9875513
-# Model the alloy as a thin layer with real refractive index, then calculate reflection and transmission probability
-# Cannot handle total internal reflection when n1<n2
-# "2" is implemented based on https://arxiv.org/abs/physics/0408075v1
-# Model the alloy as a thin layer with real and imaginary refractive indices, then calculate absorption, reflection and transmission probability
-/WCSim/tuning/pmtsurftype 0
-# Choice of photocathode optical parameters.
-# 0 = (Seems to be) SK. 1 = KCsCb, 2 = RbCsCb [1 and 2 from from pmtsurftype Model2's paper]
-/WCSim/tuning/cathodepara 0
+# Input file to set photocathode parameters
+#/WCSim/tuning/PMTCathodePara data/CathodeParameters_KCsCb.txt
 
 /WCSim/tuning/WCODWLSCladdingReflectivity 0.90
 /WCSim/tuning/WCODTyvekReflectivity 0.90

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -7,6 +7,7 @@
 #include "G4UIcmdWithADouble.hh"
 #include "G4UIcmdWithABool.hh" //jl145
 #include "G4UIcmdWithAnInteger.hh"
+#include "G4UIcmdWithAString.hh"
 
 
 WCSimTuningMessenger::WCSimTuningMessenger(WCSimTuningParameters* WCTuningPars):WCSimTuningParams(WCTuningPars) { 
@@ -43,15 +44,10 @@ WCSimTuningMessenger::WCSimTuningMessenger(WCSimTuningParameters* WCTuningPars):
   Mieff->SetGuidance("Set the Mie scattering parameter");
   Mieff->SetParameterName("Mieff",true);
   Mieff->SetDefaultValue(0.0);
-  PMTSurfType = new G4UIcmdWithAnInteger("/WCSim/tuning/pmtsurftype",this);
-  PMTSurfType->SetGuidance("Set the PMT photocathode surface optical model");
-  PMTSurfType->SetParameterName("PMTSurfType",true);
-  PMTSurfType->SetDefaultValue(0);
-  
-  CathodePara = new G4UIcmdWithAnInteger("/WCSim/tuning/cathodepara",this);
-  CathodePara->SetGuidance("Set the PMT photocathode surface parameters");
-  CathodePara->SetParameterName("CathodePara",true);
-  CathodePara->SetDefaultValue(0);
+
+  PMTCathodePara = new G4UIcmdWithAString("/WCSim/tuning/PMTCathodePara",this);
+  PMTCathodePara->SetGuidance("Input file for PMT cathode parameters");
+  PMTCathodePara->SetParameterName("PMTCathodePara",false);
 
   //TD 2019.06.22
   Ttsff = new G4UIcmdWithADouble("/WCSim/tuning/ttsff",this);
@@ -106,8 +102,7 @@ WCSimTuningMessenger::~WCSimTuningMessenger()
   delete Rgcff;
   delete Qeff;//B.Q
   delete Mieff;
-  delete PMTSurfType;
-  delete CathodePara;
+  delete PMTCathodePara;
   delete Ttsff;
   delete PMTSatur;//TD 2019.7.16
   //delete Qoiff; //TD 2019.6.26
@@ -190,14 +185,11 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
     WCSimTuningParams->SetMieff(Mieff->GetNewDoubleValue(newValue));
     G4cout << "Setting Mie scattering parameter " << Mieff->GetNewDoubleValue(newValue) << G4endl;
   }
-  else if(command == PMTSurfType) {
-    WCSimTuningParams->SetPMTSurfType(PMTSurfType->GetNewIntValue(newValue));
-    G4cout << "Setting PMT photocathode surface optical model as Model " << PMTSurfType->GetNewIntValue(newValue) << " (0 means default dielectric model)" << G4endl;
-  }
 
-  else if(command == CathodePara) {
-    WCSimTuningParams->SetCathodePara(CathodePara->GetNewIntValue(newValue));
-    G4cout << "Setting PMT photocathode surface parameters as Choice " << CathodePara->GetNewIntValue(newValue) << " (0 = SK, 1 = KCsRb, 2 = RbCsCb)" << G4endl;
+  else if (command == PMTCathodePara) {
+    WCSimTuningParams->ReadCathodeParaTable(newValue);
+    G4cout << "Setting PMT photocathode surface optical model as Model " << WCSimTuningParams->GetPMTSurfType() << " (0 means default dielectric model)," << G4endl;
+    G4cout << " cahtode thickness = " << WCSimTuningParams->GetCathodeThickness() << " nm, nCathodePara = " << WCSimTuningParams->GetNCathodePara() << G4endl;
   }
 
   else if(command == TVSpacing) {

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -6,7 +6,6 @@
 #include "G4UIparameter.hh"
 #include "G4UIcmdWithADouble.hh"
 #include "G4UIcmdWithABool.hh" //jl145
-#include "G4UIcmdWithAnInteger.hh"
 #include "G4UIcmdWithAString.hh"
 
 

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -188,7 +188,7 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   else if (command == PMTCathodePara) {
     WCSimTuningParams->ReadCathodeParaTable(newValue);
     G4cout << "Setting PMT photocathode surface optical model as Model " << WCSimTuningParams->GetPMTSurfType() << " (0 means default dielectric model)," << G4endl;
-    G4cout << " cahtode thickness = " << WCSimTuningParams->GetCathodeThickness() << " nm, nCathodePara = " << WCSimTuningParams->GetNCathodePara() << G4endl;
+    G4cout << " cathode thickness = " << WCSimTuningParams->GetCathodeThickness() << " nm, nCathodePara = " << WCSimTuningParams->GetNCathodePara() << G4endl;
   }
 
   else if(command == TVSpacing) {


### PR DESCRIPTION
To allow easier calibration studies, define a more flexible method to set photocathode parameters.
Main changes are:

- `WCSimTuningMessenger`: consolidate photocathode macro commands into one, which sets the input file for cathode parameters
- `WCSimTuningParameters`: define method to read cathode parameters
- `WCSimDetectorConstruction::ConstructMaterials()`: remove hard-coded parameters, and get parameters directly from `WCSimTuningParameters`