### PR TITLE
Clarify printout in WCSimWCTrigger

### DIFF
--- a/include/WCSimWCTrigger.hh
+++ b/include/WCSimWCTrigger.hh
@@ -246,6 +246,7 @@ public:
 
   inline G4int   GetTubeID() {return tubeID;}
   inline std::vector<G4double> GetPe      (int gate) { return FindInMultimap(gate, pe); }
+  inline G4int GetTotalPe() { return totalPe; }
   inline std::vector<G4double> GetTime    (int gate) { return FindInMultimap(gate, time); }
   std::vector<std::vector<int> > GetDigiCompositionInfo(int gate)
   {

--- a/src/WCSimWCTrigger.cc
+++ b/src/WCSimWCTrigger.cc
@@ -498,7 +498,14 @@ void WCSimWCTriggerBase::FillDigitsCollection(WCSimWCDigitsCollection* WCDCPMT, 
       }//loop over Digits
     }//loop over PMTs
   }//loop over Triggers
-  G4cout << "WCSimWCTriggerBase::FillDigitsCollection. Number of entries in output digit collection: " << DigitsCollection->entries() << G4endl;
+  G4cout << "WCSimWCTriggerBase::FillDigitsCollection. Number of entries (hit PMTs) in output digit collection: " << DigitsCollection->entries() << G4endl;
+#ifdef WCSIMWCTRIGGER_VERBOSE
+  int temp_total_digits = 0;
+  for(G4int i = 0; i < DigitsCollection->entries(); i++) {
+    temp_total_digits += (*DigitsCollection)[i]->GetTotalPe();
+  }
+  G4cout << "WCSimWCTriggerBase::FillDigitsCollection. Number of digits in output digit collection: " << temp_total_digits << G4endl;
+#endif
 }
 
 void WCSimWCTriggerBase::AlgNoTrigger(WCSimWCDigitsCollection* WCDCPMT, bool remove_hits)


### PR DESCRIPTION
- what number of entries means
- add precompiler printout of total number of triggered digits

Fixes #506 @MatthieuMelennec please confirm!

Note that you can uncomment [this line](https://github.com/WCSim/WCSim/blob/develop/src/WCSimWCTrigger.cc#L26) & recompile to get the added printout to check that the numbers you're seeing in the output file agree with the in-code printout