### PR TITLE
set default reflectivity values for FDOD TYVEK

### DIFF
--- a/macros/tuning_parameters_hkfd.mac
+++ b/macros/tuning_parameters_hkfd.mac
@@ -18,6 +18,6 @@
 /WCSim/tuning/PMTCathodePara data/CathodeParameters.txt
 
 /WCSim/tuning/WCODWLSCladdingReflectivity 0.99
-/WCSim/tuning/WCODTyvekInwallReflectivity 0.90
-/WCSim/tuning/WCODTyvekOutwallReflectivity 0.90
+/WCSim/tuning/WCODTyvekInwallReflectivity 0.95
+/WCSim/tuning/WCODTyvekOutwallReflectivity 0.87
 

--- a/src/WCSimTuningParameters.cc
+++ b/src/WCSimTuningParameters.cc
@@ -32,8 +32,8 @@ WCSimTuningParameters::WCSimTuningParameters()
  topveto = false;
 
  WCODWLSCladdingReflectivity   = 0.99; //
- WCODTyvekInwallReflectivity   = 0.90; //
- WCODTyvekOutwallReflectivity   = 0.90; //
+ WCODTyvekInwallReflectivity   = 0.95; //
+ WCODTyvekOutwallReflectivity   = 0.87; //
 
 }
 


### PR DESCRIPTION
Just a tiny incremental pull request to set the default values for the reflectivity of the FDOD to:
95% (in-wall)
87% (out-wall)