### PR TITLE
Add warning about memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ WCSim WCSim.mac macros/tuning_parameters.mac
 
 `WCSim.mac` is well commented. Take a look inside (and also at other `.mac` files in `/macros/`) for the various options you can use to run WCSim
 
+> [!WARNING]
+> There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job
 
 ## Analysing the output of WCSim
 
@@ -239,6 +241,9 @@ There are a few example scripts inside `sample-root-scripts/`
   * Compile it using the `Makefile` in `sample-root-scripts/` (i.e. run `make` from that folder)
   * Execute it using `Analyzer.sh` in `sample-root-scripts/` (i.e. run `./Analyzer.sh` from that folder)
 * For info about the other scripts, see the README inside `sample-root-scripts/`
+
+> [!WARNING]
+> There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job
 
 ## Color Convention for visualization used in `WCSimVismanager.cc`
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,12 @@ This file contains the release notes for each version of WCSim. Release notes ca
 Recent updates
 *************************************************************
 
+Bug fix
+* Pull request #481 #482 @kmtsui: Bug fix for trigger algorithm when encountering negative hit times
+
+Documentation
+* Pull request #483 @tdealtry: There is a memory leak when reading WCSim files. Warn people not to produce or analyse more than O(1000) events per job
+
 *************************************************************
 01/10/2024: Notes for v1.12.17
 *************************************************************

--- a/WCSim.mac
+++ b/WCSim.mac
@@ -477,5 +477,8 @@
 # -- The options tree will be filled with one entry for each run
 # -- The EventHeader has a run number that specifies the run (and corresponding options tree entry) for a given event
 # It is therefore your responsibility to confirm that the options you are changing work as expected in multi-run mode
+
+# There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job
+
 /run/beamOn 10
 #exit

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -655,24 +655,15 @@ public:
   */
   void Initialize();
 
-  void ReInitialize() { // need to remove all subevents at the end, or they just get added anyway...
-    for ( int i = fEventList->GetLast() ; i>=1 ; i--) {
-      //      G4cout << "removing element # " << i << "...";
-      WCSimRootTrigger* tmp = 
-	dynamic_cast<WCSimRootTrigger*>(fEventList->RemoveAt(i));
-      delete tmp;
-      //G4cout <<"done !\n";
-    }
-    Current = 0;
-    WCSimRootTrigger* tmp = dynamic_cast<WCSimRootTrigger*>( (*fEventList)[0]);
-    tmp->Clear();
-  }
+  void ReInitialize();
+  static int fNumberOfWCSimRootEventCreated; //!< Count of the number of calls to the WCSimRootEvent constructor & ReInitalise()
 
 private:
   //std::vector<WCSimRootTrigger*> fEventList;
   TObjArray* fEventList; //!< Array of WCSimRootTrigger
   Int_t Current;                      //!               means transient, not writable to file
-  ClassDef(WCSimRootEvent,3)
+
+  ClassDef(WCSimRootEvent,4)
 
 };
 

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -41,6 +41,10 @@ int sample_readfile(const char *filename="../wcsim.root", TString events_tree_na
   
   // Get the a pointer to the tree from the file
   TTree *tree = (TTree*)file->Get("wcsimT");
+  tree->SetBranchStatus("wcsimrootevent", 0);
+  tree->SetBranchStatus("wcsimrootevent2", 0);
+  tree->SetBranchStatus("wcsimrootevent_OD", 0);
+  tree->SetBranchStatus(events_tree_name, 1);
   
   // Get the number of events
   const long nevent = tree->GetEntries();

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -32,6 +32,8 @@ ClassImp(WCSimRootEvent)
 #endif
 //#define DEBUG
 
+int WCSimRootEvent::fNumberOfWCSimRootEventCreated = 0;
+
 //TClonesArray* WCSimRootTrigger::fgTracks = 0;
 //
 //TClonesArray* WCSimRootTrigger::fgCherenkovHits = 0;
@@ -788,6 +790,15 @@ WCSimRootEvent::WCSimRootEvent()
   // it will be lost
   fEventList = 0;
   Current = 0;
+
+  if(fNumberOfWCSimRootEventCreated % 1000 == 0) {
+    std::cerr << std::endl << std::endl
+	      << "***********************************************************" << std::endl
+	      <<"Created WCSimRootEvent " << fNumberOfWCSimRootEventCreated << ". There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job" << std::endl
+	      << "***********************************************************" << std::endl
+	      << std::endl << std::endl;
+  }
+  fNumberOfWCSimRootEventCreated++;
 }
 
 //_____________________________________________________________________________
@@ -808,6 +819,29 @@ void WCSimRootEvent::Initialize()
   Current = 0;
 }
 
+//_____________________________________________________________________________
+void WCSimRootEvent::ReInitialize() {
+  // need to remove all subevents at the end, or they just get added anyway...
+  for ( int i = fEventList->GetLast() ; i>=1 ; i--) {
+    //      G4cout << "removing element # " << i << "...";
+    WCSimRootTrigger* tmp = 
+      dynamic_cast<WCSimRootTrigger*>(fEventList->RemoveAt(i));
+    delete tmp;
+    //G4cout <<"done !\n";
+  }
+  Current = 0;
+  WCSimRootTrigger* tmp = dynamic_cast<WCSimRootTrigger*>( (*fEventList)[0]);
+  tmp->Clear();
+
+  if(fNumberOfWCSimRootEventCreated % 1000 == 0) {
+    std::cerr << std::endl << std::endl
+	      << "***********************************************************" << std::endl
+	      <<"Created WCSimRootEvent " << fNumberOfWCSimRootEventCreated << ". There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job" << std::endl
+	      << "***********************************************************" << std::endl
+	      << std::endl << std::endl;
+  }
+  fNumberOfWCSimRootEventCreated++;
+}
 
 //_____________________________________________________________________________
 WCSimRootEvent::~WCSimRootEvent()


### PR DESCRIPTION
We discovered a memory leak when reading WCSim event trees (leaking a `TTree::GetEntry()`)

Add documentation & printout to suggest to users not to run more than 1000 events in a single job