### PR TITLE
Added Row Seperation Factor/2

### DIFF
--- a/src/WCSimConstructRealisticPlacement.cc
+++ b/src/WCSimConstructRealisticPlacement.cc
@@ -919,7 +919,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructRealisticPlacement()
     // Inprint Columns first then rings
     for (int i = 0; i < 5; i++){
       G4RotationMatrix* imprint_rot = new G4RotationMatrix();
-      G4ThreeVector imprint_pos = G4ThreeVector(0.0,0.0,-i*imprint_spacing + WCIDHeight/2-70*cm);
+      G4ThreeVector imprint_pos = \
+        G4ThreeVector(0.0, 0.0, -i*imprint_spacing + WCIDHeight/2 - RowSeperation/4);
+
       for (int j = 0; j < config.NBlocksPerRing; j++){
         block_assembly->MakeImprint(InnerDetectorLogic, imprint_pos, imprint_rot);
         odblock_assembly->MakeImprint(OuterDetectorLogic, imprint_pos, imprint_rot);
@@ -928,7 +930,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructRealisticPlacement()
     }
 
     G4RotationMatrix* imprint_rot_bottom = new G4RotationMatrix();
-    G4ThreeVector imprint_pos_bottom = G4ThreeVector(0.0,0.0,-5*imprint_spacing + WCIDHeight/2-70*cm);
+    G4ThreeVector imprint_pos_bottom = \
+      G4ThreeVector(0.0, 0.0, -5*imprint_spacing + WCIDHeight/2 - RowSeperation/4);
+      
     for (int j = 0; j < config.NBlocksPerRing; j++){
       block_bottom->MakeImprint(InnerDetectorLogic, imprint_pos_bottom, imprint_rot_bottom);
       odblock_bottom->MakeImprint(OuterDetectorLogic, imprint_pos_bottom, imprint_rot_bottom);


### PR DESCRIPTION
ID integration diagrams consist of 5 patterns of 8 rows of PMTs, with a final single pattern of 6 rows of PMTs for the bottom. 

The whole geometry was shifted by one PMT cell width in the vertical direction to align it with the extent of the old geofile (~70cm), but this should have been actually half that distance. The result is the ID PMTs are slightly shifted away from the top cap which is only really noticeable when full PMT drawing is turned on.

Fix is to change to use RowSeperation/4 as this gives the correct offset.

**Before Fix**
<img width="340" alt="Screenshot 2025-05-25 at 23 23 15" src="https://github.com/user-attachments/assets/7a3f77ab-ca4e-4c37-801f-ae200835dafd" />

<img width="156" alt="Screenshot 2025-05-25 at 23 28 34" src="https://github.com/user-attachments/assets/f0fca123-04da-408b-888f-97e707e44616" />

<img width="156" alt="Screenshot 2025-05-25 at 23 28 53" src="https://github.com/user-attachments/assets/3f8841c3-04e3-4c7b-9d82-0ac2589dd2d9" />


**After Fix**
<img width="156" alt="Screenshot 2025-05-25 at 23 34 18" src="https://github.com/user-attachments/assets/3f519976-666c-43f9-8805-f310c7da83e5" />

<img width="156" alt="Screenshot 2025-05-25 at 23 34 23" src="https://github.com/user-attachments/assets/4c7ce8a5-5c3f-47de-8f4a-5aad09ac186d" />



