### PR TITLE
Adding compatibility with Geant4 version > 11.0.0

### DIFF
--- a/include/G4Utils.hh
+++ b/include/G4Utils.hh
@@ -1,0 +1,15 @@
+//
+// Created by Nadrino on 23/02/2026.
+//
+
+#ifndef WCSIM_G4UTILS_H
+#define WCSIM_G4UTILS_H
+
+#include "G4Version.hh"
+
+#define G4VERSION_ENCODE(major,minor,patch) ((major)*100 + (minor)*10 + (patch))
+
+#define G4VERSION_IS_GREATER_EQUAL(major,minor,patch) (G4VERSION_NUMBER >= G4VERSION_ENCODE(major,minor,patch))
+
+
+#endif //WCSIM_G4UTILS_H

--- a/include/G4Utils.hh
+++ b/include/G4Utils.hh
@@ -6,10 +6,24 @@
 #define WCSIM_G4UTILS_H
 
 #include "G4Version.hh"
+#include "G4VisAttributes.hh"
 
 #define G4VERSION_ENCODE(major,minor,patch) ((major)*100 + (minor)*10 + (patch))
 
 #define G4VERSION_IS_GREATER_EQUAL(major,minor,patch) (G4VERSION_NUMBER >= G4VERSION_ENCODE(major,minor,patch))
 
+
+namespace G4Utils{
+
+  inline const G4VisAttributes& GetInvisible(){
+    // implementation wrapper
+#if G4VERSION_IS_GREATER_EQUAL(11, 0, 0)
+    return G4VisAttributes::GetInvisible();
+#else
+    return G4VisAttributes::Invisible;
+#endif
+  }
+
+}
 
 #endif //WCSIM_G4UTILS_H

--- a/include/GdNeutronHPCapture.hh
+++ b/include/GdNeutronHPCapture.hh
@@ -17,16 +17,21 @@
 #define GdNeutronHPCapture_h 1
 
 #include "globals.hh"
-#include "G4NeutronHPChannel.hh"
+#include "G4Utils.hh"
 #include "G4HadronicInteraction.hh"
 
 #include "G4SystemOfUnits.hh"
 #include "G4NeutronHPCaptureFS.hh"
-#include "G4NeutronHPDeExGammas.hh"
 #include "G4ParticleTable.hh"
 #include "G4IonTable.hh"
-#include "G4NeutronHPManager.hh"
 #include "GdNeutronHPCaptureFS.hh"
