### PR TITLE
HepMC3 only required for running WCSim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,14 @@ set(CMAKE_CXX_STANDARD 14) # Enable c++14 standard
 ########
 # HepMC3
 ########
-find_package(HepMC3 REQUIRED)
-if (NOT HepMC3_FOUND)
+if (NOT ${WCSim_WCSimRoot_only}) # only looking for HepMC3 if WCSim_WCSimRoot_only is false
+  find_package(HepMC3 REQUIRED)
+  if (NOT HepMC3_FOUND)
     message(FATAL "Unable to find HepMC3")
-endif (NOT HepMC3_FOUND)
-include_directories (${HEPMC3_INCLUDE_DIR})
-LIST(APPEND PUBLIC_EXT_LIBS ${HEPMC3_LIBRARIES})
+  endif (NOT HepMC3_FOUND)
+  include_directories (${HEPMC3_INCLUDE_DIR})
+  LIST(APPEND PUBLIC_EXT_LIBS ${HEPMC3_LIBRARIES})
+endif ()
 
 ######
 # ROOT

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,10 +5,13 @@ This file contains the release notes for each version of WCSim. Release notes ca
 Recent updates
 *************************************************************
 
+WCSim now requires HepMC3 to be installed when compiling with the default option: `-DWCSim_WCSimRoot_only=ON`.
+
 New feature
 * Pull request #433 @JackFannon: NuHepMC Reader and Generator
 
 Update
+* Pull request #458 @tdealtry: Remove HepMC3 dependency when using build option `-DWCSim_WCSimRoot_only=OFF`
 * Pull request #457 @tdealtry: Favour use of `$WCSIM_BUILD_DIR`. Rename `$WCSIMDIR` to `$WCSIM_SOURCE_DIR` and only use it for referencing where documentation/scripts are
 * Pull request #456 @tdealtry: Prevent absolute path to header files being included in the WCSimRoot library
 


### PR DESCRIPTION
Removes the HepMC3 dependency when compiling with the `-DWCSim_WCSimRoot_only=ON` option