### PR TITLE
Prevent absolute path to header files being included in the WCSimRoot library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,18 @@ endif()
 # WCSimRoot library
 
 set (dict_headers
-		${PROJECT_SOURCE_DIR}/include/jhfNtuple.h
+        jhfNtuple.h
+        WCSimRootEvent.hh
+        WCSimRootGeom.hh
+        WCSimPmtInfo.hh
+        WCSimEnumerations.hh
+        WCSimRootOptions.hh
+        WCSimRootTools.hh
+        TJNuBeamFlux.hh
+        TNRooTrackerVtx.hh )
+
+set (dict_headers_to_install
+        ${PROJECT_SOURCE_DIR}/include/jhfNtuple.h
         ${PROJECT_SOURCE_DIR}/include/WCSimRootEvent.hh
         ${PROJECT_SOURCE_DIR}/include/WCSimRootGeom.hh
         ${PROJECT_SOURCE_DIR}/include/WCSimPmtInfo.hh
@@ -43,7 +54,7 @@ set (dict_headers
         ${PROJECT_SOURCE_DIR}/include/TNRooTrackerVtx.hh )
 
 set( linkdef_header
-        ${PROJECT_SOURCE_DIR}/include/WCSimRootLinkDef.hh )
+        WCSimRootLinkDef.hh )
 set(sources_root
         WCSimRootEvent.cc
         WCSimRootGeom.cc
@@ -81,7 +92,7 @@ pbuilder_component_install_and_export(
 )
 
 if (${WCSim_WCSimRoot_only})
-	pbuilder_install_headers(${dict_headers})
+	pbuilder_install_headers(${dict_headers_to_install})
 else ()
 	pbuilder_install_headers(${headers})
 endif ()


### PR DESCRIPTION
As found in the HK WCSim container (see discussion [here](https://git.hyperk.org/hyperk/externals/WCSim/-/issues/2)) there is an issue where there are lots of warnings/errors when you attempt to use `libWCSimRoot.so` to read an output file if you have deleted the code source directory, as the absolute path to the headers are included in the library

This PR uses
- a relative path for the argument to `ROOT_GENERATE_DICTIONARY`
- the absolute path for the header installs

@guiguem I wonder if you have any CMake magic to improve this? i.e. to prevent the repition in the definition of `dict_headers` & `dict_headers_to_install`