+
+#if G4VERSION_IS_GREATER_EQUAL(11, 2, 0)
+#include "G4ParticleHPChannel.hh"
+using G4NeutronHPChannel = G4ParticleHPChannel;
+#else
+#include "G4NeutronHPChannel.hh"
+#endif
 
 class GdNeutronHPCapture : public G4HadronicInteraction
 {

--- a/include/GdNeutronHPCaptureFS.hh
+++ b/include/GdNeutronHPCaptureFS.hh
@@ -19,14 +19,26 @@
 #define GdNeutronHPCaptureFS_h 1
 
 #include "globals.hh"
+#include "G4Utils.hh"
 #include "G4HadProjectile.hh"
 #include "G4HadFinalState.hh"
-#include "G4NeutronHPFinalState.hh"
 #include "G4ReactionProductVector.hh"
-#include "G4NeutronHPNames.hh"
-#include "G4NeutronHPPhotonDist.hh"
 #include "G4Nucleus.hh"
 #include "G4Fragment.hh"
+
+#if G4VERSION_IS_GREATER_EQUAL(11, 2, 0)
+#include "G4ParticleHPFinalState.hh"
+#include "G4ParticleHPNames.hh"
+#include "G4ParticleHPPhotonDist.hh"
+
+using G4NeutronHPFinalState = G4ParticleHPFinalState;
+using G4NeutronHPNames = G4ParticleHPNames;
+using G4NeutronHPPhotonDist = G4ParticleHPPhotonDist;
+#else
+#include "G4NeutronHPFinalState.hh"
+#include "G4NeutronHPNames.hh"
+#include "G4NeutronHPPhotonDist.hh"
+#endif
 
 #include "GdCaptureGammas.hh"
 
@@ -43,6 +55,14 @@ class GdNeutronHPCaptureFS : public G4NeutronHPFinalState
   ~GdNeutronHPCaptureFS()
   {
   }
+
+#if G4VERSION_IS_GREATER_EQUAL(11, 2, 0)
+  void Init(G4double A, G4double Z, G4int M, const G4String& dirName, const G4String& aFSType,
+    G4ParticleDefinition* p) override {
+    this->SetA_Z(A, Z, M);
+    this->SetProjectile(p);
+  }
+#endif
   
   void   UpdateNucleus( const G4Fragment* , G4double );
   void Init (G4double A, G4double Z, G4int M, G4String & dirName, G4String & aFSType);

--- a/include/GeometryScan.hh
+++ b/include/GeometryScan.hh
@@ -8,7 +8,12 @@
 
 #include "G4Navigator.hh"
 #include "G4TransportationManager.hh"
-#include "G4SIunits.hh"
+#include "G4Utils.hh"
+#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#include <G4SystemOfUnits.hh>
+#else
+#include <G4SIunits.hh>
+#endif
 
 /// @brief GeometryScanning Utility Namespace
 namespace GeometryScan {

--- a/src/GdNeutronHPCapture.cc
+++ b/src/GdNeutronHPCapture.cc
@@ -14,9 +14,20 @@
 #include "GdNeutronHPCapture.hh"
 /////////#include "OtherHPCaptureFS.hh"
 //#include "G4NeutronHPCaptureFS2.hh"
-#include "G4NeutronHPDeExGammas.hh"
 #include "G4ParticleTable.hh"
 #include "G4IonTable.hh"
+
+#include "G4Utils.hh"
+#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#include "G4ParticleHPDeExGammas.hh"
+#include "G4ParticleHPManager.hh"
+using G4NeutronHPDeExGammas = G4ParticleHPDeExGammas;
+using G4NeutronHPManager = G4ParticleHPManager;
+#else
+#include "G4NeutronHPDeExGammas.hh"
+#include "G4NeutronHPManager.hh"
+#endif
+
 
 #include "GdNeutronHPCaptureFS.hh"
 

--- a/src/GdNeutronHPCaptureFS.cc
+++ b/src/GdNeutronHPCaptureFS.cc
@@ -22,9 +22,17 @@
 #include "G4Nucleus.hh"
 #include "G4PhotonEvaporation.hh"
 #include "G4Fragment.hh"
-#include "G4ParticleTable.hh" 
-#include "G4NeutronHPDataUsed.hh"
+#include "G4ParticleTable.hh"
 #include "G4SystemOfUnits.hh"
+
+#include "G4Utils.hh"
+
+#if G4VERSION_IS_GREATER_EQUAL(11, 2, 0)
+#include "G4ParticleHPDataUsed.hh"
+#else
+#include "G4NeutronHPDataUsed.hh"
+#endif
+
 
 
 
@@ -188,7 +196,7 @@ void GdNeutronHPCaptureFS::UpdateNucleus( const G4Fragment* gamma , G4double eGa
   {
     G4String tString = "/FS";
     G4bool dbool;
-    G4NeutronHPDataUsed aFile = theNames.GetName(static_cast<G4int>(A), static_cast<G4int>(Z), M, dirName, tString, dbool);
+    G4ParticleHPDataUsed aFile = theNames.GetName(static_cast<G4int>(A), static_cast<G4int>(Z), M, dirName, tString, dbool);
 
     G4String filename = aFile.GetName();
     theBaseA = A;

--- a/src/WCSimConstructBeamPipe.cc
+++ b/src/WCSimConstructBeamPipe.cc
@@ -1,5 +1,6 @@
 #include "WCSimDetectorConstruction.hh"
 
+#include "G4Utils.hh"
 #include "G4Box.hh"
 #include "G4NistManager.hh"
 #include "G4LogicalVolume.hh"
@@ -183,7 +184,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructBeamPipe()
       G4LogicalVolume* logicAssembly = new G4LogicalVolume(solidAssembly, 
                                                            airMaterial, 
                                                            "T5_AssemblyLogic" + suffix);
-      logicAssembly->SetVisAttributes(G4VisAttributes::Invisible); // Hide container
+      logicAssembly->SetVisAttributes(G4Utils::GetInvisible()); // Hide container
 
       // 2. Create Component Solids (All share X/Y dimensions of the container)
       G4Box* sVinyl = new G4Box("T5_Vinyl"+suffix, halfLenX, halfHgtY, t_vinyl/2.0);

--- a/src/WCSimConstructCylinder.cc
+++ b/src/WCSimConstructCylinder.cc
@@ -1,6 +1,7 @@
 //  -*- mode:c++; tab-width:4;  -*-
 #include "WCSimDetectorConstruction.hh"
 
+#include "G4Utils.hh"
 #include "G4Material.hh"
 #include "G4Element.hh"
 #include "G4Box.hh"
@@ -219,7 +220,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   G4VisAttributes* showColor = new G4VisAttributes(G4Colour(0.0,1.0,0.0));
   logicWC->SetVisAttributes(showColor);
 
-  logicWC->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+  logicWC->SetVisAttributes(G4Utils::GetInvisible()); //amb79
   
   //-----------------------------------------------------
   // everything else is contained in this water tubs
@@ -282,7 +283,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
     G4VisAttributes *showTyvekCave = new G4VisAttributes(green);
     showTyvekCave->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
     logicCaveTyvek->SetVisAttributes(showTyvekCave);
-    //logicCaveTyvek->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+    //logicCaveTyvek->SetVisAttributes(G4Utils::GetInvisible()); //amb79
 
     //-----------------------------------------------------
     // Cylinder caps' tyvek
@@ -307,7 +308,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
     G4VisAttributes *CapsCaveTyvekVisAtt = new G4VisAttributes(yellow);
     CapsCaveTyvekVisAtt->SetForceWireframe(true);
     logicCaveCapsTyvek->SetVisAttributes(CapsCaveTyvekVisAtt);
-    //logicCaveCapsTyvek->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+    //logicCaveCapsTyvek->SetVisAttributes(G4Utils::GetInvisible()); //amb79
 
     G4ThreeVector CaveTyvekPosition(0., 0., WCLength / 2);
 
@@ -338,11 +339,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 
   // This volume needs to made invisible to view the blacksheet and PMTs with RayTracer
   if (Vis_Choice == "RayTracer")
-	{logicWCBarrel->SetVisAttributes(G4VisAttributes::Invisible);} 
+	{logicWCBarrel->SetVisAttributes(G4Utils::GetInvisible());}
 
   else
 	{//{if(!debugMode)
-	  G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4VisAttributes::Invisible);
+	  G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Utils::GetInvisible());
 	  tmpVisAtt->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
 	  logicWCBarrel->SetVisAttributes(tmpVisAtt);
 	}
@@ -416,7 +417,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 					  0,
 					  checkOverlaps);
   if(!debugMode)
-	logicWCBarrelAnnulus->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+	logicWCBarrelAnnulus->SetVisAttributes(G4Utils::GetInvisible()); //amb79
 
   //-----------------------------------------------------
   // Subdivide the BarrelAnnulus into rings
@@ -452,7 +453,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 	  tmpVisAtt->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
 	  logicWCBarrelRing->SetVisAttributes(tmpVisAtt);
 	  //If you want the rings on the Annulus to show in OGLSX, then comment out the line below.
-	  logicWCBarrelRing->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelRing->SetVisAttributes(G4Utils::GetInvisible());
 	}
   else {
 	G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(0,0.5,1.));
@@ -494,7 +495,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 	  tmpVisAtt->SetForceSolid(true);// This line is used to give definition to the cells in OGLSX Visualizer
 	  logicWCBarrelCell->SetVisAttributes(tmpVisAtt); 
 	  //If you want the columns on the Annulus to show in OGLSX, then comment out the line below.
-	  logicWCBarrelCell->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelCell->SetVisAttributes(G4Utils::GetInvisible());
 	}
   else {
   	G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
@@ -569,14 +570,14 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 	if(!debugMode)
 	  logicWCBarrelCellBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);
 	else
-	  logicWCBarrelCellBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);}
+	  logicWCBarrelCellBlackSheet->SetVisAttributes(G4Utils::GetInvisible());}
 
   else {
 
 	G4VisAttributes* WCBarrelBlackSheetCellVisAtt 
       = new G4VisAttributes(G4Colour(0.2,0.9,0.2));
 	if(!debugMode)
-	  logicWCBarrelCellBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelCellBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
 	else
 	  logicWCBarrelCellBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);}
 
@@ -642,7 +643,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 
  
 
-    logicWCExtraTower->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCExtraTower->SetVisAttributes(G4Utils::GetInvisible());
 	//-------------------------------------------
 	// subdivide the extra tower into cells  
 	//------------------------------------------
@@ -672,7 +673,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
     G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
   	tmpVisAtt->SetForceSolid(true);// This line is used to give definition to the cells in OGLSX Visualizer
   	//logicWCExtraTowerCell->SetVisAttributes(tmpVisAtt); 
-	logicWCExtraTowerCell->SetVisAttributes(G4VisAttributes::Invisible);
+	logicWCExtraTowerCell->SetVisAttributes(G4Utils::GetInvisible());
 	//TF vis.
 
     //---------------------------------------------
@@ -728,7 +729,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 		= new G4VisAttributes(G4Colour(0.2,0.9,0.2)); // green color
 
 	  if(!debugMode)
-		{logicWCTowerBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);}
+		{logicWCTowerBlackSheet->SetVisAttributes(G4Utils::GetInvisible());}
 	  else
 		{logicWCTowerBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);}}
   
