### PR TITLE
Consistent saving of PMT radii

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -145,6 +145,8 @@ public:
   G4int    UsePMT_Coll_Eff(){return PMT_Coll_Eff;}
 
   G4double GetPMTSize1() {return WCPMTSize;}
+  G4double GetPMTSize2() {return WCPMTSize2;}
+  G4double GetPMTSizeOD() {return WCPMTSizeOD;}
 
   G4double GetPMTQE(G4String,G4double, G4int, G4double, G4double, G4double);
   G4double GetPMTCollectionEfficiency(G4double theta_angle, G4String CollectionName) { return GetPMTPointer(CollectionName)->GetCollectionEfficiency(theta_angle); };
@@ -936,8 +938,9 @@ private:
   G4int totalNumODPMTs=0;      // The number of OD PMTs for this configuration
 
   G4double WCCylInfo[3];    // Info for the geometry tree: radius & length or mail box, length, width and depth
-  G4double WCPMTSize;       // Info for the geometry tree: pmt size
-  G4double WCPMTSize2;       // Info for the geometry tree: pmt size
+  G4double WCPMTSize;       // Info for the geometry tree: ID pmt size in cm
+  G4double WCPMTSize2;       // Info for the geometry tree: ID pmt of the second type size in cm
+  G4double WCPMTSizeOD;      // Info for the geometry tree: OD pmt size in cm
   G4ThreeVector WCOffset;   // Info for the geometry tree: WC center offset
   G4ThreeVector WCXRotation;   // Info for the geometry tree: WC detector local X axis in the global coordinate system 
   G4ThreeVector WCYRotation;   // Info for the geometry tree: WC detector local Y axis in the global coordinate system 

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -62,6 +62,7 @@ void WCSimDetectorConstruction::GetWCGeom
     // AH Need to store this in CM for it to be understood by SK code
     WCPMTSize = WCPMTRadius/cm;// I think this is just a variable no if needed
     WCPMTSize2 = WCPMTRadius2/cm;// I think this is just a variable no if needed
+    WCPMTSizeOD = WCPMTODRadius/cm;// I think this is just a variable no if needed
 
     // Note WC can be off-center... get both extremities
     static G4double zmin=100000,zmax=-100000.;
@@ -252,7 +253,7 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
   
   geoFile << "OD PMT number & size        "
 	  << setw(10)<<totalNumODPMTs
-	  << setw(8)<<WCPMTODRadius << setw(4)  <<G4endl;
+	  << setw(8)<<WCPMTSizeOD << setw(4)  <<G4endl;
 
   geoFile << "Centre offset "
 	  << setw(8) << WCOffset(0)

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -622,8 +622,8 @@ void WCSimRunAction::FillGeoTree(){
   wcsimrootgeom->SetBoundaryWallDimensions(wcsimdetector->GetBoundaryWallDimensions());
 
   pmtradius = wcsimdetector->GetPMTSize1();
-  pmtradius2 = 4.0;//B.Q debug, Temp wcsimdetector->GetPMTSize1();
-  pmtradiusOD = wcsimdetector->GetODPMTSize();
+  pmtradius2 = wcsimdetector->GetPMTSize2(); //B.Q debug, Temp wcsimdetector->GetPMTSize1();
+  pmtradiusOD = wcsimdetector->GetPMTSizeOD();
   numpmt = wcsimdetector->GetTotalNumPmts();
   numpmt2 = wcsimdetector->GetTotalNumPmts2();//Hybrid configuration
   numpmtOD = wcsimdetector->GetTotalNumODPmts();


### PR DESCRIPTION
OD PMT radius was being saved in mm, whilst others used cm. Now use cm consistently

Additionally the radius for ID PMTs of the second type (aka mPMTs in FD) was previously hardcoded