### PR TITLE
Create different tyvek surfaces

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -523,7 +523,14 @@ private:
   G4OpticalSurface * OpGlassCathodeSurface;
 
   //Tyvek surface - jl145
-  G4OpticalSurface * OpWaterTySurface;
+  G4OpticalSurface * OpWaterTySurface; // single surface used in ConstructCylinder()
+  // Multiple surfaces used in RealisticPlacement()
+  G4OpticalSurface * OpWaterTyInnerTopCapSurface;
+  G4OpticalSurface * OpWaterTyInnerBarrelSurface;
+  G4OpticalSurface * OpWaterTyInnerBottomCapSurface;
+  G4OpticalSurface * OpWaterTyOuterTopCapSurface;
+  G4OpticalSurface * OpWaterTyOuterBarrelSurface;
+  G4OpticalSurface * OpWaterTyOuterBottomCapSurface;
 
   //Reflector skin surface -tf
   G4OpticalSurface * ReflectorSkinSurface;

--- a/include/WCSimTuningMessenger.hh
+++ b/include/WCSimTuningMessenger.hh
@@ -45,7 +45,15 @@ private:
   G4UIcmdWithADouble* TVSpacing;
   G4UIcmdWithABool* TopVeto;
   G4UIcmdWithADouble* CommandWCODWLSCladdingReflectivity;
-  G4UIcmdWithADouble* CommandWCODTyvekReflectivity;
+
+  G4UIcmdWithABool*   CommandWCODTyvekReflectivityNuPrismModel;
+  G4UIcmdWithADouble* CommandWCODDefaultTyvekReflectivity;
+  G4UIcmdWithADouble* CommandWCODInnerTopCapTyvekReflectivity;
+  G4UIcmdWithADouble* CommandWCODInnerBarrelTyvekReflectivity;
+  G4UIcmdWithADouble* CommandWCODInnerBottomCapTyvekReflectivity;
+  G4UIcmdWithADouble* CommandWCODOuterTopCapTyvekReflectivity;
+  G4UIcmdWithADouble* CommandWCODOuterBarrelTyvekReflectivity;
+  G4UIcmdWithADouble* CommandWCODOuterBottomCapTyvekReflectivity;
 
 };
 

--- a/include/WCSimTuningParameters.hh
+++ b/include/WCSimTuningParameters.hh
@@ -66,9 +66,27 @@ public:
   G4double GetWCODWLSCladdingReflectivity() {return WCODWLSCladdingReflectivity;}
   void SetWCODWLSCladdingReflectivity(G4double tparam) {WCODWLSCladdingReflectivity=tparam;}
 
-  G4double GetWCODTyvekReflectivity() {return WCODTyvekReflectivity;}
-  void SetWCODTyvekReflectivity(G4double tparam) {WCODTyvekReflectivity=tparam;}
-
+  bool GetUsingNuPrismTyvekReflectivityModel() {return UsingNuPrismTyvekReflectivityModel;}
+  void SetUsingNuPrismTyvekReflectivityModel(G4bool tparam) {UsingNuPrismTyvekReflectivityModel = tparam;}
+  // default. Only used in ConstructCylinder() (e.g. for IWCD)
+  G4double GetWCODDefaultTyvekReflectivity() {return WCODDefaultTyvekReflectivity;}
+  void SetWCODDefaultTyvekReflectivity(G4double tparam) {WCODDefaultTyvekReflectivity=tparam;}
+  // Specific surfaces. Only used in RealisticPlacement (i.e. for HKFD)
+  //inner-wall tyvek
+  G4double GetWCODInnerTopCapTyvekReflectivity() {return WCODInnerTopCapTyvekReflectivity;}
+  void SetWCODInnerTopCapTyvekReflectivity(G4double tparam) {WCODInnerTopCapTyvekReflectivity=tparam;}
+  G4double GetWCODInnerBarrelTyvekReflectivity() {return WCODInnerBarrelTyvekReflectivity;}
+  void SetWCODInnerBarrelTyvekReflectivity(G4double tparam) {WCODInnerBarrelTyvekReflectivity=tparam;}
+  G4double GetWCODInnerBottomCapTyvekReflectivity() {return WCODInnerBottomCapTyvekReflectivity;}
+  void SetWCODInnerBottomCapTyvekReflectivity(G4double tparam) {WCODInnerBottomCapTyvekReflectivity=tparam;}
+  //outer-wall tyvek
+  G4double GetWCODOuterTopCapTyvekReflectivity() {return WCODOuterTopCapTyvekReflectivity;}
+  void SetWCODOuterTopCapTyvekReflectivity(G4double tparam) {WCODOuterTopCapTyvekReflectivity=tparam;}
+  G4double GetWCODOuterBarrelTyvekReflectivity() {return WCODOuterBarrelTyvekReflectivity;}
+  void SetWCODOuterBarrelTyvekReflectivity(G4double tparam) {WCODOuterBarrelTyvekReflectivity=tparam;}
+  G4double GetWCODOuterBottomCapTyvekReflectivity() {return WCODOuterBottomCapTyvekReflectivity;}
+  void SetWCODOuterBottomCapTyvekReflectivity(G4double tparam) {WCODOuterBottomCapTyvekReflectivity=tparam;}
+  
 private:
 
   // The messenger