@@ -750,7 +751,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 		= new G4VisAttributes(G4Colour(0.2,0.9,0.2)); // green color
 
 	  if(!debugMode)
-		{logicWCTowerBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);}
+		{logicWCTowerBlackSheet->SetVisAttributes(G4Utils::GetInvisible());}
 	  else
 		{logicWCTowerBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);}}
   
@@ -915,7 +916,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 
   /*These lines of code will give color and volume to the PMTs if it hasn't been set in WCSimConstructPMT.cc.
 	I recommend setting them in WCSimConstructPMT.cc. 
-	If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the SetVisAttributes(G4VisAttributes::Invisible) line.*/
+	If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the SetVisAttributes(G4Utils::GetInvisible()) line.*/
   
   G4VisAttributes* WClogic 
 	= new G4VisAttributes(G4Colour(0.4,0.0,0.8));
@@ -923,7 +924,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   WClogic->SetForceAuxEdgeVisible(true);
 
   //logicWCPMT->SetVisAttributes(WClogic);
-  //logicWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+  //logicWCPMT->SetVisAttributes(G4Utils::GetInvisible());
 
   //jl145------------------------------------------------
   // Add top veto PMTs
@@ -1233,8 +1234,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 	  new G4VisAttributes(yellow);
     WCCapsODTyvekCellVisAtt->SetForceWireframe(true);
 
-    logicWCODTopCapTyvek->SetVisAttributes(G4VisAttributes::Invisible);
-	logicWCODBotCapTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCODTopCapTyvek->SetVisAttributes(G4Utils::GetInvisible());
+	logicWCODBotCapTyvek->SetVisAttributes(G4Utils::GetInvisible());
     //// Uncomment following for TYVEK visualization
     logicWCODTopCapTyvek->SetVisAttributes(WCCapsODTyvekCellVisAtt);
 	logicWCODBotCapTyvek->SetVisAttributes(WCCapsODTyvekCellVisAtt);
@@ -1298,7 +1299,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
     WCBarrelODTyvekCellVisAtt->SetForceWireframe(true);
     WCBarrelODTyvekCellVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
 
-    logicWCBarrelCellODTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCBarrelCellODTyvek->SetVisAttributes(G4Utils::GetInvisible());
     //// Uncomment following for TYVEK visualization
     logicWCBarrelCellODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -1424,7 +1425,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
 	  new G4LogicalSkinSurface("WaterExtraTySurfaceSide", logicWCTowerODTyvek, OpWaterTySurface);
 
 
-      logicWCTowerODTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCTowerODTyvek->SetVisAttributes(G4Utils::GetInvisible());
       //// Uncomment following for TYVEK visualization
       logicWCTowerODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -1553,11 +1554,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinder()
   // These lines make the large cap volume invisible to view the caps blacksheets. Need to make invisible for
   // RayTracer
   if (Vis_Choice == "RayTracer"){
-	logicBottomCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
-	logicTopCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
+	logicBottomCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
+	logicTopCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
   } else {
-	logicBottomCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
-	logicTopCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
+	logicBottomCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
+	logicTopCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
   }
 
   //G4VPhysicalVolume* physiTopCapAssembly =
@@ -1613,7 +1614,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
                         caname,
                         0,0,0);
 
-  G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4VisAttributes::Invisible);
+  G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Utils::GetInvisible());
   tmpVisAtt->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
   logicCapAssembly->SetVisAttributes(tmpVisAtt);
 
@@ -1668,7 +1669,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
     tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
   	tmpVisAtt->SetForceSolid(true);// This line is used to give definition to the cells in OGLSX Visualizer
   	//logicWCBarrelBorderRing->SetVisAttributes(tmpVisAtt); 
-    logicWCBarrelBorderRing->SetVisAttributes(G4VisAttributes::Invisible); 
+    logicWCBarrelBorderRing->SetVisAttributes(G4Utils::GetInvisible());
 	//TF vis.
   }
 
@@ -1738,15 +1739,15 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
 	  tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
 	  tmpVisAtt->SetForceSolid(true);
 	  logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt);
-	  logicWCBarrelBorderCell->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelBorderCell->SetVisAttributes(G4Utils::GetInvisible());
 	  logicWCBarrelBorderCellBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);
         }
 	else {
 	  tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
 	  tmpVisAtt->SetForceWireframe(true);
 	  logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt);
-	  logicWCBarrelBorderCell->SetVisAttributes(G4VisAttributes::Invisible);
-	  logicWCBarrelBorderCellBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelBorderCell->SetVisAttributes(G4Utils::GetInvisible());
+	  logicWCBarrelBorderCellBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
         }
   }
   // used for OGLSX
@@ -1758,8 +1759,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
 	  tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
 	  tmpVisAtt->SetForceSolid(true);
 	  logicWCBarrelBorderCell->SetVisAttributes(tmpVisAtt);
-	  logicWCBarrelBorderCell->SetVisAttributes(G4VisAttributes::Invisible);
-	  logicWCBarrelBorderCellBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelBorderCell->SetVisAttributes(G4Utils::GetInvisible());
+	  logicWCBarrelBorderCellBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
 	}
 	else {
 	  tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
@@ -1838,7 +1839,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
     tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
   	tmpVisAtt->SetForceSolid(true);// This line is used to give definition to the cells in OGLSX Visualizer
   	logicWCExtraBorderCell->SetVisAttributes(tmpVisAtt); 
-    logicWCExtraBorderCell->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCExtraBorderCell->SetVisAttributes(G4Utils::GetInvisible());
     //TF vis.
 
 
@@ -1977,7 +1978,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
 	  tmpVisAtt = new G4VisAttributes(G4Colour(1,0.5,0.5));
 	  tmpVisAtt->SetForceSolid(true);
 	  logicWCCap->SetVisAttributes(tmpVisAtt);
-	  logicWCCap->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCCap->SetVisAttributes(G4Utils::GetInvisible());
 
 	} else{
 	
@@ -1992,7 +1993,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
 	  tmpVisAtt = new G4VisAttributes(G4Colour(1.,0.5,0.5));
 	  tmpVisAtt->SetForceSolid(true);// This line is used to give definition to the cells in OGLSX Visualizer
 	  //logicWCCap->SetVisAttributes(tmpVisAtt); 
-	  logicWCCap->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCCap->SetVisAttributes(G4Utils::GetInvisible());
 	  //TF vis.
 
 	} else
@@ -2100,7 +2101,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
 	  = new G4VisAttributes(G4Colour(0.9,0.2,0.2));
  
 	if(!debugMode)
-	  logicWCCapBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCCapBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
     else
 	  logicWCCapBlackSheet->SetVisAttributes(WCCapBlackSheetVisAtt);
   }//OGLSX
@@ -2112,7 +2113,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
 	  = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
 
 	if(!debugMode)
