### PR TITLE
Fix WCSIMDIR bug

### DIFF
--- a/src/WCSimAmBeGen.cc
+++ b/src/WCSimAmBeGen.cc
@@ -22,7 +22,7 @@ G4double WCSimAmBeGen::gammaEnergies[3] = {0.0, 4.4, 7.7};
 G4int    WCSimAmBeGen::pdgids[2] = {2112, 22};
 
 WCSimAmBeGen::WCSimAmBeGen(WCSimDetectorConstruction* detector) : myDetector(detector) {
-  wcsimdir = string(getenv("WCSIMDIR_BUILD_DIR"))+"data/";
+  wcsimdir = string(getenv("WCSIM_BUILD_DIR"))+"data/";
   gs_path = wcsimdir + "ground_state_spectrum.txt";
   fe_path = wcsimdir + "first_excited_spectrum.txt";
   se_path = wcsimdir + "second_excited_spectrum.txt";


### PR DESCRIPTION
When wanting to run a simulation with ambeevt generator, this "WCSIMDIR_BUILD_DIR" was breaking the run.