### PR TITLE
Compatibility update for neut5.6.4

### DIFF
--- a/include/TJNuBeamFlux.hh
+++ b/include/TJNuBeamFlux.hh
@@ -10,6 +10,8 @@
 /// 11a version of pass-through info.
 ///
 
+namespace ND {
+
 const int kNgmax = 12; 
 
 // This is the base class for all RooTracker type objects. For now
@@ -19,7 +21,7 @@ class RooTrackerVtxBase : public TObject {
     public:
         RooTrackerVtxBase();
         virtual ~RooTrackerVtxBase(){}
-        ClassDef(RooTrackerVtxBase, 1);
+        ClassDef(ND::RooTrackerVtxBase, 1);
 };
 
 class JNuBeamFlux : public RooTrackerVtxBase {
@@ -99,7 +101,8 @@ class JNuBeamFlux : public RooTrackerVtxBase {
         int         NuRand;             ///< Random seed
         //    int         NuRseed[2];         // Random seed
 
-        ClassDef(JNuBeamFlux, 1);
+        ClassDef(ND::JNuBeamFlux, 1);
 };
 
+}
 #endif

--- a/include/TNRooTrackerVtx.hh
+++ b/include/TNRooTrackerVtx.hh
@@ -13,6 +13,7 @@
 
 using std::ostream;
 
+namespace ND {
 
 const int kNStdHepNPmax = 100;
 const int kNStdHepIdxPx = 0;
@@ -363,4 +364,5 @@ class NRooTrackerVtx : public JNuBeamFlux {
   ClassDef(NRooTrackerVtx, 3);
 };
 
+}
 #endif

--- a/include/TNRooTrackerVtx.hh
+++ b/include/TNRooTrackerVtx.hh
@@ -5,190 +5,362 @@
 
 #include <vector>
 
-#include "TObject.h"
 #include "TBits.h"
 #include "TObjString.h"
+#include "TObject.h"
 
 #include "TJNuBeamFlux.hh"
 
 using std::ostream;
 
-///
-/// This is a simple event class which is essentially an objectified version
-/// of the NEUT nRooTracker output format. Because the nRooTracker is forcing 
-/// NEUT event into a GENIE defined storage care needs to be taken when
-/// interpreting the meaning of various data members. For example the StdHepStatus
-/// does not have a one to one mapping to GENIE StdHep status. Using this class 
-/// with GENIE based utils or the GENIE ReWeighting tools can (and most likely
-/// will result in false results!
-///
-/// Therefore, the native NEUT particle information common blocks (VCWORK, FSIHIST)
-/// are included. Analysis tools under development...
-
-/// DBrailsford 10-2013: All 1D arrays are now in a dynamic format (rather than fixed length). 
-/// Due to the class structure of the oaAnalysis NRooTracker object being used to extract the 
-/// information from the numc file, two versions of the 1D arrays are initialised.  
-/// Each array has a dynamic version, and a 'Temp' fixed length version.  The 'Temp' version 
-/// extracts the info from the numc object and feeds the information in the dynamic version.
-/// The 'Temp' version of each data member is NOT saved to the rooTracker tree, only the dynamic version is.
-/// Note that for each new event, only the 'Temp' version of the data member is reset to a default value.
-/// This current implementation reduces the NRooTracker tree by ~10Mb.
 
 const int kNStdHepNPmax = 100;
 const int kNStdHepIdxPx = 0;
 const int kNStdHepIdxPy = 1;
 const int kNStdHepIdxPz = 2;
-const int kNStdHepIdxE  = 3;
-const int kNStdHepIdxX  = 0;
-const int kNStdHepIdxY  = 1;
-const int kNStdHepIdxZ  = 2;
-const int kNStdHepIdxT  = 3;
+const int kNStdHepIdxE = 3;
+const int kNStdHepIdxX = 0;
+const int kNStdHepIdxY = 1;
+const int kNStdHepIdxZ = 2;
+const int kNStdHepIdxT = 3;
 
 const int kNEmaxvc = 100;
 const int kNEmaxvert = 100;
 const int kNEmaxvertp = 300;
 
+///\brief This is a simple event class which is essentially an objectified
+/// version of the NEUT nRooTracker output format.
+///\details Because the nRooTracker is
+/// forcing NEUT event into a GENIE defined storage care needs to be taken when
+/// interpreting the meaning of various data members. For example the
+/// StdHepStatus does not have a one to one mapping to GENIE StdHep status.
+/// Using this class with GENIE based utils or the GENIE ReWeighting tools can
+/// (and most likely will) result in false results!\n
+/// Therefore, the native NEUT particle information common blocks
+/// (VCWORK, FSIHIST) are included.
 class NRooTrackerVtx : public JNuBeamFlux {
+  static const int kNFMaxNucleonVert = 200;  ///<\brief Maximum possible number of saved NFNucleonVertices  . This is set to mirror the equivalent parameter in the NEUT   FSI hist header file nucleonfsihist.h
 
-    public:
-        NRooTrackerVtx();
-        ~NRooTrackerVtx();
+  static const int kNFMaxNucleonSteps = 2000;   ///\brief Maximum possible number of saved NFNucleonSteps  . This is set to mirror the equivalent parameter in the NEUT   FSI hist header file nucleonfsihist.h
+ public:
+  NRooTrackerVtx();
+  ~NRooTrackerVtx();
 
-        void Reset   (void);
-        void Init    (void);
+  void Reset(void);
+  void Init(void);
 
-        // Using methods from TObject to remove 'hidden' compiler warnings
-        using TObject::Copy;
-        using TObject::Print;
+  // Using methods from TObject to remove 'hidden' compiler warnings
+  using TObject::Copy;
+  void Copy(const NRooTrackerVtx* event);
+  void Print(const Option_t* option = "") const;
 
-        void Copy    (const NRooTrackerVtx * event);
-        void Print (const Option_t* = "") const;
+  //****************** Define the output rootracker tree branches
 
-        // Define the output rootracker tree branches
-        TObjString* EvtCode;                         ///< generator-specific string with 'event code'
-        int         EvtNum;                          ///< event num.
-        double      EvtXSec;                         ///< cross section for selected event (1E-38 cm2) CORRECT
-        double      EvtDXSec;                        ///< cross section for selected event kinematics (1E-38 cm2 /{K^n}) CORRECT
-        double      EvtWght;                         ///< weight for that event CORRECT
-        double      EvtProb;                         ///< probability for that event (given cross section, path lengths, etc) CORRECT
-        double      EvtVtx[4];                       ///< event vertex position in detector coord syst (SI) CORRECT
-        int         StdHepN;                         ///< number of particles in particle array 
-        //
-        //  stdhep-like particle array
-        //
-        int*        StdHepPdg; //[StdHepN] ///< pdg codes (& generator specific codes for pseudoparticles)
-        int         StdHepPdgTemp   [kNStdHepNPmax];     //!
+  TObjString* EvtCode;   ///< Generator-specific string with 'event code'
 
-        int*        StdHepStatus; //[StdHepN] ///< generator-specific status code 
-        int         StdHepStatusTemp[kNStdHepNPmax];     //!
+  int EvtNum;   ///< event num.
 
-        double      StdHepX4    [kNStdHepNPmax][4];  ///< 4-x (x, y, z, t) of particle in hit nucleus frame (fm) CORRECT
+  double EvtXSec;   ///< cross section for selected event (1E-38 cm2) 
 
-        double      StdHepP4    [kNStdHepNPmax][4];  ///< 4-p (px,py,pz,E) of particle in LAB frame (GeV) CORRECT
+  double EvtDXSec;   ///< Cross section for selected event kinematics (1E-38 cm2 /{K^n}) 
 
-        double      StdHepPolz  [kNStdHepNPmax][3];  ///< polarization vector CORRECT
+  double EvtWght;   ///< Weight for event 
 
-        int  StdHepFdTemp    [kNStdHepNPmax];     //!
-        int  StdHepLdTemp    [kNStdHepNPmax];     //!
-        int  StdHepFmTemp    [kNStdHepNPmax];     //!
-        int  StdHepLmTemp    [kNStdHepNPmax];     //!
-        int*  StdHepFd;    //[StdHepN] ///< first daughter
-        int*  StdHepLd;    //[StdHepN] ///< last daughter
-        int*  StdHepFm;    //[StdHepN] ///< first mother 
-        int*  StdHepLm;    //[StdHepN] ///< last mother
+  double EvtProb;   ///< Probability  event (given cross section, path lengths, etc)
 
-        // NEUT native VCWORK information
-        int    NEnvc;                         ///< Number of particles 
+  double EvtVtx[4];   ///< Event vertex position in detector coord syst (SI) 
 
-        int    NEipvcTemp[kNEmaxvc];          //! PDG particle code
-        int*   NEipvc; //[NEnvc]              ///< PDG particle code
-
-        float  NEpvc[kNEmaxvc][3];            ///< 3-momentum (MeV/c) CORRECT
-
-        int    NEiorgvcTemp[kNEmaxvc];        //!
-        int*   NEiorgvc; //[NEnvc]            ///<  Index of parent (Fortran convention: starting at 1)
+  int StdHepN;   ///< Number of particles in particle array
 
 
-        /// Flag of final state:   
-        ///     0 : DETERMINED LATER PROCEDURE
-        ///     1 : DECAY TO OTHER PARTICLE
-        ///     2 : ESCAPE FROM DETECTOR
-        ///     3 : ABSORPTION
-        ///     4 : CHARGE EXCHANGE
-        ///     5 : STOP A NOT CONSIDER IN M.C. 
-        ///     6 : E.M. SHOWER
-        ///     7 : HADRON PRODUCTION
-        ///     8 : QUASI-ELASTIC SCATTER
-        ///     9 : FORWARD (ELASTIC-LIKE) SCATTER
+  //******************* stdhep-like particle array
 
-        int    NEiflgvcTemp[kNEmaxvc];          //! 
-        int    NEicrnvcTemp[kNEmaxvc];          //!
-        int*    NEiflgvc; //[NEnvc]             ///< Flag of final state         
-        int*    NEicrnvc; //[NEnvc]             ///< Escaped nucleus (1) or not (0)
+  /// pdg codes (& generator specific codes for pseudoparticles)
+  int* StdHepPdg;                    //[StdHepN] dg codes (& generator specific codes for pseudoparticles)
+  int StdHepPdgTemp[kNStdHepNPmax];  //!
+  /// generator-specific status code
+  int* StdHepStatus;                    //[StdHepN] generator-specific status code
+  int StdHepStatusTemp[kNStdHepNPmax];  //!
+  double StdHepX4[kNStdHepNPmax][4];   ///< 4-x (x, y, z, t) of particle in hit nucleus frame (fm) 
+  double StdHepP4[kNStdHepNPmax][4];   ///< 4-p (px,py,pz,E) of particle in LAB frame (GeV) 
+
+  double StdHepPolz[kNStdHepNPmax][3];   ///< polarization vector 
 
 
-        // Rest of the NEUT variables below are mainly for internal reweighting routines 
+  int StdHepFdTemp[kNStdHepNPmax];  //!
+  int StdHepLdTemp[kNStdHepNPmax];  //!
+  int StdHepFmTemp[kNStdHepNPmax];  //!
+  int StdHepLmTemp[kNStdHepNPmax];  //!
+  /// first daughter
+  int* StdHepFd;  //[StdHepN] first daughter
+  /// last daughter
+  int* StdHepLd;  //[StdHepN]  last daughter
+  /// first mother
+  int* StdHepFm;  //[StdHepN]  first mother 
+  /// last mother
+  int* StdHepLm;  //[StdHepN]  last mother
 
-        float NEcrsx;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+  int NEnvc;   ///< NEUT native VCWORK information    Number of particles
+  int NEipvcTemp[kNEmaxvc];  //!
+  /// PDG particle code
+  int* NEipvc;  //[NEnvc] PDG particle code
+  float NEpvc[kNEmaxvc][3];   ///< 3-momentum (MeV/c) 
 
-        float NEcrsy;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+  int NEiorgvcTemp[kNEmaxvc];  //!
+  /// Index of parent (Fortran convention: starting at 1)
+  int* NEiorgvc;  //[NEnvc] Index of parent (Fortran convention: starting at 1)
 
-        float NEcrsz;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+  int NEiflgvcTemp[kNEmaxvc];  //!
+  int NEicrnvcTemp[kNEmaxvc];  //!
+  ///\brief Flag of final state
+  /// Values:
+  /// - 0 : DETERMINED LATER PROCEDURE
+  /// - 1 : DECAY TO OTHER PARTICLE
+  /// - 2 : ESCAPE FROM DETECTOR
+  /// - 3 : ABSORPTION
+  /// - 4 : CHARGE EXCHANGE
+  /// - 5 : STOP AND NOT CONSIDER IN M.C.
+  /// - 6 : E.M. SHOWER
+  /// - 7 : HADRON PRODUCTION
+  /// - 8 : QUASI-ELASTIC SCATTER
+  /// - 9 : FORWARD (ELASTIC-LIKE) SCATTER
+  int* NEiflgvc;  //[NEnvc]  Flag of final state 
+  /// Escaped nucleus (1) or not (0)
+  int* NEicrnvc;  //[NEnvc] Escaped nucleus (1) or not (0) 
 
-        float NEcrsphi;    	///< Cross section calculation variables (currently used for coherent interactions) CORRECT
+  //******** Rest of the NEUT variables below are mainly for internal
+  //********************** reweighting routines
 
-
-        // NEUT FSIHIST pion interaction history 
-        int    NEnvert;                     ///< Number of vertices (including production and exit points)
-        float  NEposvert[kNEmaxvert][3];    ///< Position of vertex within nucleus (fm) CORRECT
-
-        ///< Interaction type 
-        ///< (*10 FOR HI-NRG interaction, >~400 MeV/c)
-        ///<     -1 : ESCAPE
-        ///<     0 : INITIAL (or unmatched parent vertex if I>1)
-        ///<     3 : ABSORPTION
-        ///<     4 : CHARGE EXCHANGE
-        ///<     7 : HADRON PRODUCTION (hi-nrg only, i.e. 70)
-        ///<     8 : QUASI-ELASTIC SCATTER
-        ///<     9 : FORWARD (ELASTIC-LIKE) SCATTER 
-
-        int    NEiflgvertTemp[kNEmaxvert];      //!
-        int*   NEiflgvert; //[NEnvert]          ///< Interaction type
+  float NEcrsx;///<\brief Cross section calculation variables (x) (currently used for coherent  interactions) 
+  float NEcrsy; ///<\brief Cross section calculation variables (y) (currently used for coherent  interactions) 
+  float NEcrsz; ///<\brief Cross section calculation variables  (z) (currently used for coherent    interactions) 
+  float NEcrsphi; ///<\brief Cross section calculation variables (phi) (currently used for coherent    interactions) 
 
 
 
-        int    NEnvcvert;                   ///< Number of intermediate particles (including initial and final)
-        float  NEdirvert[kNEmaxvertp][3];   ///< Direction of particle CORRECT
+  //**************** NEUT FSIHIST pion interaction history
 
-        float  NEabspvertTemp[kNEmaxvertp];     //! 
-        float  NEabstpvertTemp[kNEmaxvertp];    //! 
-        int    NEipvertTemp[kNEmaxvertp];       //! 
-        int    NEivertiTemp[kNEmaxvertp];       //! 
-        int    NEivertfTemp[kNEmaxvertp];       //! 
+  int NEnvert; ///< Number of vertices (including production and exit points)
+  /// Position of vertex within nucleus (fm) 
+  float NEposvert[kNEmaxvert][3]; ///< Position of vertex within nucleus (fm)
 
-        float*  NEabspvert;  //[NEnvcvert]   ///<  Absolute momentum in the lab frame (MeV/c) CORRECT
-        float*  NEabstpvert; //[NEnvcvert]   ///<  Absolute momentum in the nucleon rest frame (MeV/c) CORRECT
-        int*    NEipvert;    //[NEnvcvert]   ///<  PDG particle code
-        int*    NEiverti;    //[NEnvcvert]   ///<  Index of initial vertex (pointing to nvert array above)
-        int*    NEivertf;    //[NEnvcvert]   ///<  Index of final vertex (pointing to nvert array above)
+  int NEiflgvertTemp[kNEmaxvert];  //!
+  ///\brief Interaction type
+  /// Values:
+  /// - (*10 FOR HI-NRG interaction, >~400 MeV/c)
+  /// - -1 : ESCAPE
+  /// - 0 : INITIAL (or unmatched parent vertex if I>1)
+  /// - 3 : ABSORPTION
+  /// - 4 : CHARGE EXCHANGE
+  /// - 7 : HADRON PRODUCTION (hi-nrg only, i.e. 70)
+  /// - 8 : QUASI-ELASTIC SCATTER
+  /// - 9 : FORWARD (ELASTIC-LIKE) SCATTER
+  int* NEiflgvert;  //[NEnvert]  Interaction type
 
-        //
-        // etc 
-        //
-        TObjString* GeomPath;                        //
+  int NEnvcvert;   ///< Number of intermediate particles (including initial and final)
 
-        // Some pass through info
-        TObjString* GeneratorName;                   //
-        TObjString* OrigFileName;                   //
-        TObjString* OrigTreeName;                   //
-        int OrigEvtNum;
-        int OrigTreeEntries;
-        double OrigTreePOT;
-        double TimeInSpill;
+  float NEdirvert[kNEmaxvertp][3];   ///< Direction of particle 
 
-        int TruthVertexID;
 
-        ClassDef(NRooTrackerVtx, 1);
+  float NEabspvertTemp[kNEmaxvertp];   //! Storage area for NEabspvert read from the RooTracker TTree
+  float NEabstpvertTemp[kNEmaxvertp];  //! Storage area for NEabtpvert read from the RooTracker TTree
+  int NEipvertTemp[kNEmaxvertp];       //! Storage area for NEipvert read from the RooTracker TTree
+  int NEivertiTemp[kNEmaxvertp];       //! Storage area for NEiverti read from the RooTracker TTree
+  int NEivertfTemp[kNEmaxvertp];       //! Storage area for NEipvertf read from the RooTracker TTree
+
+  /// Absolute momentum in the lab frame (MeV/c) 
+  float* NEabspvert;  //[NEnvcvert] Absolute momentum in the lab frame (MeV/c) 
+  /// Absolute momentum in the nucleon rest frame (MeV/c) 
+  float* NEabstpvert;  //[NEnvcvert] Absolute momentum in the nucleon rest frame (MeV/c)  
+  /// PDG particle code
+  int* NEipvert;  //[NEnvcvert] PDG particle code 
+  /// Index of initial vertex (pointing to nvert array above)
+  int* NEiverti;  //[NEnvcvert] Index of initial vertex (pointing to nvert array above) 
+  /// Index of final vertex (pointing to nvert array above)
+  int* NEivertf;  //[NEnvcvert] Index of final vertex (pointing to nvert array above)
+
+  //**************** NEUT FSIHIST nucleon interaction history
+
+  int NFnvert;   ///<\brief Number of "vertices"
+  ///< Remarks:
+  ///<   - a "vertex" is actually better described as a start, end or
+  ///<     scattering point of a track
+  ///<   - at each scattering point, the first nucleon will be followed in
+  ///<     the same track, while the
+  ///<     second one will create a new track
+  ///<   - each track consists of a series of consecutive vertices. The first
+  ///<     vertex has P=0, the last P=4. In between may be any number
+  ///<     (including 0) vertices where an actual scattering
+  ///<     took place (P=1,2,3).
+  ///<   - it is not possible (and not needed) to connect the second track
+  ///<     of a scattering vertex with the original one. Note that "first" and
+  ///<     "second" is purely arbitrary. For nucleon FSI uncertainties,
+  ///<     only the probabilities of the scattering processes have to be
+  ///<     calculated, so it is not important to know which tracks belong to
+  ///<     each other.
+
+  ///<\brief 4-digit flag for interaction type at i-th vertex, in the form
+  ///<"BNTP":
+  ///< Values:
+  ///< - N: charge nucleon propagated through nucleus (0 = neutron, 1 = proton)
+  ///< - T: charge "target" nucleon the interaction is taking place on
+  ///< - P: scattering process:
+  ///<     - P=0: start tracking of nucleon (i.e. gets "created")
+  ///<     - P=1: elastic scattering
+  ///<     - P=2: single pion production
+  ///<     - P=3: double pion production
+  ///<     - P=4: stop tracking of nucleon (i.e. leaves nucleus)
+  ///< - B: Pauli blocking flag (0 = not blocked, 1 = interaction was Pauli
+  ///<      blocked and actually did not take place)
+  ///< Examples:
+  ///<    - 103 means double pion production when a proton scattered on a neutron
+  ///<    - 1011 means elastic scattering of a neutron on a proton did not take
+  ///<     place due to Pauli blocking
+  ///< \note For P=0 and P=4, "T" is without meaning and always set to 0. 
+  int* NFiflag;  //[NFnvert]  4-digit flag for interaction type at i-th vertex
+
+  /// x-component of i-th vertex position inside nucleus
+  float* NFx;  //[NFnvert]  x-component of i-th vertex position inside nucleus
+  /// y-component of i-th vertex position inside nucleus
+  float* NFy;  //[NFnvert] y-component of i-th vertex position inside nucleus
+  ///z-component of i-th vertex position inside nucleus 
+  float* NFz;  //[NFnvert] z-component of i-th vertex position inside nucleus 
+  ///x-component of momentum of nucleon leaving the i-th vertex
+  float* NFpx;  //[NFnvert] x-component of momentum of nucleon leaving the i-th vertex
+  /// y-component of momentum of nucleon leaving the i-th vertex
+  float* NFpy;  //[NFnvert] y-component of momentum of nucleon leaving the i-th vertex
+  /// z-component of momentum of nucleon leaving the i-th vertex 
+  float* NFpz;  //[NFnvert] z-component of momentum of nucleon leaving the i-th vertex 
+  ///energy of nucleon leaving the i-th vertex 
+  float* NFe;  //[NFnvert] energy of nucleon leaving the i-th vertex 
+  ///
+  int* NFfirststep;  //[NFnvert]  first step index of this track (to obtain the CMS energies for each step)
+  int NFnstep;   ///< number of steps
+ 
+  /// CMS energy squared of collision at k-th step (i.e. before interacting).
+  /// The sign of this value indicates the charge of the target nucleon:
+  ///  NFecms2 > 0: proton,  NFecms2 < 0: neutron (same as "T" in NFiflag)
+  float* NFecms2;  //[NFnstep] CMS energy squared of collision at k-th step (i.e. before interacting).
+
+  //******Tree Readout fixed size arrays
+  int NFiflagTEMP[kNFMaxNucleonVert];  //!  Temporary RooTracker Tree readout variable, corresponds to NFiflag
+
+  float NFxTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFx
+
+  float NFyTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFy
+
+  float NFzTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFz
+
+  float NFpxTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFpx
+
+  float NFpyTEMP[kNFMaxNucleonVert];  //!   /Temporary RooTracker Tree readout variable, corresponds to NFpy
+
+  float NFpzTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFpz
+
+  float NFeTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFe
+
+  int NFfirststepTEMP[kNFMaxNucleonVert];  //!   Temporary RooTracker Tree readout variable, corresponds to NFfirststep
+
+  float NFecms2TEMP[kNFMaxNucleonSteps];  //!   Temporary RooTracker Tree readout variable, corresponds to NFecms2
+
+//
+  // Extra nucleon fsi history (incl. step info) for systematic reweighting
+  // and SPIDelta info added 2022-03-13 by S. Dolan
+  //
+
+  
+  float PCascProb;///< The overall probability for the nucelon FSI cascade. Used for nucleon FSI reweighting.
+  ///< It is the product of the probability of each step.
+  ///< This is the variable we actually use to calculate a nucleon FSI reweight
+  ///< (we take the ratio of this for nominal and new dial values).
+
+  /// A step-wise probability for the nucleon FSI cascade. 
+  /// Not directly used for nucleon FSI reweighting. 
+  float* Prob;  //[NFnstep] A step-wise probability for the nucleon FSI cascade. 
+  
+  /// Gives the interaction type of a step:
+  /// 5 = non event, 4 = survival, 3 = douple pi, 2 = single pi, 1 = elastic
+  /// Not used for nucleon FSI reweighting. 
+  float* VertFlagStep;  //[NFnstep] Gives the interaction type of a step: 5 = non event, 4 = survival, 3 = douple pi, 2 = single pi, 1 = elastic
+
+  /// Prob multiplied by rhon from nrfermi.F in NEUT. Apparently this might be useful one day. 
+  /// Not used for nucleon FSI reweighting. 
+  float* VertFsiRhon;  //[NFnstep] Prob multiplied by rhon from nrfermi.F in NEUT.
+
+  /// A step-wise probability for elastic nucleon scatter scattering.
+  /// This is by far the most common interaction.
+  /// Used for nucleon FSI reweighting.
+  float* StepPel;  //[NFnstep] A step-wise probability for elastic nucleon scatter scattering.
+
+  /// A step-wise probability for single pion production via nucleon FSI.
+  /// This rarely happens.
+  /// Used for nucleon FSI reweighting.
+  float* StepPsp;  //[NFnstep] A step-wise probability for single pion production via nucleon FSI.
+
+  /// A step-wise probability for double pion production via nucleon FSI.
+  /// This almost never happens.
+  /// Used for nucleon FSI reweighting.
+  float* StepPdp;  //[NFnstep]  A step-wise probability for double pion production via nucleon FSI.
+
+  /// A step-wise scaling factor for Pauli blocking when using hybrid or full scale factor PB.
+  /// Used for nucleon FSI reweighting.
+  float* StepScaleFactor;  //[NFnstep]  A step-wise scaling factor for Pauli blocking when using hybrid or full scale factor PB.
+
+  /// A step-wise kinetic energy of the incoming nucleon for an FSI step.
+  /// Used for nucleon FSI reweighting.
+  float* StepEkin;  //[NFnstep]  A step-wise kinetic energy of the incoming nucleon for an FSI step.
+
+  float ProbTEMP[kNFMaxNucleonSteps];  //!   Temporary RooTracker Tree readout variable, corresponds to Prob
+
+  float VertFlagStepTEMP[kNFMaxNucleonSteps];  //!   Temporary RooTracker Tree readout variable, corresponds to VertFlagStep   
+
+  float VertFsiRhonTEMP[kNFMaxNucleonSteps];  //!  Temporary RooTracker Tree readout variable, corresponds to VertFsiRhon  
+
+  float StepPelTEMP[kNFMaxNucleonSteps];  //!    Temporary RooTracker Tree readout variable, corresponds to StepPel  
+
+  float StepPspTEMP[kNFMaxNucleonSteps];  //!    Temporary RooTracker Tree readout variable, corresponds to StepPsp  
+
+  
+  float StepPdpTEMP[kNFMaxNucleonSteps];  //! Temporary RooTracker Tree readout variable, corresponds to StepPdp 
+
+  float StepScaleFactorTEMP[kNFMaxNucleonSteps];  //! Temporary RooTracker Tree readout variable, corresponds to StepScaleFactor 
+
+  float StepEkinTEMP[kNFMaxNucleonSteps];  //! Temporary RooTracker Tree readout variable, corresponds to StepEkin
+
+  
+  int SPIDelta; ///< SPIDelta flag for resonance decay reweighting
+  ///< This is documented in T2K-TN-414
+  ///< 0 means the resonance decay was sampled isotropicaly 
+  ///< 1 means the resonance decay was sampled like a Delta resonance 
+  ///< 2 means the resonance decay was sampled including multiple interfering resonances
+  ///< 3 means an old NEUT defauly which is a mix of 0 and 1  
+
+  //
+  // End of new stuff added by S. Dolan
+  //
+
+  int IRadCorrPht; ///< Event-level flag of whether real photon production was
+                     ///< added
+
+
+
+
+
+  //**************** NEUT Passthrough info
+
+  TObjString* GeomPath;  ///< Geometry path of where the vertex is
+  // Some pass through info
+  TObjString* GeneratorName; ///< NEUT
+  TObjString* OrigFileName;///< Filename of the NEUTmc file
+  TObjString* OrigTreeName;///< Tree name within the NEUT mc file 
+  int OrigEvtNum; ///< Event number within the NEUT mc file 
+  int OrigTreeEntries;  ///< Number of entries in the  NEUT mc file 
+  double OrigTreePOT;  ///< Number of POT in the  NEUT mc file 
+  double TimeInSpill; ///< Time of the vertex, relative to spill time
+
+  int TruthVertexID; ///< A link to the TTruthVertex tree
+
+  ClassDef(NRooTrackerVtx, 3);
 };
 
 #endif

--- a/include/WCSimEventAction.hh
+++ b/include/WCSimEventAction.hh
@@ -45,8 +45,9 @@ public:
 		     G4TrajectoryContainer*,
 		     WCSimWCDigitsCollection*,
 		     WCSimWCTriggeredDigitsCollection*,
-		     G4String detectorElement="tank",
-		     bool skipFillingTracks=false);
+		     G4String detectorElement,
+		     bool skipFillingTracks,
+		     bool skipFillingRooTracker);
   void FillRootEventHybrid(G4int, 
 			   const struct ntupleStruct&, 
 			   G4TrajectoryContainer*,
@@ -55,7 +56,8 @@ public:
 			   G4String,
 			   WCSimRootEvent*,
 			   WCSimRootTrigger*,
-			   bool skipFillingTracks);
+			   bool skipFillingTracks,
+			   bool skipFillingRooTracker);
   WCSimRunAction* GetRunAction(){return runAction;}
   void SetDigitizerChoice(G4String digitizer) { DigitizerChoice = digitizer; }
   void SetTriggerChoice  (G4String trigger)   { TriggerChoice   = trigger;   }

