### PR TITLE
Working build with optional hepmc3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ set(CMAKE_CXX_STANDARD 14) # Enable c++14 standard
 ########
 # HepMC3
 ########
+option(WCSIM_HEPMC3_ENABLED "HEPMC3 INTERFACE" OFF)
+if (WCSIM_HEPMC3_ENABLED)
+
 if (NOT ${WCSim_WCSimRoot_only}) # only looking for HepMC3 if WCSim_WCSimRoot_only is false
   find_package(HepMC3 REQUIRED)
   if (NOT HepMC3_FOUND)
@@ -56,6 +59,8 @@ if (NOT ${WCSim_WCSimRoot_only}) # only looking for HepMC3 if WCSim_WCSimRoot_on
   include_directories (${HEPMC3_INCLUDE_DIR})
   LIST(APPEND PUBLIC_EXT_LIBS ${HEPMC3_LIBRARIES})
 endif ()
+
+endif()
 
 ######
 # ROOT
@@ -86,6 +91,11 @@ elseif("-std=c++11" IN_LIST TMP_ROOT_FLAGS)
 else()
     set(CMAKE_CXX_STANDARD 17)
 endif ()
+
+option(FORCE_CXX_STANDARD "Flag to override root CXX standard checks" OFF)
+if (FORCE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD ${FORCE_CXX_STANDARD})
+endif()
 
 MESSAGE(STATUS "Current CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Useful cmake commands:
 * `-DWCSim_DEBUG_COMPILE_FLAG=<ON|OFF>` If ON, turns on the gcc debug compiler flag `-g`. Default: OFF
 * `-DWCSIM_SAVE_PHOTON_HISTORY_FLAG=<ON|OFF>` If ON, turns on photon scattering/reflection history saving. The data class `WCSimRootCherenkovHitHistory` is used in a similar way as `WCSimRootCherenkovHitTime`. Default: OFF
 * `-DWCSim_WCSimRoot_only=<ON|OFF>` If ON, only builds the WCSimRoot library (ignoring the WCSimCore one). This is useful if one wants only to read the WCSim output files (for e.g. reconstruction) and not running any simulation. Default: OFF
+* `-DWCSISM_HEPMC3_ENABLED=<ON|OFF>` If ON, attempts to build the HepMC3 interface. The CMAKE_PREFIX_PATH needs to be setup correctly to point towards the HepMC3 cmake config file to find this.
 
 #### Build with CMake on sukap:
 

--- a/include/WCSimNuHepMC3Reader.hh
+++ b/include/WCSimNuHepMC3Reader.hh
@@ -1,6 +1,8 @@
 #ifndef WCSimNuHepMC3Reader_h
 #define WCSimNuHepMC3Reader_h
 
+#ifdef WCSIM_HEPMC3_ENABLED
+
 #include <G4LorentzVector.hh>
 #include <G4String.hh>
 #include <memory>
@@ -54,4 +56,5 @@ class WCSimNuHepMC3Reader {
     WCSimDetectorConstruction *myDetector;
 };
 
+#endif
 #endif

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -13,7 +13,10 @@
 #include "WCSimAmBeGen.hh"
 #include "WCSimEnumerations.hh"
 #include "jhfNtuple.h"
+
+#ifdef WCSIM_HEPMC3_ENABLED
 #include "WCSimNuHepMC3Reader.hh"
+#endif
 
 #include <G4String.hh>
 #include <fstream>
@@ -131,7 +134,11 @@ private:
   // HepMC3 reader
   G4String hepmc3_filename;
     // HepMC3 reader object
+
+#ifdef WCSIM_HEPMC3_ENABLED
   WCSimNuHepMC3Reader* hepmc3_reader;
+#endif
+
     // Position generation bool
   G4bool hepmc3_positionGen;
 

--- a/src/WCSimNuHepMC3Reader.cc
+++ b/src/WCSimNuHepMC3Reader.cc
@@ -1,5 +1,7 @@
 #include "WCSimNuHepMC3Reader.hh"
 
+#ifdef WCSIM_HEPMC3_ENABLED
+
 #include "HepMC3/FourVector.h"
 #include "HepMC3/Print.h"
 #include "HepMC3/ReaderFactory.h"
@@ -131,3 +133,5 @@ HepMC3::FourVector WCSimNuHepMC3Reader::GenRandomPosition() {
     HepMC3::FourVector position(x_nu, y_nu, z_nu, 0.0);
     return position;
 }
+
+#endif

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1,9 +1,13 @@
 #include "WCSimPrimaryGeneratorAction.hh"
+
+#ifdef WCSIM_HEPMC3_ENABLED
 #include "HepMC3/FourVector.h"
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenParticle_fwd.h"
 #include "HepMC3/GenVertex.h"
 #include "HepMC3/GenVertex_fwd.h"
+#endif
+
 #include "WCSimDetectorConstruction.hh"
 #include "WCSimPrimaryGeneratorMessenger.hh"
 #include "G4RunManager.hh"
@@ -1563,6 +1567,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       SetBeamDir(dir);
       SetBeamPDG(pdg);
 
+    #ifdef WCSIM_HEPMC3_ENABLED
     } else if (useHepMC3Evt) {
 
       G4cout << "Using HepMC3 event" << G4endl;
@@ -1665,6 +1670,7 @@ NuHepMC3Reader: [INFO] Particle ID: "
           continue;
         }
       }
+#endif // WCSISM_HEPMC3_ENABLED
     }
 }
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1567,9 +1567,8 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       SetBeamDir(dir);
       SetBeamPDG(pdg);
 
-    #ifdef WCSIM_HEPMC3_ENABLED
     } else if (useHepMC3Evt) {
-
+    #ifdef WCSIM_HEPMC3_ENABLED
       G4cout << "Using HepMC3 event" << G4endl;
       // Check if the WCSimNuHepMC3Reader object has been initiaited yet
       if (!hepmc3_reader) {
@@ -1670,7 +1669,10 @@ NuHepMC3Reader: [INFO] Particle ID: "
           continue;
         }
       }
-#endif // WCSISM_HEPMC3_ENABLED
+    #else
+        std::cerr << "[WARNING] : HepMC3 events requested, but interface not compiled." << std::endl;
+        std::cerr << "          : Use -DWCSISM_HEPMC3_ENABLED=ON at compile time." << std::endl;
+    #endif // WCSISM_HEPMC3_ENABLED
     }
 }
 


### PR DESCRIPTION
HEPMC3 is only needed in limited cases. Added a "-DWCSIM_HEPMC3_ENABLED=ON" option for the build files, so a system install of hepmc3 is not always needed. 

An explanation of usage can be seen using 'make' GUI.