### PR TITLE
assign correct thicknesses to FDOD WLS plates

### DIFF
--- a/src/Build.cc
+++ b/src/Build.cc
@@ -1,9 +1,11 @@
 #include "Build.h"
 // define type for FD OD WLS plate
+// HKFD WLS plate thickness is automatically set based on the chosen plate type. 
 //const std::string HKFD_OD_WLS_PLATE_TYPE = "EljenEJ286";  // Definition
 const std::string HKFD_OD_WLS_PLATE_TYPE = "Kuraray";  // Definition
 //const std::string HKFD_OD_WLS_PLATE_TYPE = "Inr";  // Definition
 
 // define type for IWCD WLS plate
+// all IWCD WLS plates are currently set to 1 cm by default. These defaults can be overridden with /WCSim/HyperKOD/ODWLSPlatesThickness
 const std::string IWCD_OD_WLS_PLATE_TYPE = "EljenEJ286";  // Definition
 //const std::string IWCD_OD_WLS_PLATE_TYPE = "Kuraray";  // Definition

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -979,6 +979,17 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_WithOD_Realistic_Geometry()
   WCODDeadSpace            = 600.*mm;
   WCODTyvekSheetThickness  = 1.*mm; // Quite standard I guess
   WCODWLSPlatesLength      = 30.*cm; //
+  G4String WLSType="";
+  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" ){
+	WLSType = "EljenEJ286";
+	WCODWLSPlatesThickness   = 1.*cm; //
+  }else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" ){
+	WLSType = "Kuraray";
+	WCODWLSPlatesThickness   = 0.6*cm; //
+  }  else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" ){
+	WLSType = "Inr";
+	WCODWLSPlatesThickness   = 0.7*cm; //
+  }
   WCODDiameter             = WCIDDiameter + 2*(WCBlackSheetThickness+WCODDeadSpace+WCODTyvekSheetThickness+WCODWLSPlatesThickness);
 
   // OD PMTs //
@@ -1009,18 +1020,6 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_WithOD_Realistic_Geometry()
   CreateCombinedPMTQE(WCColName);
   isCombinedPMTCollectionDefined=true;
 
-  // TEST WLS collection for stacking action
-  G4String WLSType="";
-  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" ){
-	WLSType = "EljenEJ286";
-	WCODWLSPlatesThickness   = 1.*cm; //
-  }else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" ){
-	WLSType = "Kuraray";
-	WCODWLSPlatesThickness   = 0.6*cm; //
-  }  else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" ){
-	WLSType = "Inr";
-	WCODWLSPlatesThickness   = 0.7*cm; //
-  }
   isWLSFilled = true;
   BuildODWLSCladding = true;
   CreateWLSObject(WLSType);
@@ -1100,6 +1099,17 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_IDonly_Realistic_Geometry()
   WCODDeadSpace            = 600.*mm;
   WCODTyvekSheetThickness  = 1.*mm; // Quite standard I guess
   WCODWLSPlatesLength      = 30.*cm; //
+  G4String WLSType="";
+  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" ){
+	WLSType = "EljenEJ286";
+	WCODWLSPlatesThickness   = 1.*cm; //
+  }else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" ){
+	WLSType = "Kuraray";
+	WCODWLSPlatesThickness   = 0.6*cm; //
+  }else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" ){
+	WLSType = "Inr";
+	WCODWLSPlatesThickness   = 0.7*cm; //
+  }
   WCODDiameter             = WCIDDiameter + 2*(WCBlackSheetThickness+WCODDeadSpace+WCODTyvekSheetThickness+WCODWLSPlatesThickness);
 
   // OD PMTs //
@@ -1131,18 +1141,6 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_IDonly_Realistic_Geometry()
   CreateCombinedPMTQE(WCColName);
   isCombinedPMTCollectionDefined=true;
 
-  // TEST WLS collection for stacking action
-  G4String WLSType="";
-  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" ){
-	WLSType = "EljenEJ286";
-	WCODWLSPlatesThickness   = 1.*cm; //
-  }else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" ){
-	WLSType = "Kuraray";
-	WCODWLSPlatesThickness   = 0.6*cm; //
-  }else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" ){
-	WLSType = "Inr";
-	WCODWLSPlatesThickness   = 0.7*cm; //
-  }
   isWLSFilled = true;
   BuildODWLSCladding = true;
   CreateWLSObject(WLSType);

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -978,7 +978,6 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_WithOD_Realistic_Geometry()
   WCODHeightWaterDepth     = 2.*m;
   WCODDeadSpace            = 600.*mm;
   WCODTyvekSheetThickness  = 1.*mm; // Quite standard I guess
-  WCODWLSPlatesThickness   = 1.*cm; //
   WCODWLSPlatesLength      = 30.*cm; //
   WCODDiameter             = WCIDDiameter + 2*(WCBlackSheetThickness+WCODDeadSpace+WCODTyvekSheetThickness+WCODWLSPlatesThickness);
 
@@ -1012,12 +1011,16 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_WithOD_Realistic_Geometry()
 
   // TEST WLS collection for stacking action
   G4String WLSType="";
-  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" )
+  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" ){
 	WLSType = "EljenEJ286";
-  else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" )
+	WCODWLSPlatesThickness   = 1.*cm; //
+  }else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" ){
 	WLSType = "Kuraray";
-  else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" )
+	WCODWLSPlatesThickness   = 0.6*cm; //
+  }  else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" ){
 	WLSType = "Inr";
+	WCODWLSPlatesThickness   = 0.7*cm; //
+  }
   isWLSFilled = true;
   BuildODWLSCladding = true;
   CreateWLSObject(WLSType);
@@ -1096,7 +1099,6 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_IDonly_Realistic_Geometry()
   WCODHeightWaterDepth     = 2.*m;
   WCODDeadSpace            = 600.*mm;
   WCODTyvekSheetThickness  = 1.*mm; // Quite standard I guess
-  WCODWLSPlatesThickness   = 1.*cm; //
   WCODWLSPlatesLength      = 30.*cm; //
   WCODDiameter             = WCIDDiameter + 2*(WCBlackSheetThickness+WCODDeadSpace+WCODTyvekSheetThickness+WCODWLSPlatesThickness);
 
@@ -1131,12 +1133,16 @@ void WCSimDetectorConstruction::SetHyperK_HybridmPMT_IDonly_Realistic_Geometry()
 
   // TEST WLS collection for stacking action
   G4String WLSType="";
-  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" )
+  if( HKFD_OD_WLS_PLATE_TYPE == "EljenEJ286" ){
 	WLSType = "EljenEJ286";
-  else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" )
+	WCODWLSPlatesThickness   = 1.*cm; //
+  }else if( HKFD_OD_WLS_PLATE_TYPE == "Kuraray" ){
 	WLSType = "Kuraray";
-  else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" )
+	WCODWLSPlatesThickness   = 0.6*cm; //
+  }else if( HKFD_OD_WLS_PLATE_TYPE == "Inr" ){
 	WLSType = "Inr";
+	WCODWLSPlatesThickness   = 0.7*cm; //
+  }
   isWLSFilled = true;
   BuildODWLSCladding = true;
   CreateWLSObject(WLSType);


### PR DESCRIPTION
this is to fix the default values of the thickness of the different types of WLS plates for the FDOD
Hopefully it's implemented in a way to change nothing for the IWCD