-	  //logicWCCapBlackSheet->SetVisAttributes(G4VisAttributes::Invisible); //Use this line if you want to make the blacksheet on the caps invisible to view through
+	  //logicWCCapBlackSheet->SetVisAttributes(G4Utils::GetInvisible()); //Use this line if you want to make the blacksheet on the caps invisible to view through
 	  logicWCCapBlackSheet->SetVisAttributes(WCCapBlackSheetVisAtt);
     else
 	  logicWCCapBlackSheet->SetVisAttributes(WCCapBlackSheetVisAtt);
@@ -2362,7 +2363,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
     WCBarrelODTyvekCellVisAtt->SetForceWireframe(true);
     WCBarrelODTyvekCellVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
 
-    logicWCBarrelBorderCellODTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCBarrelBorderCellODTyvek->SetVisAttributes(G4Utils::GetInvisible());
     //// Uncomment following for TYVEK visualization
     logicWCBarrelBorderCellODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -2447,7 +2448,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
                              logicWCODCapTyvek,
                              OpWaterTySurface);
 
-	logicWCODCapTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+	logicWCODCapTyvek->SetVisAttributes(G4Utils::GetInvisible());
     //// Uncomment following for TYVEK visualization
     logicWCODCapTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -2517,7 +2518,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCaps(G4bool flipz)
                                logicWCExtraBorderCellODTyvek,
                                OpWaterTySurface);
 
-      logicWCExtraBorderCellODTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCExtraBorderCellODTyvek->SetVisAttributes(G4Utils::GetInvisible());
       //// Uncomment following for TYVEK visualization
       logicWCExtraBorderCellODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -2779,7 +2780,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
    G4VisAttributes* showColor = new G4VisAttributes(G4Colour(0.0,1.0,0.0));
    logicWC->SetVisAttributes(showColor);
 
-   logicWC->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+   logicWC->SetVisAttributes(G4Utils::GetInvisible()); //amb79
   
   //-----------------------------------------------------
   // everything else is contained in this water tubs
@@ -2840,7 +2841,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
     G4VisAttributes *showTyvekCave = new G4VisAttributes(green);
     showTyvekCave->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
     logicCaveTyvek->SetVisAttributes(showTyvekCave);
-    //logicCaveTyvek->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+    //logicCaveTyvek->SetVisAttributes(G4Utils::GetInvisible()); //amb79
 
     //-----------------------------------------------------
     // Cylinder caps' tyvek
@@ -2865,7 +2866,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
     G4VisAttributes *CapsCaveTyvekVisAtt = new G4VisAttributes(yellow);
     CapsCaveTyvekVisAtt->SetForceWireframe(true);
     logicCaveCapsTyvek->SetVisAttributes(CapsCaveTyvekVisAtt);
-    //logicCaveCapsTyvek->SetVisAttributes(G4VisAttributes::Invisible); //amb79
+    //logicCaveCapsTyvek->SetVisAttributes(G4Utils::GetInvisible()); //amb79
 
     G4ThreeVector CaveTyvekPosition(0., 0., WCLength / 2);
 
@@ -2899,11 +2900,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 
   // This volume needs to made invisible to view the blacksheet and PMTs with RayTracer
   if (Vis_Choice == "RayTracer")
-   {logicWCBarrel->SetVisAttributes(G4VisAttributes::Invisible);} 
+   {logicWCBarrel->SetVisAttributes(G4Utils::GetInvisible());}
 
   else
    {//{if(!debugMode)
-    G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4VisAttributes::Invisible);
+    G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Utils::GetInvisible());
 	  tmpVisAtt->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
 	  logicWCBarrel->SetVisAttributes(tmpVisAtt);
    }
@@ -2956,7 +2957,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 	  tmpVisAtt->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
 	  logicWCBarrelAnnulus->SetVisAttributes(tmpVisAtt);
 	  //If you want the rings on the Annulus to show in OGLSX, then comment out the line below.
-	  logicWCBarrelAnnulus->SetVisAttributes(G4VisAttributes::Invisible);
+	  logicWCBarrelAnnulus->SetVisAttributes(G4Utils::GetInvisible());
   }
   else {
     G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Colour(0,0.5,1.));
@@ -3062,7 +3063,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 			0,
 			checkOverlaps);
 
-    logicWCExtraTower->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCExtraTower->SetVisAttributes(G4Utils::GetInvisible());
 
     //---------------------------------------------
     // add blacksheet to this cells
@@ -3258,7 +3259,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 
   /*These lines of code will give color and volume to the PMTs if it hasn't been set in WCSimConstructPMT.cc.
   I recommend setting them in WCSimConstructPMT.cc. 
-  If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the SetVisAttributes(G4VisAttributes::Invisible) line.*/
+  If used here, uncomment the SetVisAttributes(WClogic) line, and comment out the SetVisAttributes(G4Utils::GetInvisible()) line.*/
   
   G4VisAttributes* WClogic 
       = new G4VisAttributes(G4Colour(0.4,0.0,0.8));
@@ -3266,7 +3267,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 	WClogic->SetForceAuxEdgeVisible(true);
 
   //logicWCPMT->SetVisAttributes(WClogic);
-	//logicWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+	//logicWCPMT->SetVisAttributes(G4Utils::GetInvisible());
 
   //jl145------------------------------------------------
   // Add top veto PMTs
@@ -3606,7 +3607,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
     }
     else
     {
-      logicWCBarrelAnnulusBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCBarrelAnnulusBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
     }
   }
 
@@ -3616,7 +3617,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
       = new G4VisAttributes(G4Colour(0.2,0.9,0.2));
     if(!debugMode)
     {
-      logicWCBarrelAnnulusBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCBarrelAnnulusBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
     }
     else
     {
@@ -3626,7 +3627,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 
   if(!(WCBarrelRingNPhi*WCPMTperCellHorizontal == WCBarrelNumPMTHorizontal))
   {
-    logicWCExtraTower->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCExtraTower->SetVisAttributes(G4Utils::GetInvisible());
 
     G4Polyhedra* solidWCTowerBlackSheet = new G4Polyhedra("WCExtraTowerBlackSheet",
 			   totalAngle-2.*pi+barrelPhiOffset,//+dPhi/2., // phi start
@@ -3688,7 +3689,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
         = new G4VisAttributes(G4Colour(0.2,0.9,0.2)); // green color
 
       if(!debugMode)
-        {logicWCTowerBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);}
+        {logicWCTowerBlackSheet->SetVisAttributes(G4Utils::GetInvisible());}
       else
         {logicWCTowerBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);}
     }
@@ -3829,8 +3830,8 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
 	  new G4VisAttributes(yellow);
     WCCapsODTyvekCellVisAtt->SetForceWireframe(true);
 
