### PR TITLE
Make geometry boundary wall container work with old root

### DIFF
--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -79,7 +79,7 @@ class WCSimRootGeom : public TObject {
 private:
 
   /// Boundary wall (e.g. blacksheet/tyveks) dimensions for each boundary type. Correspond to the radius & full length of the cylinder (the vector allows this to be expanded to use e.g. cuboids in the future). Units: mm
-  std::map<BoundaryWallType_t, std::vector<float> > fBoundaryWallDimensions;
+  std::map<unsigned int, std::vector<float> > fBoundaryWallDimensions;
 
   Float_t                fWCCylRadius;  //!< Radius of WC tank. Based on maximum PMT position, so does not correspond to the full size of the tank (and is wildly inaccurate when your geometry has OD PMTs on the inner wall of the OD). Suggest to use GetBoundaryWallRadius() instead. Units: cm
   Float_t                fWCCylLength;  //!< Length of WC tank. Based on maximum PMT position, so does not correspond to the full size of the tank (and is wildly inaccurate when your geometry has OD PMTs on the inner wall of the OD). Suggest to use GetBoundaryWallFullLength() instead. Units: cm
@@ -108,8 +108,8 @@ public:
   bool CompareAllVariables(const WCSimRootGeom * c) const;
 
   // Sets and gets
-  void SetBoundaryWallDimensions(std::map<BoundaryWallType_t, std::vector<float> > dims) {fBoundaryWallDimensions = dims;}
-  
+  void SetBoundaryWallDimensions(std::map<BoundaryWallType_t, std::vector<float> > dims);
+
   void  SetWCCylRadius(Double_t f) {fWCCylRadius=f;}
   void  SetWCCylLength(Double_t f) {fWCCylLength=f;}
 
@@ -180,7 +180,7 @@ public:
   const WCSimRootPMT * GetODPMTPtr(Int_t i) const {return (WCSimRootPMT*)(fODPMTArray->At(i));}
   TClonesArray * GetODPMTs() {return fODPMTArray;}
 
-  ClassDef(WCSimRootGeom,2)  //WCSimRootEvent structure
+  ClassDef(WCSimRootGeom,3)  //WCSimRootEvent structure
 };
 
 

--- a/src/WCSimRootGeom.cc
+++ b/src/WCSimRootGeom.cc
@@ -185,21 +185,29 @@ bool WCSimRootPMT::CompareAllVariables(const WCSimRootPMT * c) const
 
 //______________________________________________________________________________
 Float_t WCSimRootGeom::GetBoundaryWallRadius(BoundaryWallType_t s) const {
-  auto it = fBoundaryWallDimensions.find(s);
+  const unsigned int is = static_cast<unsigned int>(s);
+  auto it = fBoundaryWallDimensions.find(is);
   if(it == fBoundaryWallDimensions.end()) {
     std::cerr << "Boundary type: " << WCSimEnumerations::EnumAsString(s) << " not found" << std::endl;
     return -999;
   }
-  return fBoundaryWallDimensions.at(s).at(0); //0 = radius
+  return fBoundaryWallDimensions.at(is).at(0); //0 = radius
 }
 //______________________________________________________________________________
 Float_t WCSimRootGeom::GetBoundaryWallFullLength(BoundaryWallType_t s) const {
-  auto it = fBoundaryWallDimensions.find(s);
+  const unsigned int is = static_cast<unsigned int>(s);
+  auto it = fBoundaryWallDimensions.find(is);
   if(it == fBoundaryWallDimensions.end()) {
     std::cerr << "Boundary type: " << WCSimEnumerations::EnumAsString(s) << " not found" << std::endl;
     return -999;
   }
-  return fBoundaryWallDimensions.at(s).at(1); //1 = full length
+  return fBoundaryWallDimensions.at(is).at(1); //1 = full length
+}
+//______________________________________________________________________________
+void WCSimRootGeom::SetBoundaryWallDimensions(std::map<BoundaryWallType_t, std::vector<float> > dims) {
+  for(auto const& x : dims) {
+    fBoundaryWallDimensions[static_cast<int>(x.first)] = x.second;
+  }
 }
 //______________________________________________________________________________
 void WCSimRootGeom::PrintBoundaryWallInfo() const {
@@ -208,10 +216,11 @@ void WCSimRootGeom::PrintBoundaryWallInfo() const {
 	    << "Name         || Radius (mm) || Full length (mm)" << std::endl
 	    << "-----------------------------------------------" << std::endl;
   for(auto const& x : fBoundaryWallDimensions) {
-    std::cout << WCSimEnumerations::EnumAsString(x.first) << " || "
+    std::cout << WCSimEnumerations::EnumAsString(static_cast<BoundaryWallType_t>(x.first)) << " || "
 	      << x.second.at(0) << "       || "
 	      << x.second.at(1) << std::endl;
   }
   std::cout << "-----------------------------------------------" << std::endl;
 }
 //______________________________________________________________________________
+


### PR DESCRIPTION
Use int instead of an enum in the map. Older versions of ROOT (e.g. 6.20.04) can write the file, but see a std::bad_alloc when they try to read it...