--- a/include/WCSimPrimaryGeneratorAction.hh
+++ b/include/WCSimPrimaryGeneratorAction.hh
@@ -48,9 +48,9 @@ public:
   void GeneratePrimaries(G4Event* anEvent);
 
   // RooTracker related functions
-  void SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx);
+  void SetupBranchAddresses(ND::NRooTrackerVtx* nrootrackervtx);
   void OpenRootrackerFile(G4String fileName);
-  void CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx);
+  void CopyRootrackerVertex(ND::NRooTrackerVtx* nrootrackervtx);
   bool GetIsRooTrackerFileFinished(){return (fEvNum==fNEntries);}
 
   // Gun, laser & gps setting calls these functions to fill jhfNtuple and Root tree
@@ -212,7 +212,7 @@ private:
   // Temporary vertex that is saved if desired, according to WCSimIO macro option
   TTree* fRooTrackerTree;
   TTree* fSettingsTree;
-  NRooTrackerVtx* fTmpRootrackerVtx;
+  ND::NRooTrackerVtx* fTmpRootrackerVtx;
   float fNuPrismRadius;
   float fNuBeamAng;
   float fNuPlanePos[3];

--- a/include/WCSimRootLinkDef.hh
+++ b/include/WCSimRootLinkDef.hh
@@ -25,9 +25,9 @@
 #pragma link C++ class WCSimEnumerations+;
 #pragma link C++ class WCSimRootOptions+;
 