@@ -99,8 +117,15 @@ private:
   G4bool topveto;
 
   G4double WCODWLSCladdingReflectivity;
-  G4double WCODTyvekReflectivity;
 
+  G4bool   UsingNuPrismTyvekReflectivityModel;
+  G4double WCODDefaultTyvekReflectivity;
+  G4double WCODInnerTopCapTyvekReflectivity;
+  G4double WCODInnerBarrelTyvekReflectivity;
+  G4double WCODInnerBottomCapTyvekReflectivity;
+  G4double WCODOuterTopCapTyvekReflectivity;
+  G4double WCODOuterBarrelTyvekReflectivity;
+  G4double WCODOuterBottomCapTyvekReflectivity;
 };
 
 #endif

--- a/macros/tuning_parameters_hkfd.mac
+++ b/macros/tuning_parameters_hkfd.mac
@@ -18,6 +18,17 @@
 /WCSim/tuning/PMTCathodePara data/CathodeParameters.txt
 
 /WCSim/tuning/WCODWLSCladdingReflectivity 0.99
-/WCSim/tuning/WCODTyvekReflectivity 0.90
 
+# Use the HKFD tyvek reflectivity model
+/WCSim/tuning/UseNuPrismTyvekReflectivityModel 0
 
+# Used by ConstructCylinder only (e.g. for IWCD)
+/WCSim/tuning/WCODDefaultTyvekReflectivity 0.90
+
+# Used by RealisticPlacement only (i.e. for HKFD)
+/WCSim/tuning/WCODInnerTopCapTyvekReflectivity 0.90
+/WCSim/tuning/WCODInnerBarrelTyvekReflectivity 0.90
+/WCSim/tuning/WCODInnerBottomCapTyvekReflectivity 0.90
+/WCSim/tuning/WCODOuterTopCapTyvekReflectivity 0.90
+/WCSim/tuning/WCODOuterBarrelTyvekReflectivity 0.90
+/WCSim/tuning/WCODOuterBottomCapTyvekReflectivity 0.90

--- a/macros/tuning_parameters_hkfd_aged.mac
+++ b/macros/tuning_parameters_hkfd_aged.mac
@@ -18,6 +18,19 @@
 /WCSim/tuning/PMTCathodePara data/CathodeParameters.txt
 
 /WCSim/tuning/WCODWLSCladdingReflectivity 0.99
-/WCSim/tuning/WCODTyvekReflectivity 0.80
+
+# Use the HKFD tyvek reflectivity model
+/WCSim/tuning/UseNuPrismTyvekReflectivityModel 0
+
+# Used by ConstructCylinder only (e.g. for IWCD)
+/WCSim/tuning/WCODDefaultTyvekReflectivity 0.80
+
+# Used by RealisticPlacement only (i.e. for HKFD)
+/WCSim/tuning/WCODInnerTopCapTyvekReflectivity 0.80
+/WCSim/tuning/WCODInnerBarrelTyvekReflectivity 0.80
+/WCSim/tuning/WCODInnerBottomCapTyvekReflectivity 0.80
+/WCSim/tuning/WCODOuterTopCapTyvekReflectivity 0.80
+/WCSim/tuning/WCODOuterBarrelTyvekReflectivity 0.80
+/WCSim/tuning/WCODOuterBottomCapTyvekReflectivity 0.80
 
 

--- a/macros/tuning_parameters_iwcd.mac
+++ b/macros/tuning_parameters_iwcd.mac
@@ -18,6 +18,19 @@
 /WCSim/tuning/PMTCathodePara data/CathodeParameters.txt
 
 /WCSim/tuning/WCODWLSCladdingReflectivity 0.90
-/WCSim/tuning/WCODTyvekReflectivity 0.90
+
+# Use the IWCD tyvek reflectivity model
+/WCSim/tuning/UseNuPrismTyvekReflectivityModel 1
+
+# Used by ConstructCylinder only (e.g. for IWCD)
+/WCSim/tuning/WCODDefaultTyvekReflectivity 0.90
+
+# Used by RealisticPlacement only (i.e. for HKFD)
+/WCSim/tuning/WCODInnerTopCapTyvekReflectivity 0.90
+/WCSim/tuning/WCODInnerBarrelTyvekReflectivity 0.90
+/WCSim/tuning/WCODInnerBottomCapTyvekReflectivity 0.90
+/WCSim/tuning/WCODOuterTopCapTyvekReflectivity 0.90
+/WCSim/tuning/WCODOuterBarrelTyvekReflectivity 0.90
+/WCSim/tuning/WCODOuterBottomCapTyvekReflectivity 0.90
 
 

