### PR TITLE
BGO Positioning from macro file

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -169,6 +169,9 @@
 # so you can see the tag scintillation light for the AmBe source.
 #/WCSim/BGOPlacement
 # Note that /WCSim/BGOPlacement *must* be set before /WCSim/Construct
+#
+# - BGO Position: Place the source in a different position using X, Y and Z coordinates
+#/WCSim/BGOPosition 1 1 1 m
 
 
 # - /WCSim/SaveCapture & /process/inactivate nKiller: Default not set.

--- a/include/WCSimAmBeGen.hh
+++ b/include/WCSimAmBeGen.hh
@@ -19,18 +19,18 @@ class G4Event;
 class WCSimAmBeGen
 {
   public:
-    WCSimAmBeGen();
+    WCSimAmBeGen(WCSimDetectorConstruction* detector);
     ~WCSimAmBeGen();
 
     // Initialise the AmBe generator
     void Initialise();
-    //void ReadFromFile();
     
     // Set Particle Gun Properties of the neutron and gamma
     G4double NeutronEnergy();
     G4double GammaEnergy();
     void GenerateNG(G4Event* anEvent);
     void SetPositionBGOGeometry(G4double X, G4double Y, G4double Z) { BGOX=X, BGOY=Y, BGOZ=Z; }
+    G4ThreeVector GetPositionBGOGeometry() const { return G4ThreeVector(BGOX, BGOY, BGOZ); }
 
   private:
     G4ParticleGun*        myAmBeGun;
@@ -38,10 +38,11 @@ class WCSimAmBeGen
     G4SPSEneDistribution* nEnergyDistGS;
     G4SPSEneDistribution* nEnergyDistFE;
     G4SPSEneDistribution* nEnergyDistSE;
+    WCSimDetectorConstruction *myDetector;
     
     // Variables for the initialisation of AmBe generator parameters
     G4double gEnergy;
-    G4ThreeVector vtx;
+    G4ThreeVector pos;
     static G4int nGammaOutcomes;
     static G4double gammaProbabilities[3];
     static G4double gammaEnergies[3];

--- a/include/WCSimAmBeGen.hh
+++ b/include/WCSimAmBeGen.hh
@@ -1,6 +1,8 @@
 #ifndef WCSimAmBeGen_h
 #define WCSimAmBeGen_h
 
+#include "WCSimDetectorMessenger.hh"
+
 #include "G4SPSEneDistribution.hh"
 #include "G4SPSRandomGenerator.hh"
 #include "G4RandomDirection.hh"
@@ -28,6 +30,7 @@ class WCSimAmBeGen
     G4double NeutronEnergy();
     G4double GammaEnergy();
     void GenerateNG(G4Event* anEvent);
+    void SetPositionBGOGeometry(G4double X, G4double Y, G4double Z) { BGOX=X, BGOY=Y, BGOZ=Z; }
 
   private:
     G4ParticleGun*        myAmBeGun;
@@ -46,6 +49,7 @@ class WCSimAmBeGen
     G4double time;
     G4ThreeVector dir;
     G4double epsilon;
+    G4double BGOX, BGOY, BGOZ;
 
     // Variables for reading in the file
     string wcsimdir;

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -102,6 +102,7 @@ public:
   void SetIWCD_WithOD_Geometry_Old(); // Old geometry used from v1.12.5 to v1.12.11
   void SetPlaceBGOGeometry(G4bool placeBGO) { placeBGOGeometry=placeBGO; } // Diego Costas, 26/02/2024
   G4bool IsBGOGeometrySet() const { return placeBGOGeometry; } // Diego Costas, 26/02/2024
+  void SetPositionBGOGeometry(G4double X, G4double Y, G4double Z) { BGOX=X, BGOY=Y, BGOZ=Z; } // Diego Costas, 18/07/2024
   
   /**
      Dump the values of many variables used to define geometries including
@@ -741,6 +742,9 @@ private:
 
   // BGO Placement
   G4bool placeBGOGeometry;
+
+  // BGO Position
+  G4double BGOX, BGOY, BGOZ;
 
   // Add bool to indicate whether we load nuPRISM geometry  
   G4bool isNuPrism;

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -120,7 +120,8 @@ public:
 	  LCType=LightCollectorType;
   };
   G4int GetLCType(){return LCType;};
-
+  
+  G4ThreeVector GetPositionBGOGeometry()   {return G4ThreeVector(BGOX, BGOY, BGOZ);}
   G4String GetDetectorName()      {return WCDetectorName;}
   G4double GetWaterTubeLength()   {return WCLength;}
   G4double GetWaterTubePosition() {return WCPosition;}

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -37,6 +37,7 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* WCVisChoice;
   G4UIcmdWithAString* PMTGeomDetails;
   G4UIcmdWithABool*   BGOPlacement;
+  G4UIcmdWith3VectorAndUnit* BGOPosition;
   G4UIcmdWithAString* PMTSize;
   G4UIcmdWithAString* PMTSize2;
   G4UIcmdWithAString* SavePi0;

--- a/macros/WCTE.mac
+++ b/macros/WCTE.mac
@@ -79,9 +79,9 @@
 # Good for the low energy running.
 # 4. Switch off the QE, ie. set it at 100%
 
-/WCSim/PMTQEMethod     Stacking_Only
+#/WCSim/PMTQEMethod     Stacking_Only
 #/WCSim/PMTQEMethod     Stacking_And_SensitiveDetector
-#/WCSim/PMTQEMethod     SensitiveDetector_Only
+/WCSim/PMTQEMethod     SensitiveDetector_Only
 #/WCSim/PMTQEMethod     DoNotApplyQE
 
 #turn on or off the collection efficiency

--- a/macros/WCTE.mac
+++ b/macros/WCTE.mac
@@ -28,6 +28,10 @@
 # so you can see the tag scintillation light for the AmBe source.
 #/WCSim/BGOPlacement true
 # Note that /WCSim/BGOPlacement *must* be set before /WCSim/Construct
+#
+# - BGO Position: Place the source in a different position using X, Y and Z coordinates
+#/WCSim/BGOPosition 0 0 0 m
+
 
 # - /WCSim/SaveCapture & /process/inactivate nKiller: Default not set.
 # Also specially needed for AmBe calibration. The first command makes sure the Capture processes

--- a/macros/jobOptions.mac
+++ b/macros/jobOptions.mac
@@ -12,8 +12,8 @@
 #
 #/WCSim/physics/list QGSP_BIC_HP #preferred for energies below 5 GeV
 #/WCSim/physics/list LBE # preferred for low-background experiments.  
-/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
-#/WCSim/physics/list FTFP_BERT_HP
-/WCSim/physics/nCapture Default
+#/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
+/WCSim/physics/list FTFP_BERT_HP
+#/WCSim/physics/nCapture Default
 
 

--- a/macros/jobOptions.mac
+++ b/macros/jobOptions.mac
@@ -12,8 +12,8 @@
 #
 #/WCSim/physics/list QGSP_BIC_HP #preferred for energies below 5 GeV
 #/WCSim/physics/list LBE # preferred for low-background experiments.  
-#/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
-/WCSim/physics/list FTFP_BERT_HP
-#/WCSim/physics/nCapture Default
+/WCSim/physics/list FTFP_BERT # recommended for high energy physics and hadron production up to beam momentum of several tens of GeV/c.
+#/WCSim/physics/list FTFP_BERT_HP
+/WCSim/physics/nCapture Default
 
 

--- a/src/WCSimAmBeGen.cc
+++ b/src/WCSimAmBeGen.cc
@@ -21,7 +21,7 @@ G4double WCSimAmBeGen::gammaProbabilities[3] = {0.26, 0.65, 0.08};
 G4double WCSimAmBeGen::gammaEnergies[3] = {0.0, 4.4, 7.7};
 G4int    WCSimAmBeGen::pdgids[2] = {2112, 22};
 
-WCSimAmBeGen::WCSimAmBeGen(){
+WCSimAmBeGen::WCSimAmBeGen(WCSimDetectorConstruction* detector) : myDetector(detector) {
   wcsimdir = string(getenv("WCSIMDIR"))+"data/";
 
   gs_path = wcsimdir + "ground_state_spectrum.txt";
@@ -64,8 +64,6 @@ void WCSimAmBeGen::Initialise(){
     nEnergyDistSE->ArbInterpolate("Lin");
     nEnergyDistSE->SetBiasRndm(rGen);
    
-    vtx = G4ThreeVector(BGOX, BGOY, BGOZ);
-    G4cout << "Fourth BGO Coords (ParticleGun): " << vtx << G4endl;
     time = 0.;
     epsilon = 1e-6;
 }
@@ -129,9 +127,11 @@ void WCSimAmBeGen::GenerateNG(G4Event* anEvent){
       }
 
       dir = G4RandomDirection();
+      pos = myDetector->GetPositionBGOGeometry();
+      G4cout << "Fourth BGO Position (Particle Gun): " << pos << G4endl;
 
       // Configure the final properties of the particle
-      myAmBeGun->SetParticlePosition(vtx);
+      myAmBeGun->SetParticlePosition(pos);
       myAmBeGun->SetParticleTime(time);
       myAmBeGun->SetParticleMomentumDirection(dir);
 

--- a/src/WCSimAmBeGen.cc
+++ b/src/WCSimAmBeGen.cc
@@ -128,7 +128,6 @@ void WCSimAmBeGen::GenerateNG(G4Event* anEvent){
 
       dir = G4RandomDirection();
       pos = myDetector->GetPositionBGOGeometry();
-      G4cout << "Fourth BGO Position (Particle Gun): " << pos << G4endl;
 
       // Configure the final properties of the particle
       myAmBeGun->SetParticlePosition(pos);

--- a/src/WCSimAmBeGen.cc
+++ b/src/WCSimAmBeGen.cc
@@ -64,7 +64,8 @@ void WCSimAmBeGen::Initialise(){
     nEnergyDistSE->ArbInterpolate("Lin");
     nEnergyDistSE->SetBiasRndm(rGen);
    
-    vtx = G4ThreeVector(0., 0., 0.);
+    vtx = G4ThreeVector(BGOX, BGOY, BGOZ);
+    G4cout << "Fourth BGO Coords (ParticleGun): " << vtx << G4endl;
     time = 0.;
     epsilon = 1e-6;
 }

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -110,8 +110,6 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,
 
   BGOX = 0.; BGOY = 0.; BGOZ = 0.;
 
-  G4cout << "First BGO Coord: " << BGOX << BGOY << BGOZ << G4endl;
-
   //-----------------------------------------------------
   // Create Materials
   //-----------------------------------------------------
@@ -373,12 +371,16 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   //BGO Calling and Placement - Diego Costas 29/02/2024 
   // Place BGO only if command is set to true
   if (IsBGOGeometrySet()) {
-      G4cout << "Placing AmBe source in geometry at (" << BGOX << ", " << BGOY << ", " << BGOZ << ")" << G4endl;
+      G4cout << "Placing AmBe source in geometry at (" << BGOX << ", " << BGOY << ", " << BGOZ << "), Y being the vertical axis" << G4endl;
       G4Tubs* solidBGO = new G4Tubs("solidBGO", 0., 2.5*cm, 2.5*cm, 0., 360.*deg);
       G4LogicalVolume* logicBGO = new G4LogicalVolume(solidBGO, BGO, "logicBGO");
-      new G4PVPlacement(0, G4ThreeVector(BGOX, BGOY, BGOZ), logicBGO, "BGO", logicWCBox, false, 0, false); 
-
-  G4cout << "Third BGO Coords: " << BGOX << BGOY << BGOZ << G4endl;
+      G4ThreeVector BGOpos(BGOX, BGOY, BGOZ);
+      if(isNuPrism) // the input position is the final position after rotation
+      {
+        BGOpos.setY(BGOZ);
+        BGOpos.setZ(-BGOY);
+      }
+      new G4PVPlacement(0, BGOpos, logicBGO, "BGO", logicWCBox, false, 0, false);
   }
   
   //-----------------------------------------------------

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -108,6 +108,10 @@ WCSimDetectorConstruction::WCSimDetectorConstruction(G4int DetConfig,
 
   myConfiguration = DetConfig;
 
+  BGOX = 0.; BGOY = 0.; BGOZ = 0.;
+
+  G4cout << "First BGO Coord: " << BGOX << BGOY << BGOZ << G4endl;
+
   //-----------------------------------------------------
   // Create Materials
   //-----------------------------------------------------
@@ -369,10 +373,12 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
   //BGO Calling and Placement - Diego Costas 29/02/2024 
   // Place BGO only if command is set to true
   if (IsBGOGeometrySet()) {
-      G4cout << "Placing AmBe source in geometry at (0,0,0)" << G4endl;
+      G4cout << "Placing AmBe source in geometry at (" << BGOX << ", " << BGOY << ", " << BGOZ << ")" << G4endl;
       G4Tubs* solidBGO = new G4Tubs("solidBGO", 0., 2.5*cm, 2.5*cm, 0., 360.*deg);
       G4LogicalVolume* logicBGO = new G4LogicalVolume(solidBGO, BGO, "logicBGO");
-      new G4PVPlacement(0, G4ThreeVector(), logicBGO, "BGO", logicWCBox, false, 0, false); 
+      new G4PVPlacement(0, G4ThreeVector(BGOX, BGOY, BGOZ), logicBGO, "BGO", logicWCBox, false, 0, false); 
+
+  G4cout << "Third BGO Coords: " << BGOX << BGOY << BGOZ << G4endl;
   }
   
   //-----------------------------------------------------

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -852,8 +852,6 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 
   if(command == BGOPosition) {
     G4ThreeVector BGOvec = BGOPosition->GetNew3VectorValue(newValue);
-    G4cout << "Second BGO Coords: ";
-    G4cout << "Set X, Y and Z position of the BGO at " << BGOvec.x() << ", " << BGOvec.y() << ", " << BGOvec.z() << "mm" << G4endl;
     WCSimDetector->SetPositionBGOGeometry(BGOvec.x(),BGOvec.y(),BGOvec.z());
 
   }

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -635,7 +635,7 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
   delete SetCDSFile;
 
   delete BGOPlacement;
-  //delete BGOPosition;
+  delete BGOPosition;
 }
 
 void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -125,6 +125,13 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
   BGOPlacement->SetParameterName("BGOPlacement", false);
   BGOPlacement->AvailableForStates(G4State_PreInit, G4State_Idle);
 
+  BGOPosition = new G4UIcmdWith3VectorAndUnit("/WCSim/BGOPosition", this);
+  BGOPosition->SetGuidance("Set BGO position inside the tank (unit: mm cm m). Default will be 0 0 0 mm");
+  BGOPosition->SetParameterName("X", "Y", "Z", false);
+  BGOPosition->SetDefaultValue(G4ThreeVector(0,0,0));
+  BGOPosition->SetUnitCategory("Length");
+  BGOPosition->SetDefaultUnit("mm");
+
   PMTSize = new G4UIcmdWithAString("/WCSim/WCPMTsize",this);
   PMTSize->SetGuidance("Set alternate PMT size for the WC (Must be entered after geometry details are set).");
   PMTSize->SetGuidance("Available options 20inch 10inch");
@@ -626,6 +633,9 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
   delete TankRadiusChange;
   delete SetPMTPositionInput;
   delete SetCDSFile;
+
+  delete BGOPlacement;
+  //delete BGOPosition;
 }
 
 void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
@@ -838,6 +848,14 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
       G4cout << "Removing BGO Scintillation Crystal from Geometry" << G4endl; 
       WCSimDetector->SetPlaceBGOGeometry(false);
     }
+  }
+
+  if(command == BGOPosition) {
+    G4ThreeVector BGOvec = BGOPosition->GetNew3VectorValue(newValue);
+    G4cout << "Second BGO Coords: ";
+    G4cout << "Set X, Y and Z position of the BGO at " << BGOvec.x() << ", " << BGOvec.y() << ", " << BGOvec.z() << "mm" << G4endl;
+    WCSimDetector->SetPositionBGOGeometry(BGOvec.x(),BGOvec.y(),BGOvec.z());
+
   }
 
 	if(command == PMTSize) {

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -427,7 +427,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     // Initialise the ambe generator once per sim
     // This will get AmBe settings (position, direction, etc)
     if ( !AmBeGen ){
-      AmBeGen = new WCSimAmBeGen();
+      AmBeGen = new WCSimAmBeGen(myDetector);
     }
 
     if (!myDetector || !myDetector->IsBGOGeometrySet()) {


### PR DESCRIPTION
Now you can tune the position of the BGO in the tank. AmBeGen primaries vertex position automatically adjust to keep being launched from BGO's centre.