-    logicWCODTopCapTyvek->SetVisAttributes(G4VisAttributes::Invisible);
-	  logicWCODBotCapTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCODTopCapTyvek->SetVisAttributes(G4Utils::GetInvisible());
+	  logicWCODBotCapTyvek->SetVisAttributes(G4Utils::GetInvisible());
     //// Uncomment following for TYVEK visualization
     logicWCODTopCapTyvek->SetVisAttributes(WCCapsODTyvekCellVisAtt);
 	  logicWCODBotCapTyvek->SetVisAttributes(WCCapsODTyvekCellVisAtt);
@@ -3895,7 +3896,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
     WCBarrelODTyvekCellVisAtt->SetForceWireframe(true);
     WCBarrelODTyvekCellVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
 
-    logicWCBarrelODTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCBarrelODTyvek->SetVisAttributes(G4Utils::GetInvisible());
     //// Uncomment following for TYVEK visualization
     logicWCBarrelODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -4087,7 +4088,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
         new G4LogicalSkinSurface("WaterExtraTySurfaceSide", logicWCTowerODTyvek, OpWaterTySurface);
 
 
-        logicWCTowerODTyvek->SetVisAttributes(G4VisAttributes::Invisible);
+        logicWCTowerODTyvek->SetVisAttributes(G4Utils::GetInvisible());
         //// Uncomment following for TYVEK visualization
         logicWCTowerODTyvek->SetVisAttributes(WCBarrelODTyvekCellVisAtt);
 
@@ -4263,11 +4264,11 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCylinderNoReplica()
  // These lines make the large cap volume invisible to view the caps blacksheets. Need to make invisible for 
  // RayTracer
   if (Vis_Choice == "RayTracer"){
-    logicBottomCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
-    logicTopCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
+    logicBottomCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
+    logicTopCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
   } else {
-    logicBottomCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
-    logicTopCapAssembly->SetVisAttributes(G4VisAttributes::Invisible);
+    logicBottomCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
+    logicTopCapAssembly->SetVisAttributes(G4Utils::GetInvisible());
   }
 
   //G4VPhysicalVolume* physiTopCapAssembly =
@@ -4326,7 +4327,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
                         caname,
                         0,0,0);
 
-  G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4VisAttributes::Invisible);
+  G4VisAttributes* tmpVisAtt = new G4VisAttributes(G4Utils::GetInvisible());
   tmpVisAtt->SetForceWireframe(true);// This line is used to give definition to the rings in OGLSX Visualizer
   logicCapAssembly->SetVisAttributes(tmpVisAtt);
   
@@ -4898,7 +4899,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
     }
     else
     {
-      logicWCBarrelBorderBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCBarrelBorderBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
     }
   }
 
@@ -4908,7 +4909,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
       = new G4VisAttributes(G4Colour(0.2,0.9,0.2));
     if(!debugMode)
     {
-      logicWCBarrelBorderBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCBarrelBorderBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
     }
     else
     {
@@ -4971,7 +4972,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
         = new G4VisAttributes(G4Colour(0.2,0.9,0.2)); // green color
 
       if(!debugMode)
-        {logicWCExtraBorderBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);}
+        {logicWCExtraBorderBlackSheet->SetVisAttributes(G4Utils::GetInvisible());}
       else
         {logicWCExtraBorderBlackSheet->SetVisAttributes(WCBarrelBlackSheetCellVisAtt);}
     }
@@ -5005,7 +5006,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
     = new G4VisAttributes(G4Colour(0.9,0.2,0.2));
 
     if(!debugMode)
-      logicWCCapBlackSheet->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCCapBlackSheet->SetVisAttributes(G4Utils::GetInvisible());
     else
       logicWCCapBlackSheet->SetVisAttributes(WCCapBlackSheetVisAtt);}
 
@@ -5016,7 +5017,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCapsNoReplica(G4bool flipz)
     = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
 
     if(!debugMode)
-      //logicWCCapBlackSheet->SetVisAttributes(G4VisAttributes::Invisible); //Use this line if you want to make the blacksheet on the caps invisible to view through
+      //logicWCCapBlackSheet->SetVisAttributes(G4Utils::GetInvisible()); //Use this line if you want to make the blacksheet on the caps invisible to view through
       logicWCCapBlackSheet->SetVisAttributes(WCCapBlackSheetVisAtt);
     else
       logicWCCapBlackSheet->SetVisAttributes(WCCapBlackSheetVisAtt);}

--- a/src/WCSimConstructEggShapedHyperK.cc
+++ b/src/WCSimConstructEggShapedHyperK.cc
@@ -1,6 +1,7 @@
 //  -*- mode:c++; tab-width:4;  -*-
 #include "WCSimDetectorConstruction.hh"
 
+#include "G4Utils.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4ThreeVector.hh"
 #include "G4RotationMatrix.hh"
@@ -59,7 +60,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructEggShapedHyperK()
                                     waterTank_Length/2.+blackSheetThickness),
                                     FindMaterial("G4_AIR"),
                                     "EggShapedHyperK");
-  eggShapedHyperKLV->SetVisAttributes(G4VisAttributes::Invisible);
+  eggShapedHyperKLV->SetVisAttributes(G4Utils::GetInvisible());
 
   new G4LogicalSkinSurface("WaterBSSurface",eggShapedHyperKLV,OpWaterBSSurface);
 
@@ -109,7 +110,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructEggShapedHyperK()
 
   waterTankLV 
     = new G4LogicalVolume(waterTank_union,FindMaterial("G4_WATER"),"Tank");
-  waterTankLV->SetVisAttributes(G4VisAttributes::Invisible);
+  waterTankLV->SetVisAttributes(G4Utils::GetInvisible());
 
   new G4PVPlacement(0,G4ThreeVector(0,waterTank_Height/4.,0),
                     waterTankLV,"Tank",eggShapedHyperKLV,false,0,checkOverlaps);
@@ -405,7 +406,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructRadialPMT(G4bool top,
                                      -phi/2.,phi),
                           FindMaterial("G4_WATER"),
                           "PMTAnnulus");
-  pmtAnnulusLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtAnnulusLV->SetVisAttributes(G4Utils::GetInvisible());
 
   G4LogicalVolume* blackSheetALV = NULL;
   if (inner) {
@@ -427,7 +428,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructRadialPMT(G4bool top,
                                      -phi/2.,phi),
                           FindMaterial("G4_WATER"),
                           "PMTRings");
-  pmtRingLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtRingLV->SetVisAttributes(G4Utils::GetInvisible());
 
   G4LogicalVolume* pmtCellLV
     = new G4LogicalVolume(new G4Tubs("PMTCell",
@@ -436,7 +437,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructRadialPMT(G4bool top,
                                      -dphi/2.,dphi),
                           FindMaterial("G4_WATER"),
                           "PMTCell");
-  pmtCellLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtCellLV->SetVisAttributes(G4Utils::GetInvisible());
 
 //-----------------------------------------------------------------
 //
@@ -515,7 +516,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructEndWallPMT()
                                     innerPMT_Apitch/2.),
                           FindMaterial("G4_WATER"),
                           "PMTCell");