--- a/src/WCSimConstructMaterials.cc
+++ b/src/WCSimConstructMaterials.cc
@@ -1467,14 +1467,6 @@ void WCSimDetectorConstruction::ConstructMaterials()
   // ##### TYVEK ##### //
   ///////////////////////
 
-  OpWaterTySurface =
-      new G4OpticalSurface("WaterTyCellSurface");
-
-  OpWaterTySurface->SetType(dielectric_metal); // Only absorption and reflection
-  OpWaterTySurface->SetModel(unified);
-  OpWaterTySurface->SetFinish(ground); // ground surface with tyvek
-  OpWaterTySurface->SetSigmaAlpha(0.2);
-
   G4double RINDEX_tyvek[NUM] =
       { 1.5, 1.5 }; // polyethylene permittivity is ~2.25
   G4double TySPECULARLOBECONSTANT[NUM] =
@@ -1488,7 +1480,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
 #define NUMENTRIES_TY_FDOD 36 // Number of bins of wavelength to be used for the Tyvek reflectivity
 #define NUMENTRIES_TY_IWCD 33 
 
-  double WCODTyvekReflectivity = WCSimTuningParams->GetWCODTyvekReflectivity();
+  //double WCODTyvekReflectivity = WCSimTuningParams->GetWCODTyvekReflectivity();
 
   G4double PP_TyREFLECTIVITY_FDOD[NUMENTRIES_TY_FDOD] = //Tyvek reflectivity wavelength bins
       { 2.06642*eV,
@@ -1500,7 +1492,8 @@ void WCSimDetectorConstruction::ConstructMaterials()
         3.64662*eV, 3.75713*eV, 3.87454*eV, 3.99952*eV, 4.13284*eV,
         4.27535*eV, 4.42804*eV, 4.6*eV, 4.8*eV, 5.0*eV};
 
-  G4double OD_tyvek_reflectivity_scaling_factor_FDOD = WCODTyvekReflectivity/0.95; // this should be the maximum of the reflectivity values
+  //G4double OD_tyvek_reflectivity_scaling_factor_FDOD = WCODTyvekReflectivity/0.95; // this should be the maximum of the reflectivity values
+  G4double OD_tyvek_reflectivity_scaling_factor_denominator_FDOD = 0.95; // this should be the maximum of the reflectivity values
 
   G4double TyREFLECTIVITY_FDOD[NUMENTRIES_TY_FDOD] = // Tyvek refelctivity
     { 0.94, // 600 nm
@@ -1512,9 +1505,10 @@ void WCSimDetectorConstruction::ConstructMaterials()
       0.93, 0.92, 0.91, 0.89, 0.86, // 340-300
       0.80, 0.76, 0.70, 0.65, 0.55}; // 290-250
 
+  /*
  for(int i=0; i<NUMENTRIES_TY_FDOD; i++)
     TyREFLECTIVITY_FDOD[i] *= OD_tyvek_reflectivity_scaling_factor_FDOD;
-
+  */
 
   G4double PP_TyREFLECTIVITY_IWCD[NUMENTRIES_TY_IWCD] = //Tyvek reflectivity wavelength bins
       { 2.06642*eV,
@@ -1526,7 +1520,8 @@ void WCSimDetectorConstruction::ConstructMaterials()
         3.64662*eV, 3.75713*eV, 3.87454*eV, 3.99952*eV, 4.13284*eV,
         4.27535*eV, 4.42804*eV};
 
-  G4double OD_tyvek_reflectivity_scaling_factor_IWCD = WCODTyvekReflectivity/0.97; 
+  //G4double OD_tyvek_reflectivity_scaling_factor_IWCD = WCODTyvekReflectivity/0.97;
+  G4double OD_tyvek_reflectivity_scaling_factor_denominator_IWCD = 0.97;
 
   G4double TyREFLECTIVITY_IWCD[NUMENTRIES_TY_IWCD] = // Tyvek refelctivity
       { 0.97,
@@ -1537,15 +1532,16 @@ void WCSimDetectorConstruction::ConstructMaterials()
         0.96, 0.96, 0.95, 0.95, 0.95,
         0.94, 0.93, 0.92, 0.91, 0.90,
         0.89, 0.86};
