### PR TITLE
Include unistd header

### DIFF
--- a/WCSim.cc
+++ b/WCSim.cc
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <sstream>
+#include <unistd.h>
 
 namespace {     // Anonymous namespace for local helper functions and classes
   enum class WCSimExeMode {Batch, Interactive, Unknown};


### PR DESCRIPTION
If not added, I get the following compillation error on MacOS (Sonorama 14.5)

```
/Users/gdiazlop/HK_Software/WCSim/src/WCSim.cc:32:36: error: use of undeclared identifier 'F_OK'
    bool exists = access(filename, F_OK) != -1;
```