-  pmtCellLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtCellLV->SetVisAttributes(G4Utils::GetInvisible());
 
   G4RotationMatrix* rotm = new G4RotationMatrix();
   rotm->rotateY(180.*degree);
@@ -576,7 +577,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructEndWallPMT()
                                       innerPMT_Apitch/2.),
                             FindMaterial("G4_WATER"),
                             "PMTSlab");
-    pmtSlabLV->SetVisAttributes(G4VisAttributes::Invisible);
+    pmtSlabLV->SetVisAttributes(G4Utils::GetInvisible());
 
     new G4PVReplica("PMTCell",
                     pmtCellLV,
@@ -635,7 +636,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCeilingPMT(G4bool top,
                                       zlength/2.),
                             FindMaterial("G4_WATER"),
                             "PMTSlab");
-  pmtSlabLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtSlabLV->SetVisAttributes(G4Utils::GetInvisible());
 
   G4LogicalVolume* blackSheetYLV = NULL;
   if (inner) {
@@ -657,7 +658,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCeilingPMT(G4bool top,
                                       pitch/2.),
                             FindMaterial("G4_WATER"),
                             "PMTSlab");
-  pmtSliceLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtSliceLV->SetVisAttributes(G4Utils::GetInvisible());
 
   G4LogicalVolume* pmtCellLV
     = new G4LogicalVolume(new G4Box("PMTCell",
@@ -666,7 +667,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructCeilingPMT(G4bool top,
                                     pitch/2.),
                           FindMaterial("G4_WATER"),
                           "PMTCell");
-  pmtCellLV->SetVisAttributes(G4VisAttributes::Invisible);
+  pmtCellLV->SetVisAttributes(G4Utils::GetInvisible());
 
   G4VPhysicalVolume* pmtSlicePV
     = new G4PVReplica("PMTSlice",

--- a/src/WCSimConstructExSituMultiPMT.cc
+++ b/src/WCSimConstructExSituMultiPMT.cc
@@ -1,5 +1,6 @@
 #include "WCSimDetectorConstruction.hh"
 
+#include "G4Utils.hh"
 #include "G4Box.hh"
 #include "G4Sphere.hh"
 #include "G4Cons.hh"
@@ -90,7 +91,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructExSituPMT(G4String PMTName,
   } else{
     G4VisAttributes* WCPMTVisAttGrey = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
     WCPMTVisAttGrey->SetForceSolid(true);
-    logicWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCPMT->SetVisAttributes(G4Utils::GetInvisible());
     logicWCPMT->SetVisAttributes(WCPMTVisAttGrey);                   
   }
 
@@ -253,7 +254,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructExSituPMT(G4String PMTName,
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
     WCPMTVisAtt->SetForceSolid(true); // force the object to be visualized with a surface
     WCPMTVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
 
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
   } else {
@@ -264,7 +265,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructExSituPMT(G4String PMTName,
     //WCPMTVisAtt->SetForceWireframe(true);
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,0.0)); //better for seeing geometry
     WCPMTVisAtt->SetForceSolid(true);
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
 
   }
@@ -312,7 +313,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructExSituPMT(G4String PMTName,
     logicInteriorWCPMT->SetVisAttributes(WCPMTVisAtt);
   } else {
     // Making the inner portion of the detector invisible for OGLSX visualization
-    logicInteriorWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    logicInteriorWCPMT->SetVisAttributes(G4Utils::GetInvisible());
   }
 
   //Add Logical Border Surface

--- a/src/WCSimConstructInSituMultiPMT.cc
+++ b/src/WCSimConstructInSituMultiPMT.cc
@@ -1,5 +1,6 @@
 #include "WCSimDetectorConstruction.hh"
 
+#include "G4Utils.hh"
 #include "G4Box.hh"
 #include "G4Sphere.hh"
 #include "G4Cons.hh"
@@ -91,7 +92,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructInSituPMT(G4String PMTName,
   } else{
     G4VisAttributes* WCPMTVisAttGrey = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
     WCPMTVisAttGrey->SetForceSolid(true);
-    logicWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    logicWCPMT->SetVisAttributes(G4Utils::GetInvisible());
     logicWCPMT->SetVisAttributes(WCPMTVisAttGrey);                   
   }
 
@@ -253,7 +254,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructInSituPMT(G4String PMTName,
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
     WCPMTVisAtt->SetForceSolid(true); // force the object to be visualized with a surface
     WCPMTVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
 
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
   } else {
@@ -264,7 +265,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructInSituPMT(G4String PMTName,
     //WCPMTVisAtt->SetForceWireframe(true);
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,0.0)); //better for seeing geometry
     WCPMTVisAtt->SetForceSolid(true);
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
 
   }
@@ -312,7 +313,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructInSituPMT(G4String PMTName,
     logicInteriorWCPMT->SetVisAttributes(WCPMTVisAtt);
   } else {
     // Making the inner portion of the detector invisible for OGLSX visualization
-    logicInteriorWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    logicInteriorWCPMT->SetVisAttributes(G4Utils::GetInvisible());
   }
 
   //Add Logical Border Surface

--- a/src/WCSimConstructPMT.cc
+++ b/src/WCSimConstructPMT.cc
@@ -1,5 +1,6 @@
 #include "WCSimDetectorConstruction.hh"
 
+#include "G4Utils.hh"
 #include "G4Box.hh"
 #include "G4Sphere.hh"
 #include "G4Tubs.hh"
@@ -204,7 +205,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
       // Makes the volume containg the PMT invisible for normal visualization
       G4VisAttributes* WCPMTVisAttGrey = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
       WCPMTVisAttGrey->SetForceSolid(true);
-      logicWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+      logicWCPMT->SetVisAttributes(G4Utils::GetInvisible());
       logicWCPMT->SetVisAttributes(WCPMTVisAttGrey);                   //TF debug overlaps with this volume
     }
   }
@@ -263,7 +264,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
     logicInteriorWCPMT->SetVisAttributes(WCPMTVisAtt);
   } else {
     // Making the inner portion of the detector invisible for OGLSX visualization
-    logicInteriorWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    logicInteriorWCPMT->SetVisAttributes(G4Utils::GetInvisible());
   }
 
   /////////////////////////////
@@ -306,7 +307,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
       // used in OGLSX visualizer
       G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
       WCPMTVisAtt->SetForceWireframe(true);
-      //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+      //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
       logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);}
 
   if (Vis_Choice == "RayTracer"){
@@ -315,7 +316,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
     WCPMTVisAtt->SetForceSolid(true); // force the object to be visualized with a surface
     WCPMTVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
 
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
   } else {
@@ -326,7 +327,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
     //WCPMTVisAtt->SetForceWireframe(true);
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,0.0)); //better for seeing geometry
     WCPMTVisAtt->SetForceSolid(true);
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
 
   }