-
+  /*
  for(int i=0; i<NUMENTRIES_TY_IWCD; i++)
     TyREFLECTIVITY_IWCD[i] *= OD_tyvek_reflectivity_scaling_factor_IWCD;
-
+  */
   G4MaterialPropertiesTable *MPT_Tyvek = new G4MaterialPropertiesTable();
   // MPT_Tyvek->AddProperty("RINDEX", PP, RINDEX_tyvek, NUM);
   // MPT_Tyvek->AddProperty("ABSLENGTH", ENERGY_water, BLACKABS_blacksheet, NUMENTRIES_water);
   Tyvek->SetMaterialPropertiesTable(MPT_Tyvek);
 
+  /*
   G4MaterialPropertiesTable *MPTWater_Ty = new G4MaterialPropertiesTable();
   MPTWater_Ty->AddProperty("RINDEX", PP, RINDEX_tyvek, NUM);
   MPTWater_Ty->AddProperty("SPECULARLOBECONSTANT", PP, TySPECULARLOBECONSTANT, NUM);
@@ -1556,6 +1552,7 @@ void WCSimDetectorConstruction::ConstructMaterials()
   else
     MPTWater_Ty->AddProperty("REFLECTIVITY",  PP_TyREFLECTIVITY_FDOD, TyREFLECTIVITY_FDOD, NUMENTRIES_TY_FDOD);
   OpWaterTySurface->SetMaterialPropertiesTable(MPTWater_Ty);
+  */
   //
   // ----
 
@@ -1945,13 +1942,124 @@ void WCSimDetectorConstruction::ConstructMaterials()
    myST3->AddProperty("SPECULARLOBECONSTANT", PP, TySPECULARLOBECONSTANT, NUM);
    myST3->AddProperty("SPECULARSPIKECONSTANT", PP, TySPECULARSPIKECONSTANT, NUM);
    myST3->AddProperty("BACKSCATTERCONSTANT", PP, TyBACKSCATTERCONSTANT, NUM);
-   if( isNuPrism )
-     myST3->AddProperty("REFLECTIVITY", PP_TyREFLECTIVITY_IWCD, TyREFLECTIVITY_IWCD, NUMENTRIES_TY_IWCD);
-   else
-     myST3->AddProperty("REFLECTIVITY", PP_TyREFLECTIVITY_FDOD, TyREFLECTIVITY_FDOD, NUMENTRIES_TY_FDOD);
-   myST3->AddProperty("EFFICIENCY", PP, EFFICIENCY_blacksheet, NUM);
    //use same efficiency as blacksheet, which is 0
