### PR TITLE
Random printouts

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -213,7 +213,7 @@
 # Below gives possibility to overwrite nominal values, eg. to switch OFF the Dark Noise.
 /DarkRate/SetDetectorElement tank
 #/DarkRate/SetDarkRate 0 kHz   #Turn dark noise off
-#/DarkRate/SetDarkRate 4.2 kHz #This is the value for SKI set in SKDETSIM.
+#/DarkRate/SetDarkRate 4.2 kHz #This is the value for SKI set in SKDETSIM. This is the default value for HK FD 20" Box and Line PMTs that has been used in WCSim since 2020
 #/DarkRate/SetDarkRate 8.4 kHz #For 20 inch HPDs and Box and Line PMTs, based on High QE 20 inch R3600 dark rate from EGADS nov 2014
 #/DarkRate/SetDarkRate 3.0 kHz #For 12 inch HPDs and Box and Line PMTs, based on High QE 20 inch R3600 dark rate from EGADS nov 2014
 

--- a/src/WCSimConstructRealisticPlacement.cc
+++ b/src/WCSimConstructRealisticPlacement.cc
@@ -160,6 +160,7 @@ struct RealisticPlacementConfiguration {
       G4cout << "-----------------------------------" << G4endl;
       G4cout << "HK FD Detector Configuration Table (units: mm)" << G4endl;
       G4cout << "-----------------------------------" << G4endl;
+      G4cout << "** Radii" << G4endl;
       G4cout << "BlackTyvekInnerRadius = " << BlackTyvekInnerRadius << G4endl;
       G4cout << "BlackTyvekOuterRadius = " << BlackTyvekOuterRadius << G4endl;
       G4cout << "DeadSpaceInnerRadius = " << DeadSpaceInnerRadius << G4endl;
@@ -169,8 +170,13 @@ struct RealisticPlacementConfiguration {
       G4cout << "WallTyvekInnerRadius = " << WallTyvekInnerRadius << G4endl;
       G4cout << "WallTyvekOuterRadius = " << WallTyvekOuterRadius << G4endl;
       G4cout << "MainWaterTankRadius = " << MainWaterTankRadius << G4endl;
-      G4cout << "MainWaterTankLength = " << MainWaterTankLength << G4endl;
       G4cout << "RockShellRadius = " << RockShellRadius << G4endl;
+      G4cout << "** Lengths" << G4endl;
+      G4cout << "BlackTyvekBarrelLength = " << BlackTyvekBarrelLength << G4endl;
+      G4cout << "DeadSpaceBarrelLength = " << DeadSpaceBarrelLength << G4endl;
+      G4cout << "WhiteTyvekBarrelLength = " << WhiteTyvekBarrelLength << G4endl;
+      G4cout << "WallTyvekBarrelLength = " << WallTyvekBarrelLength << G4endl;
+      G4cout << "MainWaterTankLength = " << MainWaterTankLength << G4endl;
       G4cout << "RockShellLength = " << RockShellLength << G4endl;
     }
 


### PR DESCRIPTION
- Add all lengths to the realistic geometry *cylinder* size printout table
- Make it clear that the default dark rate for HK FD 20" box & line PMTs in WCSim is 4.2 kHz, and has been for 4 years. I was unaware of this (I thought it was 8.4 kHz)