### PR TITLE
Change TObjArray of triggers to TClonesArray to fix memory leak

### DIFF
--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -656,7 +656,6 @@ public:
   void Initialize();
 
   void ReInitialize();
-  static int fNumberOfWCSimRootEventCreated; //!< Count of the number of calls to the WCSimRootEvent constructor & ReInitalise()
 
 private:
   //std::vector<WCSimRootTrigger*> fEventList;

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -641,12 +641,12 @@ public:
     ++Current; 
 
     //Initialize() creates array with 10 entries.
-    // Using AddAtAndExpand() doubles the array size whenever
+    // TClonesArray expands the array size whenever
     // we hit the current array size.
     // This ensures we can keep adding entries,
     // even in the case of huge events
     // e.g. if we have a close SN
-    fEventList->AddAtAndExpand(new WCSimRootTrigger(num,Current),Current);
+    new((*fEventList)[Current]) WCSimRootTrigger(num,Current);
   }
   
   /*  void ReInitialize() { // need to remove all subevents at the end, or they just get added anyway...
@@ -660,7 +660,7 @@ public:
 
 private:
   //std::vector<WCSimRootTrigger*> fEventList;
-  TObjArray* fEventList; //!< Array of WCSimRootTrigger
+  TClonesArray* fEventList; //!< Array of WCSimRootTrigger
   Int_t Current;                      //!               means transient, not writable to file
 
   ClassDef(WCSimRootEvent,4)

--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -663,7 +663,7 @@ private:
   TClonesArray* fEventList; //!< Array of WCSimRootTrigger
   Int_t Current;                      //!               means transient, not writable to file
 
-  ClassDef(WCSimRootEvent,4)
+  ClassDef(WCSimRootEvent,5)
 
 };
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -32,8 +32,6 @@ ClassImp(WCSimRootEvent)
 #endif
 //#define DEBUG
 
-int WCSimRootEvent::fNumberOfWCSimRootEventCreated = 0;
-
 //TClonesArray* WCSimRootTrigger::fgTracks = 0;
 //
 //TClonesArray* WCSimRootTrigger::fgCherenkovHits = 0;
@@ -790,16 +788,6 @@ WCSimRootEvent::WCSimRootEvent()
   // it will be lost
   fEventList = 0;
   Current = 0;
-  
-  fNumberOfWCSimRootEventCreated++;
-  
-  if(fNumberOfWCSimRootEventCreated % 1000 == 0) {
-    std::cerr << std::endl << std::endl
-	      << "***********************************************************" << std::endl
-	      <<"Created WCSimRootEvent " << fNumberOfWCSimRootEventCreated << ". There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job" << std::endl
-	      << "***********************************************************" << std::endl
-	      << std::endl << std::endl;
-  }
 }
 
 //_____________________________________________________________________________
@@ -815,47 +803,25 @@ WCSimRootEvent & WCSimRootEvent::operator=(const WCSimRootEvent & in)
 //_____________________________________________________________________________
 void WCSimRootEvent::Initialize()
 {
-  fEventList = new TObjArray(10,0); // very rarely more than 10 subevents...
-  fEventList->AddAt(new WCSimRootTrigger(0,0),0);
+  fEventList = new TClonesArray("WCSimRootTrigger",10); // very rarely more than 10 subevents...
+  fEventList->BypassStreamer(kFALSE);
+  new((*fEventList)[0]) WCSimRootTrigger(0,0);
   Current = 0;
 }
 
 //_____________________________________________________________________________
 void WCSimRootEvent::ReInitialize() {
-  // need to remove all subevents at the end, or they just get added anyway...
-  for ( int i = fEventList->GetLast() ; i>=1 ; i--) {
-    //      G4cout << "removing element # " << i << "...";
-    WCSimRootTrigger* tmp = 
-      dynamic_cast<WCSimRootTrigger*>(fEventList->RemoveAt(i));
-    delete tmp;
-    //G4cout <<"done !\n";
-  }
   Current = 0;
-  WCSimRootTrigger* tmp = dynamic_cast<WCSimRootTrigger*>( (*fEventList)[0]);
-  tmp->Clear();
-
-  if(fNumberOfWCSimRootEventCreated % 1000 == 0) {
-    std::cerr << std::endl << std::endl
-	      << "***********************************************************" << std::endl
-	      <<"Created WCSimRootEvent " << fNumberOfWCSimRootEventCreated << ". There is a memory leak when doing TTree::GetEntry() when reading files. It is also presumed that filling is leaky. It is strongly recommended not to generate or analyse O(1000) events in a single job" << std::endl
-	      << "***********************************************************" << std::endl
-	      << std::endl << std::endl;
-  }
-  fNumberOfWCSimRootEventCreated++;
+  fEventList->Clear("C");
 }
 
 //_____________________________________________________________________________
 WCSimRootEvent::~WCSimRootEvent()
 {
   if (fEventList != 0) {
-    for (int i = 0 ; i < fEventList->GetEntriesFast() ; i++) {
-      delete (*fEventList)[i];
-    }
+    fEventList->Delete();
     delete fEventList;
   }
-  //  std::vector<WCSimRootTrigger*>::iterator  iter = fEventList.begin();
-  //for ( ; iter != fEventList.end() ; ++iter) delete (*iter);
-  //Clear("");
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
After many hours trying to track down the issue, easiest fix for the memory leak was to replace `WCSimRootEvent`'s `TObjArray` of `WCSimRootTrigger`s into a `TClonesArray`, and update the related management of the objects to use more standard ROOT way.

I don't fully understand why the `TObjArray` caused the memory leak. It's due to the `TObjArray` not "owning" the objects it points to (while `TClonesArray` does) and so it doesn't automatically delete them when the `TObjArray` is deleted (`TClonesArray` clears those objects automatically and recursively). But there was code to manually delete them in the `TObjArray` destructor. I think maybe this failed because it was deleting the entries during the loop over entries, which may not behave as expected, but I didn't figure out a way to fix that. Using `SetAutoDelete` seemed to cause all but about 50kb per event of memory to be cleaned up, but I wasn't able to track down exactly where that remaining memory came from.

In my tests of this version, the memory leak in `GetEntry` is completely gone, but further verification of this would be nice if someone has time. Using `SetAutoDelete` is still required (or manually deleting and resetting the `WCSimRootEvent*` to `nullptr`, or I think just calling its `Reinitialize` method, in each iteration of the event loop).

In any case, `TObjArray` is supposed to hold objects of different class types, whereas `TClonesArray` holds objects of the same class type, so is more appropriate anyway and should perform better. It actually does not delete the members when emptying the array, but just clears them, saving some overhead of calling contructors and destructors.

I don't think the underlying container is exposed by any `WCSimRootEvent` methods, so hopefully this change does not break anything downstream.