### PR TITLE
Fix formatting of the `make -Jnproc install` line in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To compile you need to have `CMakeLists.txt` in the WCSim source dir.
   the Makefiles for both the ROOT library as the main executable.
   * For some OS, `cmake3` is just `cmake`
 * `make clean` : if necessary
-* `make -j\`nproc\` install` : will
+* `` make -j`nproc` install `` : will
   * first compile `libWCSimRoot.so` which you need for using the ROOT Dict from WCSim (e.g. to read the output files)
   * compile WCSim (`libWCSimCore.so` and the executable `WCSim`)
   * install the software in the build directory (copies things into `bin/`, `include/`, etc.)


### PR DESCRIPTION
The current readme format displays badly (making it easy to mistakenly miss the crucial `install` part of the `` make -J`nproc` install `` command)

Currently:
![image](https://github.com/user-attachments/assets/e7edc6cc-0248-4fdd-be93-fa0c87c0ec93)

After the fix:
![image](https://github.com/user-attachments/assets/d32e6f31-0bd5-47a7-a493-5d56ed363d70)