@@ -601,7 +602,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
 
   else{
     // Makes the volume containg the PMT invisible for normal visualization
-    logicWCPMT->SetVisAttributes(G4VisAttributes::Invisible);}
+    logicWCPMT->SetVisAttributes(G4Utils::GetInvisible());}
 
 
   //Create PMT Interior
@@ -644,7 +645,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
 
   else {
     // Making the inner portion of the detector invisible for OGLSX visualization
-    logicInteriorWCPMT->SetVisAttributes(G4VisAttributes::Invisible);}
+    logicInteriorWCPMT->SetVisAttributes(G4Utils::GetInvisible());}
 
 
   //Create PMT Glass Face
@@ -703,13 +704,13 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
     if(detectorElement == "OD") WCPMTVisAtt = new G4VisAttributes(G4Colour(1.0, 0.0, 0.0));
     else WCPMTVisAtt = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
     WCPMTVisAtt->SetForceWireframe(true);
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);
     G4VisAttributes* WCLCVisAtt = new G4VisAttributes(G4Colour(.3,.3,0.));
     WCLCVisAtt->SetForceWireframe(true);
     WCLCVisAtt->SetForceAuxEdgeVisible(true);
     //WCLCVisAtt->SetForceSolid(true);
-    //logicLightCone->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicLightCone->SetVisAttributes(G4Utils::GetInvisible());
     if (logicLightCone!=NULL)
       logicLightCone->SetVisAttributes(WCLCVisAtt);
   }
@@ -720,7 +721,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
     G4VisAttributes* WCPMTVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,1.0));
     WCPMTVisAtt->SetForceSolid(true); // force the object to be visualized with a surface
     WCPMTVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
-    //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+    //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
 
     logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);}
 
@@ -732,7 +733,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMT(G4String PMTName, G4Str
       else WCPMTVisAtt = new G4VisAttributes(G4Colour(0.2,0.2,0.2));
       WCPMTVisAtt->SetForceWireframe(true);
       WCPMTVisAtt->SetForceAuxEdgeVisible(true); // force auxiliary edges to be shown
-      //logicGlassFaceWCPMT->SetVisAttributes(G4VisAttributes::Invisible);
+      //logicGlassFaceWCPMT->SetVisAttributes(G4Utils::GetInvisible());
       logicGlassFaceWCPMT->SetVisAttributes(WCPMTVisAtt);}
 
   // Instantiate a new sensitive detector
@@ -822,7 +823,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
       = new G4VisAttributes(G4Colour(0.0, 1.0, 0.0));
   visContainer->SetForceWireframe(true);
 
-  logicContainer->SetVisAttributes(G4VisAttributes::Invisible);
+  logicContainer->SetVisAttributes(G4Utils::GetInvisible());
   //// Uncomment following for WLS visualization
   logicContainer->SetVisAttributes(visContainer);
 
@@ -887,7 +888,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
       = new G4VisAttributes(G4Colour(0.0, 1.0, 1.0));
   visWLS->SetForceSolid(true);
 
-  logicWCODWLSPlate->SetVisAttributes(G4VisAttributes::Invisible);
+  logicWCODWLSPlate->SetVisAttributes(G4Utils::GetInvisible());
   //// Uncomment following for WLS visualization
   logicWCODWLSPlate->SetVisAttributes(visWLS);
 
