### PR TITLE
Fix mPMT LED position

### DIFF
--- a/WCSim.mac
+++ b/WCSim.mac
@@ -429,7 +429,7 @@
 # (Note that these are LEDs positioned in the standard mPMT modules.
 #  They are not LEDs in the LED-mPMT modules)
 #/mygen/generator mPMT-LED
-# Use PMTid (from 1 to totalNum_mPMTs) to specify source mPMT
+# Use PMTid (second value in geofile) to specify source mPMT
 # Use LEDid (from 0 to 11) to specify LED position, theta and phi directional change from nominal direction
 #/mPMTLED/PMTid 1
 #/mPMTLED/LEDid 0 0 0

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -1599,7 +1599,7 @@ void WCSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
         LEDphi = CLHEP::pi/12 + (mPMTLEDId2-6)*CLHEP::pi/3;
       }
 
-      G4double distToPMT = 5.8*cm; // ad-hoc value to start photons in acrylic
+      G4double distToPMT = 5.9*cm; // ad-hoc value to start photons in acrylic
       G4Vector3D LEDdir = sin(LEDth)*(cos(LEDphi)*x_axis+sin(LEDphi)*y_axis)+cos(LEDth)*z_axis;
       G4double xpos = pmtOrigin.x() + LEDdir.x()*(distFromOriginToPMT+distToPMT);
       G4double ypos = pmtOrigin.y() + LEDdir.y()*(distFromOriginToPMT+distToPMT);


### PR DESCRIPTION
For LEDs in in-situ mPMTs, they were placed inside the opaque matrix so photons were immediately killed. 

Now the starting position is shifted up by 0.1 mm so that photons start inside the gel (air) for in-situ (ex-situ) mPMTs.