### PR TITLE
Minimal version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Minimum cmake verison 3.1 required for the variable CMAKE_CXX_STANDARD
-cmake_minimum_required(VERSION 3.1)
+# Minimum cmake verison 3.5 required for the variable CMAKE_CXX_STANDARD
+cmake_minimum_required(VERSION 3.5)
 
 # ##############################################################################
 # setup #


### PR DESCRIPTION
With the arrival of cmake 4+, cmake 3.4- are no longer supported and the minimal requirement is 3.5