### PR TITLE
Add WCSim version that was used to generate the file to WCSimRootOptions

### DIFF
--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -59,6 +59,10 @@ public:
   virtual ~WCSimRootOptions();
   void Print(Option_t *option = "") const;
 
+  //WCSim version gets
+  string GetWCSimVersion() {return WCSimVersion;}
+  //WCSim version sets
+  void SetWCSimVersion(string iWCSimVersion) {WCSimVersion = iWCSimVersion;}
   //WCSimDetector* gets
   void SetDetectorName(string iDetectorName) {DetectorName = iDetectorName;}
   void SetGeomHasOD(bool iGeomHasOD) {GeomHasOD = iGeomHasOD;}
@@ -170,6 +174,8 @@ public:
   WCSimRandomGenerator_t GetRandomGenerator() {return RandomGenerator;}
 
 private:
+  //WCSim version
+  string WCSimVersion; //!< WCSim version. Includes latest tag, number of commits since last tag, and git hash
   //WCSimDetector*
   string DetectorName; //!< Name of the detector geometry
   bool   GeomHasOD; //!< Does the detector contain active OD PMTs?

--- a/include/WCSimRootOptions.hh
+++ b/include/WCSimRootOptions.hh
@@ -233,7 +233,7 @@ private:
   int                    RandomSeed; //!< The initial seed for one of the random number generators
   WCSimRandomGenerator_t RandomGenerator; //!< The random number generator type
   
-  ClassDef(WCSimRootOptions,5)
+  ClassDef(WCSimRootOptions,6)
 };
 
 

--- a/src/WCSimRootOptions.cc
+++ b/src/WCSimRootOptions.cc
@@ -13,7 +13,8 @@ using std::endl;
 using std::cout;
 
 //______________________________________________________________________________
-WCSimRootOptions::WCSimRootOptions()
+WCSimRootOptions::WCSimRootOptions():
+  WCSimVersion("")
 {
   // Create a WCSimRootOptions object.
 
@@ -28,6 +29,7 @@ WCSimRootOptions::~WCSimRootOptions()
 void WCSimRootOptions::Print(Option_t *) const
 {
   cout
+    << "WCSim version: " << WCSimVersion << endl
     << "Detector construction:" << endl
     << "\tDetectorName: " << DetectorName << endl
     << "\tDetectorHasOD: " << (GeomHasOD ? "yes" : "no") << endl

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -37,6 +37,10 @@ WCSimRunAction::WCSimRunAction(WCSimDetectorConstruction* test, WCSimRandomParam
   useDefaultROOTout = true;  //false;  TF: ToDo, make this false WHEN flat ROOT has RooTracker trees and when FiTQun can read that in.
   useFlatROOTout = false;
   wcsimrootoptions = new WCSimRootOptions();
+#ifdef GIT_HASH
+  const char* gitHash = GIT_HASH;
+  wcsimrootoptions->SetWCSimVersion(gitHash);
+#endif
 
   // By default do not try and save Rootracker interaction information
   SetSaveRooTracker(0);


### PR DESCRIPTION
This is taken from the git tag & git hash, from `git describe --always --long --tags --dirty` 
For example, a _clean_ git status is `v1.12.23-1-g3a5d2087` which shows
- the latest tag
- the number of commits since the last tag
- the current hash (after a trailing `g`)
When a modification to a tracked file occurs, then we get an extra `-dirty`: `v1.12.23-1-g3a5d2087-dirty`

Why like this? IWCD are already using it in their Settings tree, as I rediscovered yesterday. It's not quite what we spoke about Mathieu, but it actually combines both options (version & hash) into one. Let me know what you think - it'll be easy to modify what's actually put in the variable