-#pragma link C++ class RooTrackerVtxBase+;
-#pragma link C++ class JNuBeamFlux+;
-#pragma link C++ class NRooTrackerVtx+;
+#pragma link C++ class ND::RooTrackerVtxBase+;
+#pragma link C++ class ND::JNuBeamFlux+;
+#pragma link C++ class ND::NRooTrackerVtx+;
 
 #pragma link C++ struct WCSimDarkNoiseOptions+;
 #pragma link C++ class std::pair<std::string, WCSimDarkNoiseOptions>+;

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -129,8 +129,8 @@ public:
     fRooTrackerOutputTree->Fill();
   }
   void ClearRootrackerVertexArray() { 
-      fVertices->Clear(); 
-      fNVtx = 0;
+    //fVertices->Clear(); 
+    //fNVtx = 0;
   }
 
   void SetUseTimer(bool use) { useTimer = use; }

--- a/include/WCSimRunAction.hh
+++ b/include/WCSimRunAction.hh
@@ -97,7 +97,7 @@ public:
   }
 
   eventNtuple * GetMyStruct(){return evNtup;}
-  NRooTrackerVtx * GetMyRooTracker(){return evNRooTracker;}
+  ND::NRooTrackerVtx * GetMyRooTracker(){return evNRooTracker;}
   void SetTree(TTree* tree){WCSimTree=tree;}
   void SetBranch(TBranch* branchin, G4String detectorElement = "tank"){
     if(detectorElement=="tank") wcsimrooteventbranch=branchin;
@@ -124,7 +124,7 @@ public:
   //New:
   void FillFlatGeoTree();
 
-  NRooTrackerVtx* GetRootrackerVertex();
+  ND::NRooTrackerVtx* GetRootrackerVertex();
   void FillRootrackerVertexTree() { 
     fRooTrackerOutputTree->Fill();
   }
@@ -244,7 +244,7 @@ public:
   eventNtuple *evNtup;
 
   //NRooTracker
-  NRooTrackerVtx *evNRooTracker;
+  ND::NRooTrackerVtx *evNRooTracker;
     
   const G4Run* fG4Run;
 

--- a/src/TJNuBeamFlux.cc
+++ b/src/TJNuBeamFlux.cc
@@ -1,5 +1,7 @@
 #include "TJNuBeamFlux.hh"
 
+using namespace ND;
+
 //_______________________________________________________________________________________
 RooTrackerVtxBase::RooTrackerVtxBase() :
     TObject()

--- a/src/TNRooTrackerVtx.cc
+++ b/src/TNRooTrackerVtx.cc
@@ -10,6 +10,8 @@ using std::setprecision;
 using std::setfill;
 using std::ios;
 
+using namespace ND;
+
 ClassImp(NRooTrackerVtx)
 
 NRooTrackerVtx::NRooTrackerVtx() : JNuBeamFlux() { this->Init(); }

--- a/src/TNRooTrackerVtx.cc
+++ b/src/TNRooTrackerVtx.cc
@@ -12,362 +12,458 @@ using std::ios;
 
 ClassImp(NRooTrackerVtx)
 
-//_______________________________________________________________________________________
-NRooTrackerVtx::NRooTrackerVtx() :
-        JNuBeamFlux()
-{
-    this->Init();
+NRooTrackerVtx::NRooTrackerVtx() : JNuBeamFlux() { this->Init(); }
+
+NRooTrackerVtx::~NRooTrackerVtx() {
+  if (GeomPath != NULL) {
+    delete GeomPath;
+    GeomPath = NULL;
+  }
+  if (GeneratorName != NULL) {
+    delete GeneratorName;
+    GeneratorName = NULL;
+  }
+  if (EvtCode != NULL) {
+    delete EvtCode;
+    EvtCode = NULL;
+  }
+  if (OrigFileName != NULL) {
+    delete OrigFileName;
+    OrigFileName = NULL;
+  }
+  if (OrigTreeName != NULL) {
+    delete OrigTreeName;
+    OrigTreeName = NULL;
+  }
 }
-//_______________________________________________________________________________________
-NRooTrackerVtx::~NRooTrackerVtx()
-{
-    if(GeomPath      != NULL) { delete GeomPath;      GeomPath      = NULL; }     
-    if(GeneratorName != NULL) { delete GeneratorName; GeneratorName = NULL; }     
-    if(EvtCode       != NULL) { delete EvtCode;       EvtCode       = NULL; }     
-    if(OrigFileName  != NULL) { delete OrigFileName;  OrigFileName  = NULL; }     
-    if(OrigTreeName  != NULL) { delete OrigTreeName;  OrigTreeName  = NULL; }     
+void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
+  GeomPath->SetString(event->GeomPath->GetString());
+  GeneratorName->SetString(event->GeneratorName->GetString());
+  EvtCode->SetString(event->EvtCode->GetString());
+  OrigFileName->SetString(event->OrigFileName->GetString());
+  OrigTreeName->SetString(event->OrigTreeName->GetString());
+
+  EvtNum = event->EvtNum;
+  EvtXSec = event->EvtXSec;
+  EvtDXSec = event->EvtDXSec;
+  EvtWght = event->EvtWght;
+  EvtProb = event->EvtProb;
+  OrigTreePOT = event->OrigTreePOT;
+  OrigEvtNum = event->OrigEvtNum;
+  TimeInSpill = event->TimeInSpill;
+  OrigTreeEntries = event->OrigTreeEntries;
+  TruthVertexID = event->TruthVertexID;
+
+  for (int i = 0; i < 4; i++) {
+    EvtVtx[i] = event->EvtVtx[i];
+  }
+
+  NuNorm = event->NuNorm;
+  NuEnusk = event->NuEnusk;
+  NuNormsk = event->NuNormsk;
+  NuAnorm = event->NuAnorm;
+
+  StdHepN = event->StdHepN;
+
+  // Allocate the arrays which will be saved
+  StdHepPdg = new int[StdHepN];
+  StdHepStatus = new int[StdHepN];
+  StdHepFd = new int[StdHepN];
+  StdHepLd = new int[StdHepN];
+  StdHepFm = new int[StdHepN];
+  StdHepLm = new int[StdHepN];
+
+  for (int i = 0; i < StdHepN; i++) {
+    StdHepPdg[i] = event->StdHepPdgTemp[i];
+    StdHepStatus[i] = event->StdHepStatusTemp[i];
+
+    StdHepFd[i] = event->StdHepFdTemp[i];
+    StdHepLd[i] = event->StdHepLdTemp[i];
+    StdHepFm[i] = event->StdHepFmTemp[i];
+    StdHepLm[i] = event->StdHepLmTemp[i];
+
+    for (int j = 0; j < 4; j++) {
+      StdHepX4[i][j] = event->StdHepX4[i][j];
+      StdHepP4[i][j] = event->StdHepP4[i][j];
+    }
+    for (int j = 0; j < 3; j++) {
+      StdHepPolz[i][j] = event->StdHepPolz[i][j];
+    }
+  }
+
+  NEnvc = event->NEnvc;
+
+  // Allocate the arrays which will be saved
+  NEipvc = new int[NEnvc];
+  NEiorgvc = new int[NEnvc];
+  NEiflgvc = new int[NEnvc];
+  NEicrnvc = new int[NEnvc];
+
+  for (int i = 0; i < NEnvc; i++) {
+    NEipvc[i] = event->NEipvcTemp[i];
+    NEiorgvc[i] = event->NEiorgvcTemp[i];
+    NEiflgvc[i] = event->NEiflgvcTemp[i];
+    NEicrnvc[i] = event->NEicrnvcTemp[i];
+    for (int j = 0; j < 3; j++) {
+      NEpvc[i][j] = event->NEpvc[i][j];
+    }
+  }
+
+  NEcrsx = event->NEcrsx;
+  NEcrsy = event->NEcrsy;
+  NEcrsz = event->NEcrsz;
+  NEcrsphi = event->NEcrsphi;
+  NEnvert = event->NEnvert;
+
+  NEiflgvert = new int[NEnvert];
+  for (int i = 0; i < NEnvert; i++) {
+    NEiflgvert[i] = event->NEiflgvertTemp[i];
+    for (int j = 0; j < 3; j++) {
+      NEposvert[i][j] = event->NEposvert[i][j];
+    }
+  }
+
+  NEnvcvert = event->NEnvcvert;
+
+  // define the dynamic arrays
+  NEabspvert = new float[NEnvcvert];
+  NEabstpvert = new float[NEnvcvert];
+  NEipvert = new int[NEnvcvert];
+  NEiverti = new int[NEnvcvert];
+  NEivertf = new int[NEnvcvert];
+
+  for (int i = 0; i < NEnvcvert; i++) {
+    NEabspvert[i] = event->NEabspvertTemp[i];
+    NEabstpvert[i] = event->NEabstpvertTemp[i];
+    NEipvert[i] = event->NEipvertTemp[i];
+    NEiverti[i] = event->NEivertiTemp[i];
+    NEivertf[i] = event->NEivertfTemp[i];
+    for (int j = 0; j < 3; j++) {
+      NEdirvert[i][j] = event->NEdirvert[i][j];
+    }
+  }
+
+  /**** START Nucleon FSI PASSTHROUGH ******/
+
+  NFnvert = event->NFnvert;
+  NFiflag = new int[NFnvert];
+  NFx = new float[NFnvert];
+  NFy = new float[NFnvert];
+  NFz = new float[NFnvert];
+  NFpx = new float[NFnvert];
+  NFpy = new float[NFnvert];
+  NFpz = new float[NFnvert];
+  NFe = new float[NFnvert];
+  NFfirststep = new int[NFnvert];
+
+  for (int i = 0; i < NFnvert; i++) {
+    NFiflag[i] = event->NFiflagTEMP[i];
+    NFx[i] = event->NFxTEMP[i];
+    NFy[i] = event->NFyTEMP[i];
+    NFz[i] = event->NFzTEMP[i];
+    NFpx[i] = event->NFpxTEMP[i];
+    NFpy[i] = event->NFpyTEMP[i];
+    NFpz[i] = event->NFpzTEMP[i];
+    NFe[i] = event->NFeTEMP[i];
+    NFfirststep[i] = event->NFfirststepTEMP[i];
+  }
+  PCascProb = event->PCascProb;
+  NFnstep = event->NFnstep;
+
+  if(NFnstep!=0){
+    NFecms2 = new float[NFnstep];
+    Prob = new float[NFnstep];
+    VertFlagStep = new float[NFnstep];
+    VertFsiRhon = new float[NFnstep];
+    StepPel = new float[NFnstep];
+    StepPsp = new float[NFnstep];
+    StepPdp = new float[NFnstep];
+    StepScaleFactor = new float[NFnstep];
+    StepEkin = new float[NFnstep];
+    
+    for (int k = 0; k < NFnstep; k++) {
+      NFecms2[k]         = event->NFecms2TEMP[k];
+      Prob[k]            = event->ProbTEMP[k];
+      VertFlagStep[k]    = event->VertFlagStepTEMP[k];
+      VertFsiRhon[k]     = event->VertFsiRhonTEMP[k];
+      StepPel[k]         = event->StepPelTEMP[k];
+      StepPsp[k]         = event->StepPspTEMP[k];
+      StepPdp[k]         = event->StepPdpTEMP[k];
+      StepScaleFactor[k] = event->StepScaleFactorTEMP[k];
+      StepEkin[k]        = event->StepEkinTEMP[k];
+    }
+  }
+
+  SPIDelta = event->SPIDelta;
+  IRadCorrPht = event->IRadCorrPht;
+
+  /**** END Nucleon FSI PASSTHROUGH ******/
+
+  // Remember to copy the flux info
+  JNuBeamFlux* flux = (JNuBeamFlux*)event;
+  JNuBeamFlux::Copy(flux);
 }
-//_______________________________________________________________________________________
-void NRooTrackerVtx::Copy(const NRooTrackerVtx * event)
-{ 
-    GeomPath->SetString(event->GeomPath->GetString());
-    GeneratorName->SetString(event->GeneratorName->GetString());
-    EvtCode->SetString(event->EvtCode->GetString());
-    OrigFileName->SetString(event->OrigFileName->GetString());
-    OrigTreeName->SetString(event->OrigTreeName->GetString());
+void NRooTrackerVtx::Reset() {
+  if (GeomPath) GeomPath->SetString("Not-set");
+  if (GeneratorName) GeneratorName->SetString("Not-set");
+  if (EvtCode) EvtCode->SetString("Not-set");
+  if (OrigFileName) OrigFileName->SetString("Not-set");
+  if (OrigTreeName) OrigTreeName->SetString("Not-set");
 
-    EvtNum    = event->EvtNum;  
-    EvtXSec   = event->EvtXSec; 
-    EvtDXSec  = event->EvtDXSec; 
-    EvtWght   = event->EvtWght;   
-    EvtProb   = event->EvtProb;   
-    OrigTreePOT = event->OrigTreePOT;
-    OrigEvtNum  = event->OrigEvtNum;
-    TimeInSpill  = event->TimeInSpill;
-    OrigTreeEntries  = event->OrigTreeEntries;
-    TruthVertexID = event->TruthVertexID;
+  EvtNum = -1;
+  EvtXSec = -1.0;
+  EvtDXSec = -1.0;
+  EvtWght = -1.0;
+  EvtProb = -1.0;
+  OrigTreePOT = -1.0;
+  OrigEvtNum = -1;
+  TimeInSpill = -1.0;
+  OrigTreeEntries = -1;
+  TruthVertexID = -1;
 
-    for(int i=0; i < 4; i++) { 
-        EvtVtx[i] = event->EvtVtx[i]; 
+  for (int i = 0; i < 4; i++) {
+    EvtVtx[i] = 0.0;
+  }
+
+  StdHepN = 0;
+  for (int i = 0; i < kNStdHepNPmax; i++) {
+    // If the arrays are dynamic, only reset the Temp version of the data member
+    StdHepPdgTemp[i] = -1;
+    StdHepStatusTemp[i] = -1;
+    StdHepFdTemp[i] = -1;
+    StdHepLdTemp[i] = -1;
+    StdHepFmTemp[i] = -1;
+    StdHepLmTemp[i] = -1;
+    for (int j = 0; j < 4; j++) {
+      StdHepX4[i][j] = 0;
     }
-
-    NuNorm = event->NuNorm;
-    NuEnusk = event->NuEnusk;
-    NuNormsk = event->NuNormsk;
-    NuAnorm = event->NuAnorm;
-
-    StdHepN = event->StdHepN;
-
-    //define the dynamic arrays
-    StdHepPdg = new int[StdHepN];
-    StdHepStatus = new int[StdHepN];
-    StdHepFd = new int[StdHepN];
-    StdHepLd = new int[StdHepN];
-    StdHepFm = new int[StdHepN];
-    StdHepLm = new int[StdHepN];
-
-    for(int i=0; i< StdHepN; i++) 
-    {
-        StdHepPdg   [i] = event->StdHepPdgTemp    [i];     
-        StdHepStatus[i] = event->StdHepStatusTemp [i];    
-
-        StdHepFd  [i] = event->StdHepFdTemp   [i];    
-        StdHepLd  [i] = event->StdHepLdTemp   [i];    
-        StdHepFm  [i] = event->StdHepFmTemp   [i];    
-        StdHepLm  [i] = event->StdHepLmTemp   [i];    
-
-        for(int j=0; j < 4; j++) { StdHepX4   [i][j] = event->StdHepX4   [i][j]; }
-        for(int j=0; j < 4; j++) { StdHepP4   [i][j] = event->StdHepP4   [i][j]; }
-        for(int j=0; j < 3; j++) { StdHepPolz [i][j] = event->StdHepPolz [i][j]; }
+    for (int j = 0; j < 4; j++) {
+      StdHepP4[i][j] = 0;
     }
-
-    NEnvc = event->NEnvc;
-
-    //define the dynamic arrays
-    NEipvc = new int[NEnvc];
-    NEiorgvc = new int[NEnvc];
-    NEiflgvc = new int[NEnvc];
-    NEicrnvc = new int[NEnvc];
-
-    for(int i=0; i< NEnvc; i++) {
-        NEipvc[i] = event->NEipvcTemp[i];
-        NEiorgvc[i] = event->NEiorgvcTemp[i];
-        NEiflgvc[i] = event->NEiflgvcTemp[i];
-        NEicrnvc[i] = event->NEicrnvcTemp[i];
-        for(int j=0; j < 3; j++) { NEpvc[i][j] = event->NEpvc[i][j]; } 
+    for (int j = 0; j < 3; j++) {
+      StdHepPolz[i][j] = 0;
     }
+  }
 
-    NEcrsx = event->NEcrsx;
-    NEcrsy = event->NEcrsy;
-    NEcrsz = event->NEcrsz;
-    NEcrsphi = event->NEcrsphi;
-
-    NEnvert = event->NEnvert;
-    //define the dynamic array
-    NEiflgvert = new int[NEnvert];
-    for(int i=0; i< NEnvert; i++) {
-        NEiflgvert[i] = event->NEiflgvertTemp[i] ;
-        for(int j=0; j < 3; j++) { NEposvert[i][j] = event->NEposvert[i][j]; }
+  NEnvc = 0;
+  for (int ip = 0; ip < kNEmaxvc; ip++) {
+    NEipvcTemp[ip] = -1;
+    NEiorgvcTemp[ip] = -1;
+    NEiflgvcTemp[ip] = -1;
+    NEicrnvcTemp[ip] = -1;
+    for (int ip2 = 0; ip2 < 3; ip2++) {
+      NEpvc[ip][ip2] = -99999.9;
     }
+  }
 
-    NEnvcvert = event->NEnvcvert;
+  NEcrsx = -99999.9;
+  NEcrsy = -99999.9;
+  NEcrsz = -99999.9;
+  NEcrsphi = -99999.9;
 
-    //define the dynamic arrays
-    NEabspvert = new float[NEnvcvert];
-    NEabstpvert = new float[NEnvcvert];
-    NEipvert = new int[NEnvcvert];
-    NEiverti = new int[NEnvcvert];
-    NEivertf = new int[NEnvcvert];
-
-    for(int i=0; i< NEnvcvert; i++) {
-        NEabspvert[i] = event->NEabspvertTemp[i];
-        NEabstpvert[i] = event->NEabstpvertTemp[i];
-        NEipvert[i] = event->NEipvertTemp[i];
-        NEiverti[i] = event->NEivertiTemp[i];
-        NEivertf[i] = event->NEivertfTemp[i];
-        for(int j=0; j < 3; j++) { NEdirvert[i][j] = event->NEdirvert[i][j]; }
+  NEnvert = 0;
+  for (int iv = 0; iv < kNEmaxvert; iv++) {
+    NEiflgvertTemp[iv] = -999;
+    for (int ip2 = 0; ip2 < 3; ip2++) {
+      NEposvert[iv][ip2] = -999;
     }
+  }
 
-    // Remember to copy the flux info
-    JNuBeamFlux * flux = (JNuBeamFlux*) event;
-    JNuBeamFlux::Copy(flux);
+  NEnvcvert = 0;
+  for (int ip = 0; ip < kNEmaxvertp; ip++) {
+    NEabspvertTemp[ip] = -99999.9;
+    NEabstpvertTemp[ip] = -99999.9;
+    NEipvertTemp[ip] = -1;
+    NEivertiTemp[ip] = -1;
+    NEivertfTemp[ip] = -1;
+    for (int ip2 = 0; ip2 < 3; ip2++) {
+      NEdirvert[ip][ip2] = -99999.9;
+    }
+  }
 
+  /**** START Nucleon FSI PASSTHROUGH ******/
+
+  NFnvert = 0;
+  for (int i = 0; i < kNFMaxNucleonVert; i++) {
+    NFiflagTEMP[i] = -1;
+    NFxTEMP[i] = -99999.9;
+    NFyTEMP[i] = -99999.9;
+    NFzTEMP[i] = -99999.9;
+    NFpxTEMP[i] = -99999.9;
+    NFpyTEMP[i] = -99999.9;
+    NFpzTEMP[i] = -99999.9;
+    NFeTEMP[i] = -99999.9;
+    NFfirststepTEMP[i] = -1;
+  }
+  PCascProb = 0;
+
+  NFnstep = 0;
+  for (int k = 0; k < kNFMaxNucleonSteps; k++) {
+    NFecms2TEMP[k] = -99999.9;
+    ProbTEMP[k] = -99999.9;
+    VertFlagStepTEMP[k] = -99999.9;
+    VertFsiRhonTEMP[k] = -99999.9;
+    StepPelTEMP[k] = -99999.9;
+    StepPspTEMP[k] = -99999.9;
+    StepPdpTEMP[k] = -99999.9;
+    StepScaleFactorTEMP[k] = -99999.9;
+    StepEkinTEMP[k] = -99999.9;
+  }
+
+  /**** END Nucleon FSI PASSTHROUGH ******/
+
+  SPIDelta = -999;
+  IRadCorrPht = -999;
 }
-//_______________________________________________________________________________________
-void NRooTrackerVtx::Reset()
-{
+void NRooTrackerVtx::Init() {
+  GeomPath = new TObjString("");
+  GeneratorName = new TObjString("");
+  EvtCode = new TObjString("");
+  OrigFileName = new TObjString("");
+  OrigTreeName = new TObjString("");
 
-    if (GeomPath     ) GeomPath      -> SetString("Not-set");  
-    if (GeneratorName) GeneratorName -> SetString("Not-set");  
-    if (EvtCode      ) EvtCode       -> SetString("Not-set");             
-    if (OrigFileName ) OrigFileName   -> SetString("Not-set");             
-    if (OrigTreeName ) OrigTreeName  -> SetString("Not-set");             
-
-    EvtNum   = -1;                  
-    EvtXSec  = -1.0;                
-    EvtDXSec = -1.0;         
-    EvtWght  = -1.0;         
-    EvtProb  = -1.0;                
-    OrigTreePOT = -1.0;
-    OrigEvtNum  = -1;
-    TimeInSpill  = -1.0;
-    OrigTreeEntries  = -1;
-    TruthVertexID = -1;  
-
-    for(int i=0; i < 4; i++){
-        EvtVtx[i] = 0.0;
-    }
-
-    StdHepN = 0;
-
-    for(int i=0; i<kNStdHepNPmax; i++) 
-    {
-        //If the arrays are dynamic, only reset the Temp version of the data member
-        StdHepPdgTemp   [i] = -1;     
-        StdHepStatusTemp[i] = -1;    
-        StdHepFdTemp  [i] = -1;    
-        StdHepLdTemp  [i] = -1;    
-        StdHepFmTemp  [i] = -1;    
-        StdHepLmTemp  [i] = -1;    
-        for(int j=0; j < 4; j++) { StdHepX4    [i][j] = 0; }
-        for(int j=0; j < 4; j++) { StdHepP4    [i][j] = 0; }
-        for(int j=0; j < 3; j++) { StdHepPolz  [i][j] = 0; }
-    }
-
-    NEnvc = 0;
-    for(int ip = 0; ip < kNEmaxvc; ip++){
-        NEipvcTemp[ip] = -1;
-        NEiorgvcTemp[ip] = -1;
-        NEiflgvcTemp[ip] = -1;
-        NEicrnvcTemp[ip] = -1;
-        for(int ip2 = 0; ip2 < 3; ip2++){
-            NEpvc[ip][ip2] = -99999.9;
-        }
-    }
-
-    NEcrsx = -99999.9;
-    NEcrsy = -99999.9;
-    NEcrsz = -99999.9;
-    NEcrsphi = -99999.9;
-
-    NEnvert = 0;
-    for(int iv = 0; iv < kNEmaxvert; iv++){
-        NEiflgvertTemp[iv] = -999;
-        for(int ip2 = 0; ip2 < 3; ip2++){
-            NEposvert[iv][ip2] = -999;
-        }
-    }
-
-    NEnvcvert = 0;  
-    for(int ip = 0; ip < kNEmaxvertp; ip++){
-        NEabspvertTemp[ip] = -99999.9;
-        NEabstpvertTemp[ip] = -99999.9;
-        NEipvertTemp[ip] = -1;
-        NEivertiTemp[ip] = -1;
-        NEivertfTemp[ip] = -1;
-        for(int ip2 = 0; ip2 < 3; ip2++){
-            NEdirvert[ip][ip2] = -99999.9;
-        }
-    }
-
+  this->Reset();
 }
-//_______________________________________________________________________________________
-void NRooTrackerVtx::Init()
-{
-    GeomPath      = new TObjString("");
-    GeneratorName = new TObjString("");
-    EvtCode       = new TObjString(""); 
-    OrigFileName  = new TObjString(""); 
-    OrigTreeName  = new TObjString(""); 
+void NRooTrackerVtx::Print(const Option_t*) const {
+  cout << "\nNRooTrackerMCTruth: " << endl;
+  cout << "  --> GeneratorName = " << GeneratorName->GetString() << endl;
+  cout << "  --> EvtCode       = " << EvtCode->GetString() << endl;
+  cout << "  --> GeomPath      = " << GeomPath->GetString() << endl;
+  cout << "  --> EvtNum        = " << EvtNum << endl;
+  cout << "  --> EvtXSec       = " << EvtXSec << endl;
+  cout << "  --> EvtDXSec      = " << EvtDXSec << endl;
+  cout << "  --> EvtWght       = " << EvtWght << endl;
+  cout << "  --> EvtProb       = " << EvtProb << endl;
+  cout << "  --> EvtVtx = ";
+  for(int i = 0; i < 4; i++) {
+    cout << EvtVtx[i] << ", ";
+  }
+  cout << endl;
+  cout << "  --> TruthVertexID = " << TruthVertexID << endl;
 
-    this->Reset();
+  cout << "NRooTrackerStdHep: " << StdHepN << " values" << endl;
+
+  for (int i = 0; i < StdHepN; i++) {
+    cout << setfill(' ') << setw(4) << i << " -> pdgc: "
+         //        << setfill(' ') << setw(20) << StdHepPdg[i]
+         << " / ist: " << setfill(' ') << setw(3) << StdHepStatus[i]
+         << " / mom: " << setfill(' ') << setw(3) << StdHepFm[i]
+         << " / daughters: (" << setfill(' ') << setw(3) << StdHepFd[i] << ", "
+         << setfill(' ') << setw(3) << StdHepLd[i] << ") / E = " << setfill(' ')
+         << setw(10) << StdHepP4[i][kNStdHepIdxE] << ", px = " << setfill(' ')
+         << setw(10) << StdHepP4[i][kNStdHepIdxPx] << ", py = " << setfill(' ')
+         << setw(10) << StdHepP4[i][kNStdHepIdxPy] << ", pz = " << setfill(' ')
+         << setw(10) << StdHepP4[i][kNStdHepIdxPz] << endl;
+  }
+
+  cout << endl << "Jnu-beam pass through info:" << endl;
+  cout << "  -->  NuParentPdg      = " << NuParentPdg << endl;
+  cout << "  -->  NuParentDecMode  = " << NuParentDecMode << endl;
+  /////   cout << "  -->  NuParentProNVtx  = " << NuParentProNVtx << endl;
+  cout << "  -->  NuParentDecP4[4] = " << NuParentDecP4[0] << ", "
+       << NuParentDecP4[1] << ", " << NuParentDecP4[2] << ", "
+       << NuParentDecP4[3] << endl;
+  cout << "  -->  NuParentDecX4[4] = " << NuParentDecX4[0] << ", "
+       << NuParentDecX4[1] << ", " << NuParentDecX4[2] << ", "
+       << NuParentDecX4[3] << endl;
+  cout << "  -->  NuParentProP4[4] = " << NuParentProP4[0] << ", "
+       << NuParentProP4[1] << ", " << NuParentProP4[2] << ", "
+       << NuParentProP4[3] << endl;
+  cout << "  -->  NuParentProX4[4] = " << NuParentProX4[0] << ", "
+       << NuParentProX4[1] << ", " << NuParentProX4[2] << ", "
+       << NuParentProX4[3] << endl;
+  /////   cout << "  -->  NuPlanePos[2] = " << NuPlanePos[0] << ", "<<
+  /// NuPlanePos[1] << endl;
+  cout << "  -->  NuGipart         = " << NuGipart << endl;
+  cout << "  -->  NuGamom0         = " << NuGamom0 << endl;
+  cout << "  -->  NuGpos0[3] = " << NuGpos0[0] << ", " << NuGpos0[1] << ", "
+       << NuGpos0[2] << endl;
+  cout << "  -->  NuGvec0[3] = " << NuGvec0[0] << ", " << NuGvec0[1] << ", "
+       << NuGvec0[2] << endl;
+
+  cout << "NuEnusk = " << NuEnusk << endl;
+  cout << "NuNorm = " << NuNorm << endl;
+  cout << "NuNormsk = " << NuNormsk << endl;
+  cout << "NuAnorm = " << NuAnorm << endl;
+
+  cout << "NuVersion = " << NuVersion << endl;
+  cout << "NuTuneid = " << NuTuneid << endl;
+  ;
+  cout << "NuPint = " << NuPint << endl;
+
+  cout << "NuBpos[2] = ";
+  for (int ip = 0; ip < 2; ip++) cout << NuBpos[ip] << " ";
+  cout << endl;
+
+  cout << "NuBtilt[2] = ";
+  for (int ip = 0; ip < 2; ip++) cout << NuBtilt[ip] << " ";
+  cout << endl;
+
+  cout << "NuBrms[2] = ";
+  for (int ip = 0; ip < 2; ip++) cout << NuBrms[ip] << " ";
+  cout << endl;
+
+  cout << "NuEmit[2] = ";
+  for (int ip = 0; ip < 2; ip++) cout << NuEmit[ip] << " ";
+  cout << endl;
+
+  cout << "NuAlpha[2] = ";
+  for (int ip = 0; ip < 2; ip++) cout << NuAlpha[ip] << " ";
+  cout << endl;
+
+  cout << "NuHcur[3] = ";
+  for (int ip = 0; ip < 3; ip++) cout << NuHcur[ip] << " ";
+  cout << endl;
+
+  cout << endl << "NEUT pass through info:" << endl << endl;
+
+  cout << "NEnvc = " << NEnvc << endl;
+  cout << "ip NEipvc[ip] NEiorgvc[ip] NEiflgvc[ip] NEicrnvc[ip] NEpvc[ip][3]"
+       << endl;
+  for (int ip = 0; ip < NEnvc; ip++) {
+    cout << ip << " " << NEipvc[ip] << " " << NEiorgvc[ip] << " ";
+    cout << NEiflgvc[ip] << " " << NEicrnvc[ip] << " ";
+    for (int ip2 = 0; ip2 < 3; ip2++) {
+      cout << NEpvc[ip][ip2] << " ";
+    }
+    cout << endl;
+  }
+  cout << endl;
+
+  cout << "NEcrsx NEcrsy NEcrsz NEcrsphi" << endl;
+  cout << NEcrsx << " " << NEcrsy << " " << NEcrsz << " " << NEcrsphi << endl;
+
+  cout << "NEnvert = " << NEnvert << endl;
+  cout << "iv NEiflgvert[iv] NEposvert[iv][3]" << endl;
+
+  for (int iv = 0; iv < NEnvert; iv++) {
+    cout << iv << " " << NEiflgvert[iv] << " ";
+    for (int ip2 = 0; ip2 < 3; ip2++) {
+      cout << NEposvert[iv][ip2] << " ";
+    }
+    cout << endl;
+  }
+  cout << endl;
+
+  cout << "NEnvcvert = " << NEnvcvert << endl;
+  cout << "ip NEabspvert[ip] NEabstpvert[ip] NEipvert[ip] NEiverti[ip] "
+          "NEivertf[ip] NEdirvert[ip][3]"
+       << endl;
+  for (int ip = 0; ip < NEnvcvert; ip++) {
+    cout << ip << " " << NEabspvert[ip] << " " << NEabstpvert[ip] << " "
+         << NEipvert[ip] << " " << NEiverti[ip] << " " << NEivertf[ip] << " ";
+    for (int ip2 = 0; ip2 < 3; ip2++) {
+      cout << NEdirvert[ip][ip2] << " ";
+    }
+    cout << endl;
+  }
+  cout << endl;
+
+  cout << endl << "Pass-through file info:" << endl;
+  cout << "  --> OrigFileName       = " << OrigFileName->GetString() << endl;
+  cout << "  --> OrigTreeName       = " << OrigTreeName->GetString() << endl;
+  cout << "  --> OrigEvtNum         = " << OrigEvtNum << endl;
+  cout << "  --> TimeInSpill         = " << TimeInSpill << endl;
+  cout << "  --> OrigTreeEntries    = " << OrigTreeEntries << endl;
+  cout << "  --> OrigTreePOT        = " << OrigTreePOT << endl;
 }
-//_______________________________________________________________________________________
-void NRooTrackerVtx::Print(const Option_t*) const
-{
-
-    cout << "\nNRooTrackerMCTruth: "    << endl;
-    cout << "  --> GeneratorName = " << GeneratorName->GetString() << endl;
-    cout << "  --> EvtCode       = " << EvtCode->GetString() << endl;
-    cout << "  --> GeomPath      = " << GeomPath->GetString() << endl;
-    cout << "  --> EvtNum        = " << EvtNum << endl;
-    cout << "  --> EvtXSec       = " << EvtXSec << endl;
-    cout << "  --> EvtDXSec      = " << EvtDXSec << endl;
-    cout << "  --> EvtWght       = " << EvtWght << endl;
-    cout << "  --> EvtProb       = " << EvtProb << endl;
-    cout << "  --> EvtVtx = ";
-    for(int i = 0; i < 4; i++) {
-      cout << EvtVtx[i] << ", ";
-    }
-    cout << endl;
-    cout << "  --> TruthVertexID = " << TruthVertexID << endl;
-
-
-    cout << "NRooTrackerStdHep: " << StdHepN << " values" << endl;
-
-    for(int i=0; i<StdHepN; i++) {
-        cout 
-            << setfill(' ') << setw(4)  << i 
-            << " -> pdgc: " 
-            << " / status: " 
-            << setfill(' ') << setw(3) << StdHepStatus[i] 
-            << " / mother: "
-            << setfill(' ') << setw(3) << StdHepFm[i]   
-            << " / daughters: (" 
-            << setfill(' ') << setw(3) << StdHepFd[i] 
-            << ", " 
-            << setfill(' ') << setw(3) << StdHepLd[i] 
-            << ") / E = " 
-            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxE] 
-            << ", px = " 
-            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxPx] 
-            << ", py = " 
-            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxPy] 
-            << ", pz = " 
-            << setfill(' ') << setw(10) << StdHepP4[i][kNStdHepIdxPz] 
-            << endl;
-    }
-
-    cout << endl << "Jnu-beam pass through info:" << endl;
-    cout << "  -->  NuParentPdg      = " << NuParentPdg << endl;
-    cout << "  -->  NuParentDecMode  = " << NuParentDecMode << endl;
-    cout << "  -->  NuParentDecP4[4] = " << NuParentDecP4[0] << ", "<< NuParentDecP4[1] << ", " << NuParentDecP4[2] << ", " << NuParentDecP4[3] << endl;
-    cout << "  -->  NuParentDecX4[4] = " << NuParentDecX4[0] << ", "<< NuParentDecX4[1] << ", " << NuParentDecX4[2] << ", " << NuParentDecX4[3] << endl;
-    cout << "  -->  NuParentProP4[4] = " << NuParentProP4[0] << ", "<< NuParentProP4[1] << ", " << NuParentProP4[2] << ", " << NuParentProP4[3] << endl;
-    cout << "  -->  NuParentProX4[4] = " << NuParentProX4[0] << ", "<< NuParentProX4[1] << ", " << NuParentProX4[2] << ", " << NuParentProX4[3] << endl;
-    cout << "  -->  NuGipart         = " << NuGipart << endl;
-    cout << "  -->  NuGamom0         = " << NuGamom0 << endl;
-    cout << "  -->  NuGpos0[3] = " << NuGpos0[0] << ", "<< NuGpos0[1] << ", " << NuGpos0[2] << endl; 
-    cout << "  -->  NuGvec0[3] = " << NuGvec0[0] << ", "<< NuGvec0[1] << ", " << NuGvec0[2] << endl; 
-
-    cout << "NuEnusk = " << NuEnusk << endl;
-    cout << "NuNorm = " << NuNorm << endl;
-    cout << "NuNormsk = " << NuNormsk << endl;
-    cout << "NuAnorm = " << NuAnorm << endl;
-
-    cout << "NuVersion = " << NuVersion << endl;
-    cout << "NuTuneid = " << NuTuneid << endl;;
-    cout << "NuPint = " << NuPint << endl;
-
-    cout << "NuBpos[2] = ";
-    for(int ip = 0; ip < 2; ip++)
-        cout << NuBpos[ip] << " ";
-    cout << endl;
-
-    cout << "NuBtilt[2] = ";
-    for(int ip = 0; ip < 2; ip++)
-        cout << NuBtilt[ip] << " ";
-    cout << endl;
-
-    cout << "NuBrms[2] = ";
-    for(int ip = 0; ip < 2; ip++)
-        cout << NuBrms[ip] << " ";
-    cout << endl;
-
-    cout << "NuEmit[2] = ";
-    for(int ip = 0; ip < 2; ip++)
-        cout << NuEmit[ip] << " ";
-    cout << endl;
-
-    cout << "NuAlpha[2] = ";
-    for(int ip = 0; ip < 2; ip++)
-        cout << NuAlpha[ip] << " ";
-    cout << endl;
-
-    cout << "NuHcur[3] = "; 
-    for(int ip = 0; ip < 3; ip++)
-        cout << NuHcur[ip] << " "; 
-    cout << endl;
-
-
-    cout << endl << "NEUT pass through info:" << endl << endl;
-
-    cout << "NEnvc = " << NEnvc << endl;
-    cout << "ip NEipvc[ip] NEiorgvc[ip] NEiflgvc[ip] NEicrnvc[ip] NEpvc[ip][3]" << endl;
-    for(int ip = 0; ip < NEnvc; ip++) {
-        cout << ip << " " << NEipvc[ip] << " " << NEiorgvc[ip] << " ";
-        cout << NEiflgvc[ip] << " " << NEicrnvc[ip] << " ";
-        for(int ip2 = 0; ip2 < 3; ip2++){
-            cout << NEpvc[ip][ip2] << " ";
-        }
-        cout << endl;
-    }
-    cout << endl;
-
-    cout << "NEcrsx NEcrsy NEcrsz NEcrsphi" << endl;
-    cout << NEcrsx << " " << NEcrsy << " " <<  NEcrsz << " " << NEcrsphi << endl;
-
-    cout << "NEnvert = " << NEnvert << endl;
-    cout << "iv NEiflgvert[iv] NEposvert[iv][3]" << endl;
-
-    for(int iv = 0; iv < NEnvert; iv++){
-        cout << iv << " " << NEiflgvert[iv] << " ";
-        for(int ip2 = 0; ip2 < 3; ip2++){
-            cout << NEposvert[iv][ip2] << " ";
-        }
-        cout << endl;
-    }
-    cout << endl;
-
-    cout << "NEnvcvert = " << NEnvcvert << endl;
-    cout << "ip NEabspvert[ip] NEabstpvert[ip] NEipvert[ip] NEiverti[ip] NEivertf[ip] NEdirvert[ip][3]" << endl;
-    for(int ip = 0; ip < NEnvcvert; ip++){
-        cout << ip << " " << NEabspvert[ip] << " " <<   NEabstpvert[ip] << " " <<  NEipvert[ip] << " " << NEiverti[ip] << " " << NEivertf[ip] << " ";
-        for(int ip2 = 0; ip2 < 3; ip2++){
-            cout << NEdirvert[ip][ip2] << " ";
-        }
-        cout << endl;
-    }
-    cout << endl;
-
-    cout << endl << "Pass-through file info:" << endl;
-    cout << "  --> OrigFileName       = " << OrigFileName->GetString() << endl;
-    cout << "  --> OrigTreeName       = " << OrigTreeName->GetString() << endl;
-    cout << "  --> OrigEvtNum         = " << OrigEvtNum << endl;
-    cout << "  --> TimeInSpill         = " << TimeInSpill << endl;
-    cout << "  --> OrigTreeEntries    = " << OrigTreeEntries << endl;
-    cout << "  --> OrigTreePOT        = " << OrigTreePOT << endl;
-
-}
-//_______________________________________________________________________________________
-

--- a/src/TNRooTrackerVtx.cc
+++ b/src/TNRooTrackerVtx.cc
@@ -235,18 +235,23 @@ void NRooTrackerVtx::Print(const Option_t*) const
     cout << "  --> EvtDXSec      = " << EvtDXSec << endl;
     cout << "  --> EvtWght       = " << EvtWght << endl;
     cout << "  --> EvtProb       = " << EvtProb << endl;
+    cout << "  --> EvtVtx = ";
+    for(int i = 0; i < 4; i++) {
+      cout << EvtVtx[i] << ", ";
+    }
+    cout << endl;
     cout << "  --> TruthVertexID = " << TruthVertexID << endl;
 
 
-    cout << "NRooTrackerStdHep:" << endl;
+    cout << "NRooTrackerStdHep: " << StdHepN << " values" << endl;
 
     for(int i=0; i<StdHepN; i++) {
         cout 
             << setfill(' ') << setw(4)  << i 
             << " -> pdgc: " 
-            << " / ist: " 
+            << " / status: " 
             << setfill(' ') << setw(3) << StdHepStatus[i] 
-            << " / mom: "
+            << " / mother: "
             << setfill(' ') << setw(3) << StdHepFm[i]   
             << " / daughters: (" 
             << setfill(' ') << setw(3) << StdHepFd[i] 

--- a/src/TNRooTrackerVtx.cc
+++ b/src/TNRooTrackerVtx.cc
@@ -35,6 +35,44 @@ NRooTrackerVtx::~NRooTrackerVtx() {
     delete OrigTreeName;
     OrigTreeName = NULL;
   }
+
+  if (StdHepPdg) delete [] StdHepPdg;
+  if (StdHepStatus) delete [] StdHepStatus;
+  if (StdHepFd) delete [] StdHepFd;
+  if (StdHepLd) delete [] StdHepLd;
+  if (StdHepFm) delete [] StdHepFm;
+  if (StdHepLm) delete [] StdHepLm;
+
+  if (NEipvc) delete [] NEipvc;
+  if (NEiorgvc) delete [] NEiorgvc;
+  if (NEiflgvc) delete [] NEiflgvc;
+  if (NEicrnvc) delete [] NEicrnvc;
+
+  if (NEiflgvert) delete [] NEiflgvert;
+  if (NEabspvert) delete [] NEabspvert;
+  if (NEabstpvert) delete [] NEabstpvert;
+  if (NEipvert) delete [] NEipvert;
+  if (NEiverti) delete [] NEiverti;
+  if (NEivertf) delete [] NEivertf;
+
+  if (NFiflag) delete [] NFiflag;
+  if (NFx) delete [] NFx;
+  if (NFy) delete [] NFy;
+  if (NFz) delete [] NFz;
+  if (NFpx) delete [] NFpx;
+  if (NFpy) delete [] NFpy;
+  if (NFpz) delete [] NFpz;
+  if (NFe) delete [] NFe;
+  if (NFfirststep) delete [] NFfirststep;
+  if (NFecms2) delete [] NFecms2;
+  if (Prob) delete [] Prob;
+  if (VertFlagStep) delete [] VertFlagStep;
+  if (VertFsiRhon) delete [] VertFsiRhon;
+  if (StepPel) delete [] StepPel;
+  if (StepPsp) delete [] StepPsp;
+  if (StepPdp) delete [] StepPdp;
+  if (StepScaleFactor) delete [] StepScaleFactor;
+  if (StepEkin) delete [] StepEkin;
 }
 void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   GeomPath->SetString(event->GeomPath->GetString());
@@ -66,11 +104,17 @@ void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   StdHepN = event->StdHepN;
 
   // Allocate the arrays which will be saved
+  if (StdHepPdg) delete [] StdHepPdg;
   StdHepPdg = new int[StdHepN];
+  if (StdHepStatus) delete [] StdHepStatus;
   StdHepStatus = new int[StdHepN];
+  if (StdHepFd) delete [] StdHepFd;
   StdHepFd = new int[StdHepN];
+  if (StdHepLd) delete [] StdHepLd;
   StdHepLd = new int[StdHepN];
+  if (StdHepFm) delete [] StdHepFm;
   StdHepFm = new int[StdHepN];
+  if (StdHepLm) delete [] StdHepLm;
   StdHepLm = new int[StdHepN];
 
   for (int i = 0; i < StdHepN; i++) {
@@ -94,9 +138,13 @@ void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   NEnvc = event->NEnvc;
 
   // Allocate the arrays which will be saved
+  if (NEipvc) delete [] NEipvc;
   NEipvc = new int[NEnvc];
+  if (NEiorgvc) delete [] NEiorgvc;
   NEiorgvc = new int[NEnvc];
+  if (NEiflgvc) delete [] NEiflgvc;
   NEiflgvc = new int[NEnvc];
+  if (NEicrnvc) delete [] NEicrnvc;
   NEicrnvc = new int[NEnvc];
 
   for (int i = 0; i < NEnvc; i++) {
@@ -115,6 +163,7 @@ void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   NEcrsphi = event->NEcrsphi;
   NEnvert = event->NEnvert;
 
+  if (NEiflgvert) delete [] NEiflgvert;
   NEiflgvert = new int[NEnvert];
   for (int i = 0; i < NEnvert; i++) {
     NEiflgvert[i] = event->NEiflgvertTemp[i];
@@ -126,10 +175,15 @@ void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   NEnvcvert = event->NEnvcvert;
 
   // define the dynamic arrays
+  if (NEabspvert) delete [] NEabspvert;
   NEabspvert = new float[NEnvcvert];
+  if (NEabstpvert) delete [] NEabstpvert;
   NEabstpvert = new float[NEnvcvert];
+  if (NEipvert) delete [] NEipvert;
   NEipvert = new int[NEnvcvert];
+  if (NEiverti) delete [] NEiverti;
   NEiverti = new int[NEnvcvert];
+  if (NEivertf) delete [] NEivertf;
   NEivertf = new int[NEnvcvert];
 
   for (int i = 0; i < NEnvcvert; i++) {
@@ -146,14 +200,23 @@ void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   /**** START Nucleon FSI PASSTHROUGH ******/
 
   NFnvert = event->NFnvert;
+  if (NFiflag) delete [] NFiflag;
   NFiflag = new int[NFnvert];
+  if (NFx) delete [] NFx;
   NFx = new float[NFnvert];
+  if (NFy) delete [] NFy;
   NFy = new float[NFnvert];
+  if (NFz) delete [] NFz;
   NFz = new float[NFnvert];
+  if (NFpx) delete [] NFpx;
   NFpx = new float[NFnvert];
+  if (NFpy) delete [] NFpy;
   NFpy = new float[NFnvert];
+  if (NFpz) delete [] NFpz;
   NFpz = new float[NFnvert];
+  if (NFe) delete [] NFe;
   NFe = new float[NFnvert];
+  if (NFfirststep) delete [] NFfirststep;
   NFfirststep = new int[NFnvert];
 
   for (int i = 0; i < NFnvert; i++) {
@@ -171,14 +234,23 @@ void NRooTrackerVtx::Copy(const NRooTrackerVtx* event) {
   NFnstep = event->NFnstep;
 
   if(NFnstep!=0){
+    if (NFecms2) delete [] NFecms2;
     NFecms2 = new float[NFnstep];
+    if (Prob) delete [] Prob;
     Prob = new float[NFnstep];
+    if (VertFlagStep) delete [] VertFlagStep;
     VertFlagStep = new float[NFnstep];
+    if (VertFsiRhon) delete [] VertFsiRhon;
     VertFsiRhon = new float[NFnstep];
+    if (StepPel) delete [] StepPel;
     StepPel = new float[NFnstep];
+    if (StepPsp) delete [] StepPsp;
     StepPsp = new float[NFnstep];
+    if (StepPdp) delete [] StepPdp;
     StepPdp = new float[NFnstep];
+    if (StepScaleFactor) delete [] StepScaleFactor;
     StepScaleFactor = new float[NFnstep];
+    if (StepEkin) delete [] StepEkin;
     StepEkin = new float[NFnstep];
     
     for (int k = 0; k < NFnstep; k++) {
@@ -316,6 +388,46 @@ void NRooTrackerVtx::Reset() {
   IRadCorrPht = -999;
 }
 void NRooTrackerVtx::Init() {
+  StdHepPdg = 0;
+  StdHepStatus = 0;
+  StdHepFd = 0;
+  StdHepLd = 0;
+  StdHepFm = 0;
+  StdHepLm = 0;
+
+  NEipvc = 0;
+  NEiorgvc = 0;
+  NEiflgvc = 0;
+  NEicrnvc = 0;
+
+  NEiflgvert = 0;
+
+  NEabspvert = 0;
+  NEabstpvert = 0;
+  NEipvert = 0;
+  NEiverti = 0;
+  NEivertf = 0;
+
+  NFiflag = 0;
+  NFx = 0;
+  NFy = 0;
+  NFz = 0;
+  NFpx = 0;
+  NFpy = 0;
+  NFpz = 0;
+  NFe = 0;
+  NFfirststep = 0;
+
+  NFecms2 = 0;
+  Prob = 0;
+  VertFlagStep = 0;
+  VertFsiRhon = 0;
+  StepPel = 0;
+  StepPsp = 0;
+  StepPdp = 0;
+  StepScaleFactor = 0;
+  StepEkin = 0;
+
   GeomPath = new TObjString("");
   GeneratorName = new TObjString("");
   EvtCode = new TObjString("");

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -152,6 +152,10 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 	<< "GEOMCHECK3 WCPMTODExposeHeight \t" << WCPMTODExposeHeight << G4endl
 	;
 #endif
+  // Tell DetectorConstruction about boundary walls
+  AddBoundaryWallCylinderDimensions(kBoundaryWallODInnerTyvek,
+									WCODRadius,
+									(WCIDHeight + 2*WCODDeadSpace + 2*WCODTyvekSheetThickness)); //from CapTyvekPosition creation, without the /2 as we store the full length in the boundary wall variables, including the OD tyvek thickness
 
   // the radii are measured to the center of the surfaces
   // (tangent distance). Thus distances between the corner and the center are bigger.
@@ -332,6 +336,9 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 					  false,
 					  checkOverlaps);
 
+  // Tell DetectorConstruction about boundary walls
+	AddBoundaryWallCylinderDimensions(kBoundaryWallODOuterTyvek,
+									  WCRadius, WCLength);
 
   } // END Tyvek cave
   //-----------------------------------------------------
@@ -520,6 +527,10 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   G4cout << mainAnnulusRmin[0] << ", " << mainAnnulusRmax[0] << ", " << mainAnnulusZ[0] << G4endl;
   G4cout << mainAnnulusRmin[1] << ", " << mainAnnulusRmax[1] << ", " << mainAnnulusZ[1] << G4endl;
   
+  // Tell DetectorConstruction about boundary walls
+  AddBoundaryWallCylinderDimensions(kBoundaryWallIDBlacksheet,
+									WCIDRadius, WCIDHeight);
+
   G4Polyhedra* solidWCBarrelCellBlackSheet = new G4Polyhedra("WCBarrelCellBlackSheet",
 															 -dPhi/2., // phi start
 															 dPhi, //total phi

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -956,14 +956,17 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
     WCSimRootTrigger * wcsimrootevent2 = wcsimrootsuperevent2->GetTrigger(0);
 
     bool skipFillingTracks = false;
+    bool skipFillingRooTracker = false;
     FillRootEventHybrid(event_id,
 			jhfNtuple,
 			trajectoryContainer,
 			WCDC_hits,
 			WCDC,
 			"tank",wcsimrootsuperevent,wcsimrootevent,
-			skipFillingTracks);
+			skipFillingTracks,
+			skipFillingRooTracker);
     skipFillingTracks = true;
+    skipFillingRooTracker = true;
     if(detectorConstructor->GetHybridPMT()){
       FillRootEventHybrid(event_id,
 			  jhfNtuple,
@@ -971,7 +974,8 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 			  WCDC_hits2,
 			  WCDC2,
 			  "tankPMT2",wcsimrootsuperevent2,wcsimrootevent2,
-			  skipFillingTracks);
+			  skipFillingTracks,
+			  skipFillingRooTracker);
     }
 
     if(detectorConstructor->GetIsODConstructed()){
@@ -981,7 +985,8 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
 		    WCDC_hits_OD,
 		    WCDC_OD,
 		    "OD",
-		    skipFillingTracks);
+		    skipFillingTracks,
+		    skipFillingRooTracker);
     }
     runAction->incrementEventsGenerated(); // Increment after filling branches
 
@@ -1121,7 +1126,8 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 				     WCSimWCDigitsCollection* WCDC_hits,
 				     WCSimWCTriggeredDigitsCollection* WCDC,
 				     G4String detectorElement,
-				     bool skipFillingTracks)
+				     bool skipFillingTracks,
+				     bool skipFillingRooTracker)
 {
   // Fill up a Root event with stuff from the ntuple
 
@@ -1704,15 +1710,13 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
   //G4cout <<"WCFV digi sumQ:"<<std::setw(4)<<wcsimrootevent->GetSumQ()<<"  ";
   //  }
 
-  /*
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
-  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
+  if(!skipFillingRooTracker && GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
       GetRunAction()->ClearRootrackerVertexArray();
       generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex()); //will increment NVtx
       GetRunAction()->FillRootrackerVertexTree();
   }
-  */
 
 }
 
@@ -1724,7 +1728,8 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 				       G4String detectorElement,
 				       WCSimRootEvent * wcsimrootsuperevent,
 					   WCSimRootTrigger * wcsimrootevent,
-					   bool skipFillingTracks)
+					   bool skipFillingTracks,
+					   bool skipFillingRooTracker)
  {
   wcsimrootsuperevent->ReInitialize();
   // start with the first "sub-event"
@@ -2295,15 +2300,13 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
   //G4cout <<"WCFV digi sumQ:"<<std::setw(4)<<wcsimrootevent->GetSumQ()<<"  ";
   //  }
 
-  /*
   // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
   // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
-  if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
+  if(!skipFillingRooTracker && GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
       GetRunAction()->ClearRootrackerVertexArray();
       generatorAction->CopyRootrackerVertex(GetRunAction()->GetRootrackerVertex()); //will increment NVtx
       GetRunAction()->FillRootrackerVertexTree();
   }
-  */
 }
 
 

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -2699,7 +2699,7 @@ void WCSimEventAction::FillFlatTree(G4int event_id,
     // Check we are supposed to be saving the NEUT vertex and that the generator was given a NEUT vector file to process
     // If there is no NEUT vector file an empty NEUT vertex will be written to the output file
     if(GetRunAction()->GetSaveRooTracker() && generatorAction->IsUsingRootrackerEvtGenerator()){
-      NRooTrackerVtx *thisRooTracker = GetRunAction()->GetMyRooTracker();
+      ND::NRooTrackerVtx *thisRooTracker = GetRunAction()->GetMyRooTracker();
       generatorAction->CopyRootrackerVertex(thisRooTracker);
 
       G4cout << "Test: " << thisRooTracker->NuParentDecMode << G4endl;

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -516,7 +516,9 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       //G4cout<<"od_inner_radius "<< od_inner_blacksheet_radius << G4endl;
       //G4cout<<"od_inner_full_length "<< od_inner_blacksheet_full_length << G4endl;
 
-      vector<float> od_outer_dims = myDetector->GetBoundaryWallDimensions()[kBoundaryWallODOuterTyvek];
+      vector<float> od_outer_dims = od_inner_dims;
+      // OuterTyvek may not exist
+      if (myDetector->GetBoundaryWallDimensions().count(kBoundaryWallODOuterTyvek)) myDetector->GetBoundaryWallDimensions()[kBoundaryWallODOuterTyvek];
       double od_outer_blacksheet_radius = od_outer_dims[0];
       double od_outer_blacksheet_full_length = od_outer_dims[1];
       //G4cout<<"od_outer_radius "<< od_outer_blacksheet_radius << G4endl;

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -480,9 +480,6 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
       //Load event from file
       if(fEvNum == 0){
-	fSettingsTree->SetBranchAddress("NuBeamAng",&fNuBeamAng);
-	fSettingsTree->SetBranchAddress("DetRadius",&fNuPrismRadius);
-	fSettingsTree->SetBranchAddress("NuIdfdPos",fNuPlanePos);
 	fSettingsTree->GetEntry(0);
       }
       if (fEvNum<fNEntries){
@@ -1829,7 +1826,6 @@ void WCSimPrimaryGeneratorAction::OpenRootrackerFile(G4String fileName)
   }
 
   fRooTrackerTree = (TTree*) fInputRootrackerFile->Get("nRooTracker");
-  fSettingsTree = (TTree*) fInputRootrackerFile->Get("Settings");
   if (!fRooTrackerTree){
     G4cout << "File: " << fileName << " does not contain a Rootracker nRooTracker tree - please check you intend to process Rootracker events" << G4endl;
     exit(1);
@@ -1839,10 +1835,24 @@ void WCSimPrimaryGeneratorAction::OpenRootrackerFile(G4String fileName)
   fTmpRootrackerVtx = new NRooTrackerVtx();
   SetupBranchAddresses(fTmpRootrackerVtx); //link fTmpRootrackerVtx and current input file
 
-  fSettingsTree->SetBranchAddress("NuBeamAng",&fNuBeamAng);
-  fSettingsTree->SetBranchAddress("DetRadius",&fNuPrismRadius);
-  fSettingsTree->SetBranchAddress("NuIdfdPos",fNuPlanePos);
-
+  // Different names across NEUT versions
+  fSettingsTree = (TTree*) fInputRootrackerFile->Get("Settings");
+  if (fSettingsTree)
+  {
+    fSettingsTree->SetBranchAddress("NuBeamAng",&fNuBeamAng);
+    fSettingsTree->SetBranchAddress("DetRadius",&fNuPrismRadius);
+    fSettingsTree->SetBranchAddress("NuIdfdPos",fNuPlanePos);
+  }
+  else 
+  {
+    fSettingsTree = (TTree*) fInputRootrackerFile->Get("settings");
+    if (!fSettingsTree) 
+    {
+      G4cout << "Error: Could not find 'Settings' or 'settings' tree in file!" << G4endl;
+      exit(1);
+    }
+    fSettingsTree->SetBranchAddress("NuIdfdPosGeomCoord", fNuPlanePos);
+  }
 }
 
 void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx){

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1940,10 +1940,9 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
     fRooTrackerTree->SetBranchAddress("StepPsp", (nrootrackervtx->StepPspTEMP));
     fRooTrackerTree->SetBranchAddress("StepPdp", (nrootrackervtx->StepPdpTEMP));
     // These two are missing in NEUT 5.6.4 vectors in /hyperk.org/beta-production/iwcd/prod2/neut564_cnev2.0/neut564_cnge2.0/rnge
-    fRooTrackerTree->SetBranchAddress("StepScaleFactor", (nrootrackervtx->StepScaleFactorTEMP));
-    fRooTrackerTree->SetBranchAddress("StepEkin", (nrootrackervtx->StepEkinTEMP));
+    // fRooTrackerTree->SetBranchAddress("StepScaleFactor", (nrootrackervtx->StepScaleFactorTEMP));
+    // fRooTrackerTree->SetBranchAddress("StepEkin", (nrootrackervtx->StepEkinTEMP));
 
-    // Do these two exist in old nRooTracker tree? 
     fRooTrackerTree->SetBranchAddress("SPIDelta", &(nrootrackervtx->SPIDelta));
     fRooTrackerTree->SetBranchAddress("IRadCorrPht", &(nrootrackervtx->IRadCorrPht));
   }
@@ -1959,8 +1958,8 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
 void WCSimPrimaryGeneratorAction::CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx){
   //fTmpRootrackerVtx->Print();
   nrootrackervtx->Copy(fTmpRootrackerVtx);
-  nrootrackervtx->TruthVertexID = -999;
-  nrootrackervtx->NuParentPdg = 1234567;
-  fRooTrackerTree->Show(0);
-  nrootrackervtx->Print();
+  // nrootrackervtx->TruthVertexID = -999;
+  // nrootrackervtx->NuParentPdg = 1234567;
+  // fRooTrackerTree->Show(0);
+  // nrootrackervtx->Print();
 }

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -596,38 +596,24 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       //i = 2 is the target nucleon
       //i > 2 are the outgoing particles
       
-      // First simulate the incoming neutrino
-      // Get the neutrino direction
-      xDir=fTmpRootrackerVtx->StdHepP4[0][0]*GeV;
-      yDir=fTmpRootrackerVtx->StdHepP4[0][1]*GeV;
-      zDir=fTmpRootrackerVtx->StdHepP4[0][2]*GeV;
-
-      double momentum=sqrt((xDir*xDir)+(yDir*yDir)+(zDir*zDir));
-
-      G4ThreeVector vtx = G4ThreeVector(xPos, yPos, zPos);
-      G4ThreeVector dir = G4ThreeVector(-xDir, -yDir, -zDir);
-
-      dir = dir*(1./momentum);
-
-      particleGun->SetParticleDefinition(particleTable->FindParticle(fTmpRootrackerVtx->StdHepPdgTemp[0]));
-      double kin_energy = momentum;//fabs(fTmpRootrackerVtx->StdHepP4[i][3])*GeV - particleGun->GetParticleDefinition()->GetPDGMass();
-      particleGun->SetParticleEnergy(kin_energy);
-      particleGun->SetParticlePosition(vtx);
-      particleGun->SetParticleMomentumDirection(dir);
-      // Will want to include some beam time structure at some point, but not needed at the moment since we only simulate 1 interaction per events
-      // particleGun->SetParticleTime(time);
-      particleGun->GeneratePrimaryVertex(anEvent);  //Place vertex in stack
+      double momentum;
+      G4ThreeVector vtx;
+      G4ThreeVector dir;
+      double kin_energy;
 
         // Now simulate the outgoing particles
         for (int i = 0; i < fTmpRootrackerVtx->StdHepN; i++){
 
             // Skip the initial neutrino, target nucleus and target nucleon
-            if( i < 3){
-                int pdg = abs(fTmpRootrackerVtx->StdHepPdgTemp[i]);
-                if(pdg > 100000 || pdg == 12 || pdg == 14 || pdg == 2112 || pdg == 2212){
-                    continue;
-                }
-            }
+	  int abspdg = abs(fTmpRootrackerVtx->StdHepPdgTemp[i]);
+	  if( i < 3){
+	    if(abspdg > 100000 || abspdg == 2112 || abspdg == 2212){
+	      continue;
+	    }
+	  }
+	  if(abspdg == 12 || abspdg == 14 || abspdg == 16) {
+	    continue;
+	  }
 
             xDir=fTmpRootrackerVtx->StdHepP4[i][0]*GeV;
             yDir=fTmpRootrackerVtx->StdHepP4[i][1]*GeV;
@@ -655,8 +641,11 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
             // Will want to include some beam time structure at some point, but not needed at the moment since we only simulate 1 interaction per events
             // particleGun->SetParticleTime(time);
             particleGun->GeneratePrimaryVertex(anEvent);  //Place vertex in stack
-        }
-    }
+	    G4cout << "ROOTRACKER: created particle gun with KinEnergy/PDG/Position/Direction: "
+		   << kin_energy << "/" << fTmpRootrackerVtx->StdHepPdgTemp[i]
+		   << "/" << vtx << "/" << dir << " i = " << i << G4endl;
+        }//loop over RooTracker particles
+    }//useRooTracker
 
   else if (useGunEvt)
     {      // manual gun operation
@@ -1913,10 +1902,13 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
   fRooTrackerTree->SetBranchAddress("NuGmec",           (nrootrackervtx->NuGmec));
   fRooTrackerTree->SetBranchAddress("NuGdistc",         (nrootrackervtx->NuGdistc));
   fRooTrackerTree->SetBranchAddress("NuGdistal",        (nrootrackervtx->NuGdistal));
-
 }
 
 void WCSimPrimaryGeneratorAction::CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx){
+  //fTmpRootrackerVtx->Print();
   nrootrackervtx->Copy(fTmpRootrackerVtx);
   nrootrackervtx->TruthVertexID = -999;
+  nrootrackervtx->NuParentPdg = 1234567;
+  fRooTrackerTree->Show(0);
+  nrootrackervtx->Print();
 }

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1834,7 +1834,7 @@ void WCSimPrimaryGeneratorAction::OpenRootrackerFile(G4String fileName)
   }
   fNEntries=fRooTrackerTree->GetEntries();
 
-  fTmpRootrackerVtx = new NRooTrackerVtx();
+  fTmpRootrackerVtx = new ND::NRooTrackerVtx();
   SetupBranchAddresses(fTmpRootrackerVtx); //link fTmpRootrackerVtx and current input file
 
   // Different names across NEUT versions
@@ -1857,7 +1857,7 @@ void WCSimPrimaryGeneratorAction::OpenRootrackerFile(G4String fileName)
   }
 }
 
