### PR TITLE
save sheet dimensions

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -652,7 +652,7 @@ private:
   G4String Vis_Choice;
   
 
-  /// Boundary wall (e.g. blacksheet/tyveks) dimensions
+  /// Boundary wall (e.g. blacksheet/tyveks) dimensions. Units: mm
   std::map<BoundaryWallType_t, std::vector<G4float> > fBoundaryWallDimensions;
 
   void AddBoundaryWallCylinderDimensions(BoundaryWallType_t s,

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -496,6 +496,8 @@ public:
   ////////// END OD /////////////
   ///////////////////////////////
 
+  std::map<BoundaryWallType_t, std::vector<G4float> > GetBoundaryWallDimensions() const {return fBoundaryWallDimensions;}
+
 private:
 
   // Overlap checking turned on and off with cmake option
@@ -650,6 +652,22 @@ private:
   G4String Vis_Choice;
   
 
+  /// Boundary wall (e.g. blacksheet/tyveks) dimensions
+  std::map<BoundaryWallType_t, std::vector<G4float> > fBoundaryWallDimensions;
+
+  void AddBoundaryWallCylinderDimensions(BoundaryWallType_t s,
+					 G4float radius,
+					 G4float full_length) {
+    auto it = fBoundaryWallDimensions.find(s);
+    if(it != fBoundaryWallDimensions.end()) {
+      G4cerr << "Boundary wall type " << WCSimEnumerations::EnumAsString(s)
+	     << " already exists inside fBoundaryWallDimensions. Replacing dimensions"
+	     << G4endl;
+    }
+    std::vector<G4float> dims = {radius, full_length};
+    fBoundaryWallDimensions[s] = dims;
+  }
+  
   G4double WCLength;
 
   G4double WCPosition;

--- a/include/WCSimEnumerations.hh
+++ b/include/WCSimEnumerations.hh
@@ -3,6 +3,12 @@
 
 #include <string>
 
+typedef enum EBoundaryWallType {
+  kBoundaryWallIDBlacksheet, //< Blacksheet on the outer wall of the ID
+  kBoundaryWallODInnerTyvek, //< Tyvek on the inner wall (dead-space side) of the OD
+  kBoundaryWallODOuterTyvek  //< Tyvek on the outer wall (cavern side) of the OD
+} BoundaryWallType_t;
+  
 typedef enum ETriggerType {
   kTriggerUndefined = -1,
   kTriggerNDigits,
@@ -175,6 +181,7 @@ class WCSimEnumerations
 {
 public:
 
+  static std::string EnumAsString(BoundaryWallType_t s);
   static std::string EnumAsString(DigitizerType_t d);
   static std::string EnumAsString(TriggerType_t t);
   static std::string EnumAsString(WCSimRandomGenerator_t r);

--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -78,7 +78,7 @@ class WCSimRootGeom : public TObject {
 
 private:
 
-  /// Boundary wall (e.g. blacksheet/tyveks) dimensions for each boundary type. Correspond to the radius & full length of the cylinder (the vector allows this to be expanded to use e.g. cuboids in the future). Units: cm
+  /// Boundary wall (e.g. blacksheet/tyveks) dimensions for each boundary type. Correspond to the radius & full length of the cylinder (the vector allows this to be expanded to use e.g. cuboids in the future). Units: mm
   std::map<BoundaryWallType_t, std::vector<float> > fBoundaryWallDimensions;
 
   Float_t                fWCCylRadius;  //!< Radius of WC tank. Based on maximum PMT position, so does not correspond to the full size of the tank (and is wildly inaccurate when your geometry has OD PMTs on the inner wall of the OD). Suggest to use GetBoundaryWallRadius() instead. Units: cm

--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -10,8 +10,12 @@
 //     WC info
 //////////////////////////////////////////////////////////////////////////
 
+#include "WCSimEnumerations.hh"
+
 #include "TObject.h"
 #include "TClonesArray.h"
+
+#include <map>
 
 class TDirectory;
 
@@ -74,8 +78,11 @@ class WCSimRootGeom : public TObject {
 
 private:
 
-  Float_t                fWCCylRadius;  //!< Radius of WC tank. Units: cm
-  Float_t                fWCCylLength;  //!< Length of WC tank. Units: cm
+  /// Boundary wall (e.g. blacksheet/tyveks) dimensions for each boundary type. Correspond to the radius & full length of the cylinder (the vector allows this to be expanded to use e.g. cuboids in the future). Units: cm
+  std::map<BoundaryWallType_t, std::vector<float> > fBoundaryWallDimensions;
+
+  Float_t                fWCCylRadius;  //!< Radius of WC tank. Based on maximum PMT position, so does not correspond to the full size of the tank (and is wildly inaccurate when your geometry has OD PMTs on the inner wall of the OD). Suggest to use GetBoundaryWallRadius() instead. Units: cm
+  Float_t                fWCCylLength;  //!< Length of WC tank. Based on maximum PMT position, so does not correspond to the full size of the tank (and is wildly inaccurate when your geometry has OD PMTs on the inner wall of the OD). Suggest to use GetBoundaryWallFullLength() instead. Units: cm
 
   Int_t                  fgeo_type;  //!< UNUSED mailbox or cylinder?
 
@@ -101,7 +108,8 @@ public:
   bool CompareAllVariables(const WCSimRootGeom * c) const;
 
   // Sets and gets
-
+  void SetBoundaryWallDimensions(std::map<BoundaryWallType_t, std::vector<float> > dims) {fBoundaryWallDimensions = dims;}
+  
   void  SetWCCylRadius(Double_t f) {fWCCylRadius=f;}
   void  SetWCCylLength(Double_t f) {fWCCylLength=f;}
 
@@ -123,6 +131,10 @@ public:
   void  SetPMT(Int_t i, Int_t tubeno, Int_t mPMTNo, Int_t mPMT_PMTno, Int_t cyl_loc, Double_t rot[3], Double_t pos[3], bool expand=true, bool hybridsecondtype=false);
   void  SetOrientation(Int_t o) {fOrientation = o;}
 
+  void    PrintBoundaryWallInfo() const;
+  Float_t GetBoundaryWallRadius(BoundaryWallType_t s) const;
+  Float_t GetBoundaryWallFullLength(BoundaryWallType_t s) const;
+  
   Float_t GetWCCylRadius() const {return fWCCylRadius;}
   Float_t GetWCCylLength() const {return fWCCylLength;}
 

--- a/sample-root-scripts/sample_readfile.C
+++ b/sample-root-scripts/sample_readfile.C
@@ -69,6 +69,7 @@ int sample_readfile(const char *filename="../wcsim.root", TString events_tree_na
       exit(9);
   }
   geotree->GetEntry(0);
+  geo->PrintBoundaryWallInfo();
 
   // Options tree - only need 1 "event"
   TTree *opttree = (TTree*)file->Get("wcsimRootOptionsT");
@@ -85,12 +86,15 @@ int sample_readfile(const char *filename="../wcsim.root", TString events_tree_na
   // and always exists.
   WCSimRootTrigger* wcsimrootevent;
 
-  const float detR = geo->GetWCCylRadius();
-  const float detZ = geo->GetWCCylLength();
+  // Attempt to use the boundary wall information. This corresponds to the as-built radius/length of the blacksheet or tyvek
+  // Will fallback to the WCCyl methods, but these correspond to maximum PMT positions, and so are less intuitive to use
+  float temp_IDdetR = geo->GetBoundaryWallRadius(kBoundaryWallIDBlacksheet); // this will return -999 if not found
+  const float IDdetR = temp_IDdetR > 0 ? temp_IDdetR : geo->GetWCCylRadius();
+  const float IDdetZ = temp_IDdetR > 0 ? geo->GetBoundaryWallFullLength(kBoundaryWallIDBlacksheet) : geo->GetWCCylLength();
   TH1F *h1 = new TH1F("h1", "NDigits;NDigits in Trigger 0;Entries in bin", 8000, 0, 8000);
-  TH1F *hvtxX = new TH1F("hvtxX", "Event VTX X;True vertex X (cm);Entries in bin", 200, -detR, +detR);
-  TH1F *hvtxY = new TH1F("hvtxY", "Event VTX Y;True vertex Y (cm);Entries in bin", 200, -detR, +detR);
-  TH1F *hvtxZ = new TH1F("hvtxZ", "Event VTX Z;True vertex Z (cm);Entries in bin", 200, -detZ/2, +detZ/2);
+  TH1F *hvtxX = new TH1F("hvtxX", "Event VTX X;True vertex X (cm);Entries in bin", 200, -IDdetR, +IDdetR);
+  TH1F *hvtxY = new TH1F("hvtxY", "Event VTX Y;True vertex Y (cm);Entries in bin", 200, -IDdetR, +IDdetR);
+  TH1F *hvtxZ = new TH1F("hvtxZ", "Event VTX Z;True vertex Z (cm);Entries in bin", 200, -IDdetZ/2, +IDdetZ/2);
   
   int num_trig=0;
   

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -3718,14 +3718,14 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 
     G4double odTopCapZ[4] = {
       (-WCODDeadSpace+1*mm+WCBlackSheetThickness+pmt_blacksheet_offset),
-      -.5*(WCODTyvekSheetThickness),
-      -.5*(WCODTyvekSheetThickness),
-      .5*(WCODTyvekSheetThickness)};
+      WCBlackSheetThickness,
+      WCBlackSheetThickness,
+      1*(WCODTyvekSheetThickness)+WCBlackSheetThickness};
     G4double odBotCapZ[4] = {
       -(-WCODDeadSpace+1*mm+WCBlackSheetThickness+pmt_blacksheet_offset),
-      .5*(WCODTyvekSheetThickness),
-      .5*(WCODTyvekSheetThickness),
-      -.5*(WCODTyvekSheetThickness)};
+      -WCBlackSheetThickness,
+      -WCBlackSheetThickness,
+      -1*(WCODTyvekSheetThickness)-WCBlackSheetThickness};
     G4double odCapRmin[4] = {WCODRadius-WCODTyvekSheetThickness,
                 WCODRadius-WCODTyvekSheetThickness,
                 0,

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -2710,7 +2710,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
   // Tell DetectorConstruction about boundary walls
   AddBoundaryWallCylinderDimensions(kBoundaryWallODInnerTyvek,
 									WCODRadius,
-									(WCIDHeight + 2*WCODDeadSpace)); //from CapTyvekPosition creation, without the /2 as we store the full length in the boundary wall variables
+									(WCIDHeight + 2*WCODDeadSpace + 2*WCODTyvekSheetThickness)); //from CapTyvekPosition creation, without the /2 as we store the full length in the boundary wall variables, including the OD tyvek thickness
 
 
   // the radii are measured to the center of the surfaces

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -3718,14 +3718,14 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 
     G4double odTopCapZ[4] = {
       (-WCODDeadSpace+1*mm+WCBlackSheetThickness+pmt_blacksheet_offset),
-      WCBlackSheetThickness,
-      WCBlackSheetThickness,
-      1*(WCODTyvekSheetThickness)+WCBlackSheetThickness};
+      -.5*(WCODTyvekSheetThickness),
+      -.5*(WCODTyvekSheetThickness),
+      .5*(WCODTyvekSheetThickness)};
     G4double odBotCapZ[4] = {
       -(-WCODDeadSpace+1*mm+WCBlackSheetThickness+pmt_blacksheet_offset),
-      -WCBlackSheetThickness,
-      -WCBlackSheetThickness,
-      -1*(WCODTyvekSheetThickness)-WCBlackSheetThickness};
+      .5*(WCODTyvekSheetThickness),
+      .5*(WCODTyvekSheetThickness),
+      -.5*(WCODTyvekSheetThickness)};
     G4double odCapRmin[4] = {WCODRadius-WCODTyvekSheetThickness,
                 WCODRadius-WCODTyvekSheetThickness,
                 0,

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -2716,7 +2716,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
   // the radii are measured to the center of the surfaces
   // (tangent distance). Thus distances between the corner and the center are bigger.
   //BQ: Updated with new HK OD size (2020/12/06). Simply assume no tyvek thickness or dead space.
-  WCLength    = WCIDHeight + 2*(WCODHeightWaterDepth + WCBlackSheetThickness + WCODDeadSpace + WCODTyvekSheetThickness + 1*mm + pmt_blacksheet_offset);
+  if (!isODConstructed) WCLength = WCIDHeight + 2*(WCBlackSheetThickness + 1*mm + pmt_blacksheet_offset);
+  else WCLength = WCIDHeight + 2*(WCODHeightWaterDepth + WCBlackSheetThickness + WCODDeadSpace + WCODTyvekSheetThickness);
   WCRadius    = (outerAnnulusRadius + WCODLateralWaterDepth)/cos(dPhi/2.) ;
 #ifdef WCSIMCONSTRUCTCYLINDER_VERBOSE
   G4cout

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -2707,6 +2707,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 	<< "GEOMCHECK3 WCPMTODExposeHeight \t" << WCPMTODExposeHeight << G4endl
 	;
 #endif
+  // Tell DetectorConstruction about boundary walls
+  AddBoundaryWallCylinderDimensions(kBoundaryWallODInnerTyvek,
+									WCODRadius,
+									(WCIDHeight + 2*WCODDeadSpace)); //from CapTyvekPosition creation, without the /2 as we store the full length in the boundary wall variables
+
 
   // the radii are measured to the center of the surfaces
   // (tangent distance). Thus distances between the corner and the center are bigger.
@@ -2886,6 +2891,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 					  checkOverlaps);
 
 
+	// Tell DetectorConstruction about boundary walls
+	AddBoundaryWallCylinderDimensions(kBoundaryWallODOuterTyvek,
+									  WCRadius, WCLength);
   } // END Tyvek cave
   //-----------------------------------------------------
 
@@ -2980,6 +2988,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
   {
     G4cout << mainAnnulusRmin[i] << ", " << mainAnnulusRmax[i] << ", " << mainAnnulusZ[i] << G4endl;
   }
+  // Tell DetectorConstruction about boundary walls
+  AddBoundaryWallCylinderDimensions(kBoundaryWallIDBlacksheet,
+									WCIDRadius, WCIDHeight);
 
   G4Polyhedra* solidWCBarrelBlackSheet = new G4Polyhedra("WCBarrelAnnulusBlackSheet",
                                                    barrelPhiOffset, // phi start

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -2716,8 +2716,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
   // the radii are measured to the center of the surfaces
   // (tangent distance). Thus distances between the corner and the center are bigger.
   //BQ: Updated with new HK OD size (2020/12/06). Simply assume no tyvek thickness or dead space.
-  if (!isODConstructed) WCLength = WCIDHeight + 2*(WCBlackSheetThickness + 1*mm + pmt_blacksheet_offset);
-  else WCLength = WCIDHeight + 2*(WCODHeightWaterDepth + WCBlackSheetThickness + WCODDeadSpace + WCODTyvekSheetThickness);
+  WCLength    = WCIDHeight + 2*(WCODHeightWaterDepth + WCBlackSheetThickness + WCODDeadSpace + WCODTyvekSheetThickness + 1*mm + pmt_blacksheet_offset);
   WCRadius    = (outerAnnulusRadius + WCODLateralWaterDepth)/cos(dPhi/2.) ;
 #ifdef WCSIMCONSTRUCTCYLINDER_VERBOSE
   G4cout

--- a/src/WCSimConstructRealisticPlacement.cc
+++ b/src/WCSimConstructRealisticPlacement.cc
@@ -415,6 +415,17 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructRealisticPlacement()
 
     config.Print();
 
+	// Tell DetectorConstruction about boundary walls
+	AddBoundaryWallCylinderDimensions(kBoundaryWallIDBlacksheet,
+									  config.InnerDetectorOuterRadius,
+									  config.InnerDetectorBarrelLength);
+	AddBoundaryWallCylinderDimensions(kBoundaryWallODInnerTyvek,
+									  config.OuterDetectorInnerRadius,
+									  config.WhiteTyvekBarrelLength);
+	AddBoundaryWallCylinderDimensions(kBoundaryWallODOuterTyvek,
+									  config.OuterDetectorOuterRadius,
+									  config.OuterDetectorBarrelLength);
+	
     // *************************
     // Shell Hierarchy Construction
     // *************************

--- a/src/WCSimEnumerations.cc
+++ b/src/WCSimEnumerations.cc
@@ -3,6 +3,25 @@
 
 #include "WCSimEnumerations.hh"
 
+std::string WCSimEnumerations::EnumAsString(BoundaryWallType_t d)
+{
+  switch(d) {
+  case (kBoundaryWallIDBlacksheet) :
+    return "IDBlacksheet";
+    break;
+  case (kBoundaryWallODInnerTyvek) :
+    return "ODInnerTyvek";
+    break;
+  case (kBoundaryWallODOuterTyvek) :
+    return "ODOuterTyvek";
+    break;
+  default:
+    return "";
+    break;
+  }
+  return "";
+}
+
 std::string WCSimEnumerations::EnumAsString(DigitizerType_t d)
 {
   switch(d) {

--- a/src/WCSimRootGeom.cc
+++ b/src/WCSimRootGeom.cc
@@ -182,3 +182,36 @@ bool WCSimRootPMT::CompareAllVariables(const WCSimRootPMT * c) const
   }//i
   return !failed;
 }
+
+//______________________________________________________________________________
+Float_t WCSimRootGeom::GetBoundaryWallRadius(BoundaryWallType_t s) const {
+  auto it = fBoundaryWallDimensions.find(s);
+  if(it != fBoundaryWallDimensions.end()) {
+    std::cerr << "Boundary type: " << WCSimEnumerations::EnumAsString(s) << " not found" << std::endl;
+    return -999;
+  }
+  return fBoundaryWallDimensions.at(s).at(0); //0 = radius
+}
+//______________________________________________________________________________
+Float_t WCSimRootGeom::GetBoundaryWallFullLength(BoundaryWallType_t s) const {
+  auto it = fBoundaryWallDimensions.find(s);
+  if(it != fBoundaryWallDimensions.end()) {
+    std::cerr << "Boundary type: " << WCSimEnumerations::EnumAsString(s) << " not found" << std::endl;
+    return -999;
+  }
+  return fBoundaryWallDimensions.at(s).at(1); //1 = full length
+}
+//______________________________________________________________________________
+void WCSimRootGeom::PrintBoundaryWallInfo() const {
+  std::cout << "Boundary wall information" << std::endl
+	    << "-----------------------------------------------" << std::endl
+	    << "Name         || Radius (cm) || Full length (cm)" << std::endl 
+	    << "-----------------------------------------------" << std::endl;
+  for(auto const& x : fBoundaryWallDimensions) {
+    std::cout << WCSimEnumerations::EnumAsString(x.first) << " || "
+	      << x.second.at(0) << "       || "
+	      << x.second.at(1) << std::endl;
+  }
+  std::cout << "-----------------------------------------------" << std::endl;
+}
+//______________________________________________________________________________

--- a/src/WCSimRootGeom.cc
+++ b/src/WCSimRootGeom.cc
@@ -186,7 +186,7 @@ bool WCSimRootPMT::CompareAllVariables(const WCSimRootPMT * c) const
 //______________________________________________________________________________
 Float_t WCSimRootGeom::GetBoundaryWallRadius(BoundaryWallType_t s) const {
   auto it = fBoundaryWallDimensions.find(s);
-  if(it != fBoundaryWallDimensions.end()) {
+  if(it == fBoundaryWallDimensions.end()) {
     std::cerr << "Boundary type: " << WCSimEnumerations::EnumAsString(s) << " not found" << std::endl;
     return -999;
   }
@@ -195,7 +195,7 @@ Float_t WCSimRootGeom::GetBoundaryWallRadius(BoundaryWallType_t s) const {
 //______________________________________________________________________________
 Float_t WCSimRootGeom::GetBoundaryWallFullLength(BoundaryWallType_t s) const {
   auto it = fBoundaryWallDimensions.find(s);
-  if(it != fBoundaryWallDimensions.end()) {
+  if(it == fBoundaryWallDimensions.end()) {
     std::cerr << "Boundary type: " << WCSimEnumerations::EnumAsString(s) << " not found" << std::endl;
     return -999;
   }

--- a/src/WCSimRootGeom.cc
+++ b/src/WCSimRootGeom.cc
@@ -205,7 +205,7 @@ Float_t WCSimRootGeom::GetBoundaryWallFullLength(BoundaryWallType_t s) const {
 void WCSimRootGeom::PrintBoundaryWallInfo() const {
   std::cout << "Boundary wall information" << std::endl
 	    << "-----------------------------------------------" << std::endl
-	    << "Name         || Radius (cm) || Full length (cm)" << std::endl 
+	    << "Name         || Radius (mm) || Full length (mm)" << std::endl
 	    << "-----------------------------------------------" << std::endl;
   for(auto const& x : fBoundaryWallDimensions) {
     std::cout << WCSimEnumerations::EnumAsString(x.first) << " || "

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -598,6 +598,7 @@ void WCSimRunAction::FillGeoTree(){
       wcsimrootgeom-> SetWCCylLength(cylinfo[2]);
   }
 
+  wcsimrootgeom->SetBoundaryWallDimensions(wcsimdetector->GetBoundaryWallDimensions());
 
   pmtradius = wcsimdetector->GetPMTSize1();
   pmtradius2 = 4.0;//B.Q debug, Temp wcsimdetector->GetPMTSize1();


### PR DESCRIPTION
The current radius & length stored in WCSimRootGeom are not so useful
- they are to do with the maximum extent of the PMT position (depends on PMT type)
- with geometries with an OD, them being 

This adds an extra variable such that we can store radii/full lengths of important _boundaries_ (the variable itself is extentable, such that in the future we can store info on other shapes, if required)

This is done for the RealisticPlacement & NoReplica methods for now (I believe that this encompases all official geometries for HK FD, IWCD & WCTE - please do let me know if this is wrong), and in each the following are saved
- ID blacksheet position (effectively ID wall)
- OD inner (next to deadspace) tyvek position (effectively OD inner wall)
- OD outer (next to rock/sand/...) tyvek position (effectively OD outer wall)

When using HK FD,
```
/WCSim/WCgeom HyperK_HybridmPMT_WithOD_Realistic
/WCSim/Construct
```
 this produces
```
-----------------------------------------------
Name         || Radius (cm) || Full length (cm)
-----------------------------------------------
IDBlacksheet || 32400       || 65751
ODInnerTyvek || 33021       || 66993
ODOuterTyvek || 34021       || 70993
-----------------------------------------------
```
which have the same values as the numbers printed out by the RealisticPlacement function


For IWCD, 
```
/WCSim/WCgeom IWCD_mPMT_WithOD
/WCSim/PMT/ReplicaPlacement false
/WCSim/Construct
```
this produces
```
-----------------------------------------------
Name         || Radius (cm) || Full length (cm)
-----------------------------------------------
IDBlacksheet || 3500       || 8000
ODInnerTyvek || 3721       || 8400
ODOuterTyvek || 4628.72       || 9844
-----------------------------------------------
```
@kmtsui I would appreciate it if you could check these IWCD numbers. They look wrong (e.g. ~2 m dead space) I'm obviously missing something in the tyvek geometry positioning definitions... Thanks