### PR TITLE
Save all Michel electrons from the muMinusCaptureAtRest process

### DIFF
--- a/src/WCSimTrackingAction.cc
+++ b/src/WCSimTrackingAction.cc
@@ -19,8 +19,7 @@ WCSimTrackingAction::WCSimTrackingAction()
   ProcessList.insert("Decay") ;                         // Michel e- from pi+ and mu+
   ProcessList.insert("conv") ;                         // Products of gamma conversion
 
-  //ProcessList.insert("muMinusCaptureAtRest") ;          // Includes Muon decay from K-shell: for Michel e- from mu0. This dominates/replaces the mu- decay (noticed when switching off this process in PhysicsList)                                                   // TF: IMPORTANT: ONLY USE FROM G4.9.6 onwards because buggy/double counting before.
-  ////////// ToDo: switch ON the above when NuPRISM uses G4 >= 4.9.6
+  ProcessList.insert("muMinusCaptureAtRest") ;          // Includes Muon decay from K-shell: for Michel e- from muonic atoms. This dominates/replaces the mu- decay (noticed when switching off this process in PhysicsList)                                                   // TF: IMPORTANT: ONLY USE FROM G4.9.6 onwards because buggy/double counting before.
   ProcessList.insert("nCapture");
 
 //   ProcessList.insert("conv");


### PR DESCRIPTION
The current default is to only save Michel electrons from mu- in the WCSimTracks output container, if the Michel electron goes on to create Cherenkov photons that hit PMTs (unless they have the `Decay` process, which is not prevelant for mu-. It dominates for mu+). There are therefore some edge cases where the Michel electron isn't saved for mu-.

There has been a request from the LBL group to always save the produced Michel electron. This will catch the edge cases e.g. where the Michel is created & remains in the deadspace. This solves that