-void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrackervtx){
+void WCSimPrimaryGeneratorAction::SetupBranchAddresses(ND::NRooTrackerVtx* nrootrackervtx){
 
   // Set up branch address for rooTrackerVertex tree in nuPRISM files
   fRooTrackerTree->SetBranchAddress("EvtCode",        &(nrootrackervtx->EvtCode) );
@@ -1955,7 +1955,7 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
   }
 }
 
-void WCSimPrimaryGeneratorAction::CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx){
+void WCSimPrimaryGeneratorAction::CopyRootrackerVertex(ND::NRooTrackerVtx* nrootrackervtx){
   //fTmpRootrackerVtx->Print();
   nrootrackervtx->Copy(fTmpRootrackerVtx);
   // nrootrackervtx->TruthVertexID = -999;

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1914,6 +1914,46 @@ void WCSimPrimaryGeneratorAction::SetupBranchAddresses(NRooTrackerVtx* nrootrack
   fRooTrackerTree->SetBranchAddress("NuGmec",           (nrootrackervtx->NuGmec));
   fRooTrackerTree->SetBranchAddress("NuGdistc",         (nrootrackervtx->NuGdistc));
   fRooTrackerTree->SetBranchAddress("NuGdistal",        (nrootrackervtx->NuGdistal));
+
+  // Nucleon FSI information
+  bool fHaveNFBranches = (fRooTrackerTree->SetBranchAddress("NFnvert", &(nrootrackervtx->NFnvert)) == 0);
+  if (fHaveNFBranches)
+  {
+    fRooTrackerTree->SetBranchAddress("NFiflag", (nrootrackervtx->NFiflagTEMP));
+    fRooTrackerTree->SetBranchAddress("NFx", (nrootrackervtx->NFxTEMP));
+    fRooTrackerTree->SetBranchAddress("NFy", (nrootrackervtx->NFyTEMP));
+    fRooTrackerTree->SetBranchAddress("NFz", (nrootrackervtx->NFzTEMP));
+    fRooTrackerTree->SetBranchAddress("NFpx", (nrootrackervtx->NFpxTEMP));
+    fRooTrackerTree->SetBranchAddress("NFpy", (nrootrackervtx->NFpyTEMP));
+    fRooTrackerTree->SetBranchAddress("NFpz", (nrootrackervtx->NFpzTEMP));
+    fRooTrackerTree->SetBranchAddress("NFe", (nrootrackervtx->NFeTEMP));
+    fRooTrackerTree->SetBranchAddress("PCascProb", &(nrootrackervtx->PCascProb));
+
+    fRooTrackerTree->SetBranchAddress("NFfirststep",
+                                      (nrootrackervtx->NFfirststepTEMP));
+    fRooTrackerTree->SetBranchAddress("NFnstep", &(nrootrackervtx->NFnstep));
+    fRooTrackerTree->SetBranchAddress("NFecms2", (nrootrackervtx->NFecms2TEMP));
+    fRooTrackerTree->SetBranchAddress("Prob", (nrootrackervtx->ProbTEMP));
+    fRooTrackerTree->SetBranchAddress("VertFlagStep", (nrootrackervtx->VertFlagStepTEMP));
+    fRooTrackerTree->SetBranchAddress("VertFsiRhon", (nrootrackervtx->VertFsiRhonTEMP));
+    fRooTrackerTree->SetBranchAddress("StepPel", (nrootrackervtx->StepPelTEMP));
+    fRooTrackerTree->SetBranchAddress("StepPsp", (nrootrackervtx->StepPspTEMP));
+    fRooTrackerTree->SetBranchAddress("StepPdp", (nrootrackervtx->StepPdpTEMP));
+    // These two are missing in NEUT 5.6.4 vectors in /hyperk.org/beta-production/iwcd/prod2/neut564_cnev2.0/neut564_cnge2.0/rnge
+    fRooTrackerTree->SetBranchAddress("StepScaleFactor", (nrootrackervtx->StepScaleFactorTEMP));
+    fRooTrackerTree->SetBranchAddress("StepEkin", (nrootrackervtx->StepEkinTEMP));
+
+    // Do these two exist in old nRooTracker tree? 
+    fRooTrackerTree->SetBranchAddress("SPIDelta", &(nrootrackervtx->SPIDelta));
+    fRooTrackerTree->SetBranchAddress("IRadCorrPht", &(nrootrackervtx->IRadCorrPht));
+  }
+  else
+  {
+    G4cout << "=======================================================================================."<< G4endl;
+    G4cout << "WCSimPrimaryGeneratorAction::SetupBranchAddresses() : Passthrough tree doesn't contain" << G4endl;
+    G4cout << " nucleon FSI tracking information, these branches will remain off." << G4endl;
+    G4cout << "=======================================================================================."<< G4endl;
+  }
 }
 
 void WCSimPrimaryGeneratorAction::CopyRootrackerVertex(NRooTrackerVtx* nrootrackervtx){

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -164,12 +164,14 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
       //Setup rooTracker tree
       if (SaveRooTracker) {
 	//Setup TClonesArray to store Rootracker truth info
-	fVertices = new TClonesArray("NRooTrackerVtx", 10);
-	fVertices->Clear();
+	//fVertices = new TClonesArray("NRooTrackerVtx", 10);
+	//fVertices->Clear();
 	fNVtx = 0;
+	evNRooTracker = new NRooTrackerVtx;
 	fRooTrackerOutputTree = new TTree("fRooTrackerOutputTree", "Event Vertex Truth Array");
-	fRooTrackerOutputTree->Branch("NVtx", &fNVtx, "NVtx/I");
-	fRooTrackerOutputTree->Branch("NRooTrackerVtx", "TClonesArray", &fVertices);
+	//fRooTrackerOutputTree->Branch("NVtx", &fNVtx, "NVtx/I");
+	//fRooTrackerOutputTree->Branch("NRooTrackerVtx", "TClonesArray", &fVertices);
+	fRooTrackerOutputTree->Branch("NRooTrackerVtx", &evNRooTracker);
       }
     }
     else{
@@ -818,9 +820,9 @@ void WCSimRunAction::FillFlatGeoTree(){
 }
 
 NRooTrackerVtx* WCSimRunAction::GetRootrackerVertex(){
-
-  NRooTrackerVtx* currRootrackerVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
-  fNVtx += 1;
-  return currRootrackerVtx;
+  return evNRooTracker;
+  //NRooTrackerVtx* currRootrackerVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
+  //fNVtx += 1;
+  //return currRootrackerVtx;
 }
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -72,9 +72,24 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
     if(GetSaveRooTracker()){
       //Setup settings tree
       // Assume the NEUT file is open.
+      // Old NEUT
       fSettingsInputTree = (TTree*) gDirectory->Get("Settings");
-      fSettingsInputTree->SetBranchAddress("NuIdfdPos",fNuPlanePos);
-      fSettingsInputTree->SetBranchAddress("DetRadius",&fNuPrismRadius);
+      if (fSettingsInputTree)
+      {
+        fSettingsInputTree->SetBranchAddress("NuIdfdPos",fNuPlanePos);
+        fSettingsInputTree->SetBranchAddress("DetRadius",&fNuPrismRadius);
+      }
+      else
+      {
+        // NEUT 5.6.4
+        fSettingsInputTree = (TTree*) gDirectory->Get("settings");
+        if (!fSettingsInputTree) 
+        {
+          G4cout << "Error: Could not find 'Settings' or 'settings' tree in file!" << G4endl;
+          exit(1);
+        }
+        fSettingsInputTree->SetBranchAddress("NuIdfdPosGeomCoord", fNuPlanePos);
+      }
     }
   }
 

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -182,7 +182,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
 	//fVertices = new TClonesArray("NRooTrackerVtx", 10);
 	//fVertices->Clear();
 	fNVtx = 0;
-	evNRooTracker = new NRooTrackerVtx;
+	evNRooTracker = new ND::NRooTrackerVtx;
 	fRooTrackerOutputTree = new TTree("fRooTrackerOutputTree", "Event Vertex Truth Array");
 	//fRooTrackerOutputTree->Branch("NVtx", &fNVtx, "NVtx/I");
 	//fRooTrackerOutputTree->Branch("NRooTrackerVtx", "TClonesArray", &fVertices);
@@ -375,7 +375,7 @@ void WCSimRunAction::BeginOfRunAction(const G4Run* aRun)
       //fVertices = new TClonesArray("NRooTrackerVtx", 10);
       //fVertices->Clear();
       //fNVtx = 0;
-      evNRooTracker = new NRooTrackerVtx();   // should be an array? Not clear where in WCSim NVtx > 1
+      evNRooTracker = new ND::NRooTrackerVtx();   // should be an array? Not clear where in WCSim NVtx > 1
       flatRooTrackerTree = new TTree("RooTracker","Event Vertex Truth Array");
       flatRooTrackerTree->Branch("Run",&run,"Run/I");
       flatRooTrackerTree->Branch("Event",&event,"Event/I");
@@ -834,10 +834,9 @@ void WCSimRunAction::FillFlatGeoTree(){
   flatfile->Write(); 
 }
 
-NRooTrackerVtx* WCSimRunAction::GetRootrackerVertex(){
+ND::NRooTrackerVtx* WCSimRunAction::GetRootrackerVertex(){
   return evNRooTracker;
   //NRooTrackerVtx* currRootrackerVtx = new((*fVertices)[fNVtx])NRooTrackerVtx();
   //fNVtx += 1;
   //return currRootrackerVtx;
 }
-

--- a/src/WCSimWLSProperties.cc
+++ b/src/WCSimWLSProperties.cc
@@ -663,7 +663,7 @@ void Kuraray::SetgAbs(){
   //       0.71, 0.54, 0, 0, // 300 --- 250
   //       0, 0, 0, 0, 0}; // 250 --- 200
   gAbs = new TGraph();
-  const int step = 10;
+  // const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS ABS" << std::endl;
   // Then fill with point there is data
@@ -675,7 +675,7 @@ void Kuraray::SetgAbs(){
 }
 void Kuraray::SetgEm(){
   gEm = new TGraph();
-  const int step = 10;
+  // const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS EM" << std::endl;
   // Then fill with point there is data
@@ -936,7 +936,7 @@ void Inr::SetgAbs(){
   //       0.71, 0.54, 0, 0, // 300 --- 250
   //       0, 0, 0, 0, 0}; // 250 --- 200
   gAbs = new TGraph();
-  const int step = 10;
+  // const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS ABS" << std::endl;
   // Then fill with point there is data
@@ -948,7 +948,7 @@ void Inr::SetgAbs(){
 }
 void Inr::SetgEm(){
   gEm = new TGraph();
-  const int step = 10;
+  // const int step = 10;
   // std::cout << "Creating Stacking graph objects for WLS" << std::endl;
   // std::cout << "WLS EM" << std::endl;
   // Then fill with point there is data


### PR DESCRIPTION
### Work in progress. Not ready to merge yet.

This work is inherited from @tdealtry effort
```
I got as far as reproducing the issue Sophie was seeing & almost figuring out how to fix it
In case it’s useful https://github.com/WCSim/WCSim/compare/develop...tdealtry:WCSim:rootracker2 

- Needed to uncomment some things in WCSimEventAction
- Needed to add new functionality to WCSimEventAction, so we don’t fill the rootracker tree for every PMT type
- The stuff in WCSimPrimaryGeneratorAction & WCSimRunAction I’m less clear on whether it’s required.
- The TNRooTracker changes were just for debugging

One issue I found difficult is that the example rootracker file I had had a lot of default values set. This made it very difficult to work out which variables were working & which weren’t
A related issue is that there are A LOT of variables to pass through. I don’t think all of them are currently correctly filled in WCSimPrimaryGeneratorAction::SetupBranchAddresses()
```

Upon running with neut5.6.4 file, there are errors due to different tree and branch names. Can @sk1806 confirm the correct branch is accessed?
```
  // Old NEUT
  fSettingsTree = (TTree*) fInputRootrackerFile->Get("Settings");
  if (fSettingsTree)
  {
    fSettingsTree->SetBranchAddress("NuBeamAng",&fNuBeamAng);
    fSettingsTree->SetBranchAddress("DetRadius",&fNuPrismRadius);
    fSettingsTree->SetBranchAddress("NuIdfdPos",fNuPlanePos);
  }
  else 
  { // NEUT 5.6.4
    fSettingsTree = (TTree*) fInputRootrackerFile->Get("settings");
    if (!fSettingsTree) 
    {
      G4cout << "Error: Could not find 'Settings' or 'settings' tree in file!" << G4endl;
      exit(1);
    }
    // The other two branches are not used at all
    fSettingsTree->SetBranchAddress("NuIdfdPosGeomCoord", fNuPlanePos);
  }
```