@@ -903,7 +904,7 @@ G4LogicalVolume* WCSimDetectorConstruction::ConstructPMTAndWLSPlate(G4String PMT
       = new G4VisAttributes(G4Colour(1.0, 1.0, 1.0));
   visWLSCladding->SetForceSolid(true);
 
-  logicWCODWLSPlateCladding->SetVisAttributes(G4VisAttributes::Invisible);
+  logicWCODWLSPlateCladding->SetVisAttributes(G4Utils::GetInvisible());
   //// Uncomment following for WLS visualization
   logicWCODWLSPlateCladding->SetVisAttributes(visWLSCladding);
 

--- a/src/WCSimDetectorConstruction.cc
+++ b/src/WCSimDetectorConstruction.cc
@@ -2,6 +2,7 @@
 #include "WCSimDetectorMessenger.hh"
 #include "WCSimTuningParameters.hh"
 
+#include "G4Utils.hh"
 #include "G4Element.hh"
 #include "G4Box.hh"
 #include "G4Tubs.hh"
@@ -375,8 +376,8 @@ G4VPhysicalVolume* WCSimDetectorConstruction::Construct()
 
   // Now set the visualization attributes of the logical volumes.
 
-  //   logicWCBox->SetVisAttributes(G4VisAttributes::Invisible);
-  logicExpHall->SetVisAttributes(G4VisAttributes::Invisible);
+  //   logicWCBox->SetVisAttributes(G4Utils::GetInvisible());
+  logicExpHall->SetVisAttributes(G4Utils::GetInvisible());
 
   //----------------------------------------------------------
   //BGO Calling and Placement - Diego Costas 29/02/2024 

--- a/src/WCSimLC.cc
+++ b/src/WCSimLC.cc
@@ -1,6 +1,7 @@
 #include "G4UnitsTable.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
+#include "G4Utils.hh"
 
 #include "WCSimLC.hh"
 
@@ -17,9 +18,10 @@
 #include "G4VisAttributes.hh"
 
 #include <vector>
+
 using namespace std;
 
-G4OpticalSurface * WCSimLC::OpLCMirrorSurface = NULL;
+G4OpticalSurface * WCSimLC::OpLCMirrorSurface = nullptr;
 
 WCSimLC::WCSimLC(
 		const G4String &name, 
@@ -192,6 +194,10 @@ G4double WCSimLC::Tsukada_z_from_r (double radius)
 
 void WCSimLC::SetInvisible()
 {
+#if G4VERSION_IS_GREATER_EQUAL(11, 2, 0)
+	this->SetVisAttributes(G4VisAttributes::GetInvisible());
+#else
 	this->SetVisAttributes(G4VisAttributes::Invisible);
+#endif
 
 }

--- a/src/WCSimLC.cc
+++ b/src/WCSimLC.cc
@@ -194,7 +194,7 @@ G4double WCSimLC::Tsukada_z_from_r (double radius)
 
 void WCSimLC::SetInvisible()
 {
-#if G4VERSION_IS_GREATER_EQUAL(11, 2, 0)
+#if G4VERSION_IS_GREATER_EQUAL(11, 0, 0)
 	this->SetVisAttributes(G4VisAttributes::GetInvisible());
 #else
 	this->SetVisAttributes(G4VisAttributes::Invisible);

--- a/src/WCSimLC.cc
+++ b/src/WCSimLC.cc
@@ -194,10 +194,5 @@ G4double WCSimLC::Tsukada_z_from_r (double radius)
 
 void WCSimLC::SetInvisible()
 {
-#if G4VERSION_IS_GREATER_EQUAL(11, 0, 0)
-	this->SetVisAttributes(G4VisAttributes::GetInvisible());
-#else
-	this->SetVisAttributes(G4VisAttributes::Invisible);
-#endif
-
+	this->SetVisAttributes(G4Utils::GetInvisible());
 }

--- a/src/WCSimOpticalPhysics.cc
+++ b/src/WCSimOpticalPhysics.cc
@@ -290,6 +290,13 @@ void WCSimOpticalPhysics::SetScintillationYieldFactor(G4double val)
    fYieldFactor = val;
    if (fScintillationProcess) {
      // @nadrino: water have no scintillation processes so these methods aren't used
+     // In Geant4, the scintillation yield and excitation ratio are applied
+     // as multiplicative factors to material scintillation properties
+     // (e.g. SCINTILLATIONYIELD and YIELDRATIO in the Material Properties Table).
+     // If the material (e.g. pure water in WCSim) does not define any
+     // scintillation properties, the G4Scintillation process has nothing
+     // to act on. Therefore these setters are effectively inert in this
+     // configuration and do not modify the physics outcome.
 #if G4VERSION_IS_GREATER_EQUAL(11,2,0)
 #else
      fScintillationProcess->SetScintillationYieldFactor(fYieldFactor);

--- a/src/WCSimOpticalPhysics.cc
+++ b/src/WCSimOpticalPhysics.cc
@@ -39,6 +39,8 @@
 
 #include "WCSimOpticalPhysics.hh"
 
+#include "G4Utils.hh"
+
 //#include "G4OpticalPhoton.hh"
 #include "G4OpAbsorption.hh"
 #include "G4OpRayleigh.hh"
@@ -215,8 +217,8 @@ void WCSimOpticalPhysics::ConstructProcess()
   }
 
   fScintillationProcess = new G4Scintillation();
-  fScintillationProcess->SetScintillationYieldFactor(fYieldFactor);
-  fScintillationProcess->SetScintillationExcitationRatio(fExcitationRatio);
+  this->SetScintillationYieldFactor(fYieldFactor);
+  this->SetScintillationExcitationRatio(fExcitationRatio);
   fScintillationProcess->SetFiniteRiseTime(fFiniteRiseTime);
   fScintillationProcess->SetScintillationByParticleType(fScintillationByParticleType);
 #if G4VERSION_NUMBER > 1023
@@ -287,7 +289,11 @@ void WCSimOpticalPhysics::SetScintillationYieldFactor(G4double val)
 {
    fYieldFactor = val;
    if (fScintillationProcess) {
-    fScintillationProcess->SetScintillationYieldFactor(fYieldFactor);
+     // @nadrino: water have no scintillation processes so these methods aren't used
+#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#else
+     fScintillationProcess->SetScintillationYieldFactor(fYieldFactor);
+#endif
   }
 }
 
@@ -295,7 +301,11 @@ void WCSimOpticalPhysics::SetScintillationExcitationRatio(G4double val)
 {
   fExcitationRatio = val;
   if (fScintillationProcess) {
+     // @nadrino: same here
+#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#else
     fScintillationProcess->SetScintillationExcitationRatio(fExcitationRatio);
+#endif
   }
 }
 

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -11,7 +11,7 @@
 
 // https://github.com/Geant4/geant4/blob/master/source/physics_lists/lists/History
 #include "G4Utils.hh"
-#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#if G4VERSION_IS_GREATER_EQUAL(10,7,4)
 #include <G4NeutronCaptureProcess.hh>
 using G4HadronCaptureProcess = G4NeutronCaptureProcess;
 #else

--- a/src/WCSimPhysicsListFactory.cc
+++ b/src/WCSimPhysicsListFactory.cc
@@ -2,13 +2,21 @@
 #include <G4Neutron.hh>
 #include <G4NeutronHPCapture.hh>
 #include <G4NeutronHPCaptureData.hh>
-#include <G4HadronCaptureProcess.hh>
 #include <G4NeutronRadCapture.hh>
 #include <G4NeutronCaptureXS.hh>
 #include <G4CrossSectionDataSetRegistry.hh>
 #include <G4HadronicInteractionRegistry.hh>
 #include <G4RadioactiveDecayPhysics.hh>
 #include "WCSimPhysicsListFactory.hh"
+
+// https://github.com/Geant4/geant4/blob/master/source/physics_lists/lists/History
+#include "G4Utils.hh"
+#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#include <G4NeutronCaptureProcess.hh>
+using G4HadronCaptureProcess = G4NeutronCaptureProcess;
+#else
+#include <G4HadronCaptureProcess.hh>
+#endif
 
 #include "GdNeutronHPCapture.hh"
 

--- a/src/WCSimRootGeom.cc
+++ b/src/WCSimRootGeom.cc
@@ -6,6 +6,7 @@
 #include "TDirectory.h"
 #include "TProcessID.h"
 #include "TClonesArray.h"
+#include "TMath.h"
 
 #include "WCSimRootGeom.hh"
 #include "WCSimRootTools.hh"

--- a/src/WCSimSteppingAction.cc
+++ b/src/WCSimSteppingAction.cc
@@ -3,8 +3,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <WCSimRootEvent.hh>
-#include <G4SIunits.hh>
 #include <G4OpticalPhoton.hh>
+
+#include "G4Utils.hh"
+#if G4VERSION_IS_GREATER_EQUAL(11,2,0)
+#include <G4SystemOfUnits.hh>
+#else
+#include <G4SIunits.hh>
+#endif
 
 #include "G4Track.hh"
 #include "G4VProcess.hh"

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -69,7 +69,7 @@ WCSimWCDAQMessenger::WCSimWCDAQMessenger(WCSimEventAction* eventaction) :
   RelativeHitTime->SetGuidance("Set the digitized hit time relative to the first one");
   RelativeHitTime->SetParameterName("RelativeHitTime",true);
   RelativeHitTime->SetDefaultValue(defaultRelativeHitTime);
-  SetNewValue(RelativeHitTime, defaultRelativeHitTime);
+  SetNewValue(RelativeHitTime, std::to_string(defaultRelativeHitTime));
 
   //Generic digitizer specific options
   DigitizerDir = new G4UIdirectory("/DAQ/DigitizerOpt/");

--- a/src/WCSimWCDAQMessenger.cc
+++ b/src/WCSimWCDAQMessenger.cc
@@ -3,6 +3,7 @@
 #include "WCSimWCDigitizer.hh"
 #include "WCSimWCTrigger.hh"
 
+#include "G4Utils.hh"
 #include "G4UIdirectory.hh"
 #include "G4UIcommand.hh"
 #include "G4UIcmdWithADoubleAndUnit.hh"


### PR DESCRIPTION
This PR is a collection of commits I've implemented to get the code running with the latest Geant4. A few deprecated methods were replaced accordingly.

This PR also preserves the original implementation for version below 11.0.0. This is done thanks to pre-processor macros that redirect the compiler depending on the G4 version it's compiling in with.