-   OpWaterTySurface->SetMaterialPropertiesTable(myST3);
+   myST3->AddProperty("EFFICIENCY", PP, EFFICIENCY_blacksheet, NUM);
+
+   // Different tyvek for different surfaces, each with different reflectivity
+   std::array<std::string, 5> properties_to_copy = {"RINDEX", "SPECULARLOBECONSTANT", "SPECULARSPIKECONSTANT", "BACKSCATTERCONSTANT", "EFFICIENCY"};
+   const bool isNuPrismTyvekModel = WCSimTuningParams->GetUsingNuPrismTyvekReflectivityModel();
+   const int n_tyvek_reflectivity_entries = isNuPrismTyvekModel ? NUMENTRIES_TY_IWCD : NUMENTRIES_TY_FDOD;
+   const G4double * tyvek_reflectivity_base_array = isNuPrismTyvekModel ? TyREFLECTIVITY_IWCD : TyREFLECTIVITY_FDOD;
+   G4double * tyvek_reflectivity_energy_array = isNuPrismTyvekModel ? PP_TyREFLECTIVITY_IWCD : PP_TyREFLECTIVITY_FDOD;
+   const G4double OD_tyvek_reflectivity_scaling_factor_denominator = isNuPrismTyvekModel ? OD_tyvek_reflectivity_scaling_factor_denominator_IWCD : OD_tyvek_reflectivity_scaling_factor_denominator_FDOD;
+   G4cout << "I'm setting up tyvek assuming nuprism? " << isNuPrismTyvekModel << G4endl;
+   // DEFAULT SURFACE - USED BY CONSTRUCT CYLINDER
+   std::vector<G4double> TyREFLECTIVITY_Default(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_Default[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODDefaultTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_Default = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_Default->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_Default->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_Default.data(), n_tyvek_reflectivity_entries);
+   OpWaterTySurface =
+     new G4OpticalSurface("WaterTyCellSurface");
+   OpWaterTySurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTySurface->SetModel(unified);
+   OpWaterTySurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTySurface->SetSigmaAlpha(0.2);
+   OpWaterTySurface->SetMaterialPropertiesTable(myST3_Default);
+
+   // SPECIFIC SURFACES - USED BY REALISTIC PLACEMENT
+   // INNER WALL TOP CAP
+   std::vector<G4double> TyREFLECTIVITY_InnerTopCap(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_InnerTopCap[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODInnerTopCapTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_InnerTopCap = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_InnerTopCap->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_InnerTopCap->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_InnerTopCap.data(), n_tyvek_reflectivity_entries);
+   OpWaterTyInnerTopCapSurface =
+     new G4OpticalSurface("WaterTyInnerTopCapCellSurface");
+   OpWaterTyInnerTopCapSurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTyInnerTopCapSurface->SetModel(unified);
+   OpWaterTyInnerTopCapSurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTyInnerTopCapSurface->SetSigmaAlpha(0.2);
+   OpWaterTyInnerTopCapSurface->SetMaterialPropertiesTable(myST3_InnerTopCap);
+   // INNER WALL BARREL
+   std::vector<G4double> TyREFLECTIVITY_InnerBarrel(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_InnerBarrel[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODInnerBarrelTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_InnerBarrel = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_InnerBarrel->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_InnerBarrel->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_InnerBarrel.data(), n_tyvek_reflectivity_entries);
+   OpWaterTyInnerBarrelSurface =
+     new G4OpticalSurface("WaterTyInnerBarrelCellSurface");
+   OpWaterTyInnerBarrelSurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTyInnerBarrelSurface->SetModel(unified);
+   OpWaterTyInnerBarrelSurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTyInnerBarrelSurface->SetSigmaAlpha(0.2);
+   OpWaterTyInnerBarrelSurface->SetMaterialPropertiesTable(myST3_InnerBarrel);
+   // INNER WALL BOTTOM CAP
+   std::vector<G4double> TyREFLECTIVITY_InnerBottomCap(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_InnerBottomCap[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODInnerBottomCapTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_InnerBottomCap = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_InnerBottomCap->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_InnerBottomCap->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_InnerBottomCap.data(), n_tyvek_reflectivity_entries);
+   OpWaterTyInnerBottomCapSurface =
+     new G4OpticalSurface("WaterTyInnerBottomCapCellSurface");
+   OpWaterTyInnerBottomCapSurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTyInnerBottomCapSurface->SetModel(unified);
+   OpWaterTyInnerBottomCapSurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTyInnerBottomCapSurface->SetSigmaAlpha(0.2);
+   OpWaterTyInnerBottomCapSurface->SetMaterialPropertiesTable(myST3_InnerBottomCap);
+   // OUTER WALL TOP CAP
+   std::vector<G4double> TyREFLECTIVITY_OuterTopCap(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_OuterTopCap[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODOuterTopCapTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_OuterTopCap = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_OuterTopCap->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_OuterTopCap->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_OuterTopCap.data(), n_tyvek_reflectivity_entries);
+   OpWaterTyOuterTopCapSurface =
+     new G4OpticalSurface("WaterTyOuterTopCapCellSurface");
+   OpWaterTyOuterTopCapSurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTyOuterTopCapSurface->SetModel(unified);
+   OpWaterTyOuterTopCapSurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTyOuterTopCapSurface->SetSigmaAlpha(0.2);
+   OpWaterTyOuterTopCapSurface->SetMaterialPropertiesTable(myST3_OuterTopCap);
+   // OUTER WALL BARREL
+   std::vector<G4double> TyREFLECTIVITY_OuterBarrel(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_OuterBarrel[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODOuterBarrelTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_OuterBarrel = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_OuterBarrel->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_OuterBarrel->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_OuterBarrel.data(), n_tyvek_reflectivity_entries);
+   OpWaterTyOuterBarrelSurface =
+     new G4OpticalSurface("WaterTyOuterBarrelCellSurface");
+   OpWaterTyOuterBarrelSurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTyOuterBarrelSurface->SetModel(unified);
+   OpWaterTyOuterBarrelSurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTyOuterBarrelSurface->SetSigmaAlpha(0.2);
+   OpWaterTyOuterBarrelSurface->SetMaterialPropertiesTable(myST3_OuterBarrel);
+   // OUTER WALL BOTTOM CAP
+   std::vector<G4double> TyREFLECTIVITY_OuterBottomCap(n_tyvek_reflectivity_entries);
+   for(int i = 0; i < n_tyvek_reflectivity_entries; i++)
+     TyREFLECTIVITY_OuterBottomCap[i] = tyvek_reflectivity_base_array[i] * WCSimTuningParams->GetWCODOuterBottomCapTyvekReflectivity() / OD_tyvek_reflectivity_scaling_factor_denominator;
+   G4MaterialPropertiesTable *myST3_OuterBottomCap = new G4MaterialPropertiesTable();
+   for(const auto & property : properties_to_copy)
+     myST3_OuterBottomCap->AddProperty(property.c_str(), myST3->GetProperty(property.c_str()));
+   myST3_OuterBottomCap->AddProperty("REFLECTIVITY", tyvek_reflectivity_energy_array, TyREFLECTIVITY_OuterBottomCap.data(), n_tyvek_reflectivity_entries);
+   OpWaterTyOuterBottomCapSurface =
+     new G4OpticalSurface("WaterTyOuterBottomCapCellSurface");
+   OpWaterTyOuterBottomCapSurface->SetType(dielectric_metal); // Only absorption and reflection
+   OpWaterTyOuterBottomCapSurface->SetModel(unified);
+   OpWaterTyOuterBottomCapSurface->SetFinish(ground); // ground surface with tyvek
+   OpWaterTyOuterBottomCapSurface->SetSigmaAlpha(0.2);
+   OpWaterTyOuterBottomCapSurface->SetMaterialPropertiesTable(myST3_OuterBottomCap);
 
 
    // Surfaces for Al, Ag and future combinations:

--- a/src/WCSimTuningMessenger.cc
+++ b/src/WCSimTuningMessenger.cc
@@ -86,11 +86,45 @@ WCSimTuningMessenger::WCSimTuningMessenger(WCSimTuningParameters* WCTuningPars):
   CommandWCODWLSCladdingReflectivity->SetParameterName("WCODWLSCladdingReflectivity",true);
   CommandWCODWLSCladdingReflectivity->SetDefaultValue(0.90);
 
-  CommandWCODTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODTyvekReflectivity",this);
-  CommandWCODTyvekReflectivity->SetGuidance("Set OD tyvek cladding reflectivity");
-  CommandWCODTyvekReflectivity->SetParameterName("WCODTyvekReflectivity",true);
-  CommandWCODTyvekReflectivity->SetDefaultValue(0.90);
+  CommandWCODTyvekReflectivityNuPrismModel = new G4UIcmdWithABool("/WCSim/tuning/UseNuPrismTyvekReflectivityModel",this);
+  CommandWCODTyvekReflectivityNuPrismModel->SetGuidance("Use IWCD model for tyvek reflectivity?");
+  CommandWCODTyvekReflectivityNuPrismModel->SetParameterName("UseNuPrismTyvekReflectivityModel",true);
+  CommandWCODTyvekReflectivityNuPrismModel->SetDefaultValue(0);
+    
+  CommandWCODDefaultTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODDefaultTyvekReflectivity",this);
+  CommandWCODDefaultTyvekReflectivity->SetGuidance("Set OD cladding reflectivity. Only used in ConstructCylinder() (e.g. for IWCD)");
+  CommandWCODDefaultTyvekReflectivity->SetParameterName("WCODDefaultTyvekReflectivity",true);
+  CommandWCODDefaultTyvekReflectivity->SetDefaultValue(0.90);
 
+  CommandWCODInnerTopCapTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODInnerTopCapTyvekReflectivity",this);
+  CommandWCODInnerTopCapTyvekReflectivity->SetGuidance("Set OD inner-wall top-cap tyvek cladding reflectivity");
+  CommandWCODInnerTopCapTyvekReflectivity->SetParameterName("WCODInnerTopCapTyvekReflectivity",true);
+  CommandWCODInnerTopCapTyvekReflectivity->SetDefaultValue(0.90);
+
+  CommandWCODInnerBarrelTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODInnerBarrelTyvekReflectivity",this);
+  CommandWCODInnerBarrelTyvekReflectivity->SetGuidance("Set OD inner-wall barrel tyvek cladding reflectivity");
+  CommandWCODInnerBarrelTyvekReflectivity->SetParameterName("WCODInnerBarrelTyvekReflectivity",true);
+  CommandWCODInnerBarrelTyvekReflectivity->SetDefaultValue(0.90);
+
+  CommandWCODInnerBottomCapTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODInnerBottomCapTyvekReflectivity",this);
+  CommandWCODInnerBottomCapTyvekReflectivity->SetGuidance("Set OD inner-wall bottom-cap tyvek cladding reflectivity");
+  CommandWCODInnerBottomCapTyvekReflectivity->SetParameterName("WCODInnerBottomCapTyvekReflectivity",true);
+  CommandWCODInnerBottomCapTyvekReflectivity->SetDefaultValue(0.90);
+
+  CommandWCODOuterTopCapTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODOuterTopCapTyvekReflectivity",this);
+  CommandWCODOuterTopCapTyvekReflectivity->SetGuidance("Set OD outer-wall top-cap tyvek cladding reflectivity");
+  CommandWCODOuterTopCapTyvekReflectivity->SetParameterName("WCODOuterTopCapTyvekReflectivity",true);
+  CommandWCODOuterTopCapTyvekReflectivity->SetDefaultValue(0.90);
+
+  CommandWCODOuterBarrelTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODOuterBarrelTyvekReflectivity",this);
+  CommandWCODOuterBarrelTyvekReflectivity->SetGuidance("Set OD outer-wall barrel tyvek cladding reflectivity");
+  CommandWCODOuterBarrelTyvekReflectivity->SetParameterName("WCODOuterBarrelTyvekReflectivity",true);
+  CommandWCODOuterBarrelTyvekReflectivity->SetDefaultValue(0.90);
+
+  CommandWCODOuterBottomCapTyvekReflectivity = new G4UIcmdWithADouble("/WCSim/tuning/WCODOuterBottomCapTyvekReflectivity",this);
+  CommandWCODOuterBottomCapTyvekReflectivity->SetGuidance("Set OD outer-wall bottom-cap tyvek cladding reflectivity");
+  CommandWCODOuterBottomCapTyvekReflectivity->SetParameterName("WCODOuterBottomCapTyvekReflectivity",true);
+  CommandWCODOuterBottomCapTyvekReflectivity->SetDefaultValue(0.90);
 }
 
 WCSimTuningMessenger::~WCSimTuningMessenger()
@@ -112,7 +146,15 @@ WCSimTuningMessenger::~WCSimTuningMessenger()
   delete TopVeto;
 
   delete CommandWCODWLSCladdingReflectivity;
-  delete CommandWCODTyvekReflectivity;
+
+  delete CommandWCODTyvekReflectivityNuPrismModel;
+  delete CommandWCODDefaultTyvekReflectivity;
+  delete CommandWCODInnerTopCapTyvekReflectivity;
+  delete CommandWCODInnerBarrelTyvekReflectivity;
+  delete CommandWCODInnerBottomCapTyvekReflectivity;
+  delete CommandWCODOuterTopCapTyvekReflectivity;
+  delete CommandWCODOuterBarrelTyvekReflectivity;
+  delete CommandWCODOuterBottomCapTyvekReflectivity;
 
   delete WCSimDir;
 }
@@ -207,14 +249,44 @@ void WCSimTuningMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
   }
 
   else if(command == CommandWCODWLSCladdingReflectivity) {
-    // Set the Top Veto PMT Spacing
     WCSimTuningParams->SetWCODWLSCladdingReflectivity(CommandWCODWLSCladdingReflectivity->GetNewDoubleValue(newValue));
     G4cout << "Setting OD WLS plate cladding reflectivity " << CommandWCODWLSCladdingReflectivity->GetNewDoubleValue(newValue) << G4endl;
   }
 
-  else if(command == CommandWCODTyvekReflectivity) {
-    // Set the Top Veto PMT Spacing
-    WCSimTuningParams->SetWCODTyvekReflectivity(CommandWCODTyvekReflectivity->GetNewDoubleValue(newValue));
-    G4cout << "Setting OD tyvek reflectivity " << CommandWCODTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  else if(command == CommandWCODTyvekReflectivityNuPrismModel) {
+    WCSimTuningParams->SetUsingNuPrismTyvekReflectivityModel(CommandWCODTyvekReflectivityNuPrismModel->GetNewBoolValue(newValue));
+    if(CommandWCODTyvekReflectivityNuPrismModel->GetNewBoolValue(newValue))
+      G4cout << "Using IWCD tyvek reflectivity model" << G4endl;
+    else
+      G4cout << "Using HKFD tyvek reflectivity model" << G4endl;
+  }
+
+  else if(command == CommandWCODDefaultTyvekReflectivity) {
+    WCSimTuningParams->SetWCODDefaultTyvekReflectivity(CommandWCODDefaultTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting OD inner-wall top-cap tyvek reflectivity (only used in ConstructCylinder e.g. for IWCD) " << CommandWCODDefaultTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  }
+  else if(command == CommandWCODInnerTopCapTyvekReflectivity) {
+    WCSimTuningParams->SetWCODInnerTopCapTyvekReflectivity(CommandWCODInnerTopCapTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting OD inner-wall top-cap tyvek reflectivity (only used in RealisticPlacement i.e. for HKFD) " << CommandWCODInnerTopCapTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  }
+  else if(command == CommandWCODInnerBarrelTyvekReflectivity) {
+    WCSimTuningParams->SetWCODInnerBarrelTyvekReflectivity(CommandWCODInnerBarrelTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting inner-wall barrel tyvek reflectivity (only used in RealisticPlacement i.e. for HKFD) " << CommandWCODInnerBarrelTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  }
+  else if(command == CommandWCODInnerBottomCapTyvekReflectivity) {
+    WCSimTuningParams->SetWCODInnerBottomCapTyvekReflectivity(CommandWCODInnerBottomCapTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting inner-wall bottom-cap tyvek reflectivity (only used in RealisticPlacement i.e. for HKFD) " << CommandWCODInnerBottomCapTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  }
+  else if(command == CommandWCODOuterTopCapTyvekReflectivity) {
+    WCSimTuningParams->SetWCODOuterTopCapTyvekReflectivity(CommandWCODOuterTopCapTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting OD outer-wall top-cap tyvek reflectivity (only used in RealisticPlacement i.e. for HKFD) " << CommandWCODOuterTopCapTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  }
+  else if(command == CommandWCODOuterBarrelTyvekReflectivity) {
+    WCSimTuningParams->SetWCODOuterBarrelTyvekReflectivity(CommandWCODOuterBarrelTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting outer-wall barrel tyvek reflectivity (only used in RealisticPlacement i.e. for HKFD) " << CommandWCODOuterBarrelTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
+  }
+  else if(command == CommandWCODOuterBottomCapTyvekReflectivity) {
+    WCSimTuningParams->SetWCODOuterBottomCapTyvekReflectivity(CommandWCODOuterBottomCapTyvekReflectivity->GetNewDoubleValue(newValue));
+    G4cout << "Setting outer-wall bottom-cap tyvek reflectivity (only used in RealisticPlacement i.e. for HKFD) " << CommandWCODOuterBottomCapTyvekReflectivity->GetNewDoubleValue(newValue) << G4endl;
   }
 }

--- a/src/WCSimTuningParameters.cc
+++ b/src/WCSimTuningParameters.cc
@@ -32,8 +32,15 @@ WCSimTuningParameters::WCSimTuningParameters()
  topveto = false;
 
  WCODWLSCladdingReflectivity   = 0.99; //
- WCODTyvekReflectivity   = 0.90; //
 
+ UsingNuPrismTyvekReflectivityModel = false;
+ WCODDefaultTyvekReflectivity   = 0.90; //
+ WCODInnerTopCapTyvekReflectivity   = 0.90; //
+ WCODInnerBarrelTyvekReflectivity   = 0.90; //
+ WCODInnerBottomCapTyvekReflectivity   = 0.90; //
+ WCODOuterTopCapTyvekReflectivity   = 0.90; //
+ WCODOuterBarrelTyvekReflectivity   = 0.90; //
+ WCODOuterBottomCapTyvekReflectivity   = 0.90; //
 }
 
 WCSimTuningParameters::~WCSimTuningParameters()

--- a/src/WCSimWLSProperties.cc
+++ b/src/WCSimWLSProperties.cc
@@ -663,7 +663,7 @@ void Kuraray::SetgAbs(){
   //       0.71, 0.54, 0, 0, // 300 --- 250
   //       0, 0, 0, 0, 0}; // 250 --- 200
   gAbs = new TGraph();
-  const int step = 10;
+  //const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS ABS" << std::endl;
   // Then fill with point there is data
@@ -675,7 +675,7 @@ void Kuraray::SetgAbs(){
 }
 void Kuraray::SetgEm(){
   gEm = new TGraph();
-  const int step = 10;
+  //const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS EM" << std::endl;
   // Then fill with point there is data
@@ -936,7 +936,7 @@ void Inr::SetgAbs(){
   //       0.71, 0.54, 0, 0, // 300 --- 250
   //       0, 0, 0, 0, 0}; // 250 --- 200
   gAbs = new TGraph();
-  const int step = 10;
+  //const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS ABS" << std::endl;
   // Then fill with point there is data
@@ -948,7 +948,7 @@ void Inr::SetgAbs(){
 }
 void Inr::SetgEm(){
   gEm = new TGraph();
-  const int step = 10;
+  //const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS EM" << std::endl;
   // Then fill with point there is data


### PR DESCRIPTION
Adds 6 new tyvek surfaces, for each of (inner, outer wall) x (top / barrel / bottom). They are currently just defined, not used.
A follow-up PR will _use_ the new tyvek surfaces for the HK FD (probably tomorrow)

This PR also fixes a bug: IWCD detectors were using the same tyvek model as HKFD. We wanted to keep IWCD on the older model. What went wrong?
- The materials are defined **before** WCSim.mac is read (only jobOptions.mac & tuning_parameters.mac have been read in)
- The decision to use HKFD or IWCD tyvek model was based on `isNuPrism`, which defaults to `false`
- The `isNuPrism` variable is then set (based on geometry options in WCSim.mac), being set to `true` if an IWCD geometry is used

* This PR _should_ produce identical results in CI to previously, as the CI currently uses a standard tuning_parameter.mac file for all detectors.
* If successful, I will then update the validation scripts to use the IWCD tyvek model for IWCD, and FD model for FD. This _should_ modify IWCD CI results only